### PR TITLE
Custom DB name

### DIFF
--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -46,7 +46,7 @@ def get_db_engine():
                 sys.exit(3)
             DB_USER: str = os.getenv('DB_USER')
             DB_PASSWD: str = os.getenv('DB_PASSWD')
-            DB_NAME: str = 'romm'
+            DB_NAME: str = os.getenv('DB_NAME', 'romm')
         
             return f"mariadb+mariadbconnector://{DB_USER}:{DB_PASSWD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
     container_name: romm_db
     environment:
       - MYSQL_ROOT_PASSWORD=${DB_ROOT_PASSWD}
-      - MYSQL_DATABASE=romm
+      - MYSQL_DATABASE=${DB_NAME}
       - MYSQL_USER=${DB_USER}
       - MYSQL_PASSWORD=${DB_PASSWD}
     volumes:

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -8,6 +8,7 @@ services:
       - DB_HOST=romm_db # Only if ROMM_DB_DRIVER='mariadb'
       - DB_PORT=3306 # Only if ROMM_DB_DRIVER='mariadb'
       - DB_USER=romm-user # Only if ROMM_DB_DRIVER='mariadb'
+      - DB_NAME=romm # Only if ROMM_DB_DRIVER='mariadb'. Can be optionally changed, and should match the MYSQL_DATABASE value in the mariadb container.
       - DB_PASSWD=change-me # Only if ROMM_DB_DRIVER='mariadb'
       - CLIENT_ID=<IGDB client id>
       - CLIENT_SECRET=<IGDB client secret>


### PR DESCRIPTION
Thanks for RomM!

This is a simple change that would allow users to optionally define their own database name. 

I, for instance, have a specific naming convention on my mariadb instance.