### PR TITLE
Quote maria DB password

### DIFF
--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -2,6 +2,7 @@ import os
 import sys
 import pathlib
 
+from urllib.parse import quote_plus
 from logger.logger import log
 
 # Uvicorn
@@ -48,7 +49,7 @@ def get_db_engine():
             DB_PASSWD: str = os.getenv('DB_PASSWD')
             DB_NAME: str = 'romm'
         
-            return f"mariadb+mariadbconnector://{DB_USER}:{DB_PASSWD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+            return f"mariadb+mariadbconnector://{DB_USER}:%s@{DB_HOST}:{DB_PORT}/{DB_NAME}" % quote_plus(DB_PASSWD)
 
         elif ROMM_DB_DRIVER == 'sqlite':
             SQLITE_PATH: str = f"{LIBRARY_BASE_PATH}/database"


### PR DESCRIPTION
Special characters in your mysql password (like `@`) will generate a string that errors out when `sqlalchemy` tries to connect.

### Before

> [DEV] In: f"mariadb+mariadbconnector://{DB_USER}:{DB_PASSWD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
[DEV] Out: 'mariadb+mariadbconnector://ruff:ddFa2@!5sD@maria:3306/ruff'

### After

> [DEV] In: f"mariadb+mariadbconnector://{DB_USER}:%s@{DB_HOST}:{DB_PORT}/{DB_NAME}" % quote_plus(DB_PASSWD)
[DEV] Out: 'mariadb+mariadbconnector://ruff:ddFa2%40%215sD@maria:3306/romm'

https://stackoverflow.com/questions/1423804/writing-a-connection-string-when-password-contains-special-characters