### PR TITLE
Refactor/models codebase

### DIFF
--- a/backend/src/handler/__init__.py
+++ b/backend/src/handler/__init__.py
@@ -1,0 +1,7 @@
+from handler.db_handler import DBHandler
+from handler.igdb_handler import IGDBHandler
+from handler.sgdb_handler import SGDBHandler
+
+igdbh: IGDBHandler = IGDBHandler()
+sgdbh: SGDBHandler = SGDBHandler()
+dbh: DBHandler = DBHandler()

--- a/backend/src/handler/db_handler.py
+++ b/backend/src/handler/db_handler.py
@@ -23,60 +23,19 @@ class DBHandler:
         return wrapper
 
     
-    def add_platform(self, **kargs) -> None:
-        with Session.begin() as session:
-            session.merge(Platform(**kargs))
+    def add_platform(self, Platform: Platform) -> None:
+        try:
+            with Session.begin() as session:
+                session.merge(Platform)
+        except ProgrammingError as e:
+            raise HTTPException(status_code=404, detail=f"Platforms table not found: {e}")
 
-
-    def add_platform(self, **kargs) -> None:
-        with Session.begin() as session:
-            session.merge(Platform(**kargs))
-
-    
     def get_platforms(self) -> list[Platform]:
         try:
             with Session.begin() as session:
                 return session.scalars(select(Platform).order_by(Platform.slug.asc())).all()
         except ProgrammingError as e:
             raise HTTPException(status_code=404, detail=f"Platforms table not found: {e}")
-        
-
-    def add_platform(self, **kargs) -> None:
-        try:
-            with Session.begin() as session:
-                session.merge(Platform(**kargs))
-        except ProgrammingError as e:
-            raise HTTPException(status_code=404, detail=f"Roms table not found: {e}")
-
-
-    def get_roms(self, p_slug: str) -> list[Rom]:
-        with Session.begin() as session:
-            return session.scalars(select(Rom).filter_by(p_slug=p_slug).order_by(Rom.filename.asc())).all()
-
-
-    def get_rom(self, p_slug: str, filename: str) -> Rom:
-        with Session.begin() as session:
-            return session.scalars(select(Rom).filter_by(p_slug=p_slug, filename=filename)).first()
-
-
-    def add_rom(self, **kargs) -> None:
-        with Session.begin() as session:
-            session.merge(Rom(**kargs))
-    
-
-    def update_rom(self, p_slug: str, filename: str, data: dict) -> None:
-        with Session.begin() as session:
-            session.query(Rom) \
-                .filter(Rom.p_slug==p_slug, Rom.filename==filename) \
-                .update(data, synchronize_session='evaluate')
-
-
-    def delete_rom(self, p_slug: str, filename: str) -> None:
-        with Session.begin() as session:
-            session.query(Rom) \
-                .filter(Rom.p_slug==p_slug, Rom.filename==filename) \
-                .delete(synchronize_session='evaluate')
-
 
     def purge_platforms(self, platforms: list) -> None:
         with Session.begin() as session:
@@ -84,6 +43,29 @@ class DBHandler:
                 .filter(Platform.slug.not_in(platforms)) \
                 .delete(synchronize_session='evaluate')
 
+    def add_rom(self, **kargs) -> None:
+        with Session.begin() as session:
+            session.merge(Rom(**kargs))
+
+    def get_roms(self, p_slug: str) -> list[Rom]:
+        with Session.begin() as session:
+            return session.scalars(select(Rom).filter_by(p_slug=p_slug).order_by(Rom.filename.asc())).all()
+
+    def get_rom(self, p_slug: str, filename: str) -> Rom:
+        with Session.begin() as session:
+            return session.scalars(select(Rom).filter_by(p_slug=p_slug, filename=filename)).first()
+
+    def update_rom(self, p_slug: str, filename: str, data: dict) -> None:
+        with Session.begin() as session:
+            session.query(Rom) \
+                .filter(Rom.p_slug==p_slug, Rom.filename==filename) \
+                .update(data, synchronize_session='evaluate')
+
+    def delete_rom(self, p_slug: str, filename: str) -> None:
+        with Session.begin() as session:
+            session.query(Rom) \
+                .filter(Rom.p_slug==p_slug, Rom.filename==filename) \
+                .delete(synchronize_session='evaluate')
 
     def purge_roms(self, p_slug: str, roms: list) -> None:
         with Session.begin() as session:

--- a/backend/src/handler/db_handler.py
+++ b/backend/src/handler/db_handler.py
@@ -37,15 +37,9 @@ class DBHandler:
         except ProgrammingError as e:
             raise HTTPException(status_code=404, detail=f"Platforms table not found: {e}")
 
-    def purge_platforms(self, platforms: list) -> None:
+    def add_rom(self, rom: Rom) -> None:
         with Session.begin() as session:
-            session.query(Platform) \
-                .filter(Platform.slug.not_in(platforms)) \
-                .delete(synchronize_session='evaluate')
-
-    def add_rom(self, **kargs) -> None:
-        with Session.begin() as session:
-            session.merge(Rom(**kargs))
+            session.merge(rom)
 
     def get_roms(self, p_slug: str) -> list[Rom]:
         with Session.begin() as session:
@@ -67,7 +61,15 @@ class DBHandler:
                 .filter(Rom.p_slug==p_slug, Rom.filename==filename) \
                 .delete(synchronize_session='evaluate')
 
-    def purge_roms(self, p_slug: str, roms: list) -> None:
+    def purge_platforms(self, platforms: list[str]) -> None:
+        log.info("Purging platforms")
+        with Session.begin() as session:
+            session.query(Platform) \
+                .filter(Platform.slug.not_in(platforms)) \
+                .delete(synchronize_session='evaluate')
+
+    def purge_roms(self, p_slug: str, roms: list[dict]) -> None:
+        log.info(f"Purging {p_slug} roms")
         with Session.begin() as session:
             session.query(Rom) \
                 .filter(Rom.p_slug==p_slug, Rom.filename.not_in([rom['filename'] for rom in roms])) \

--- a/backend/src/handler/igdb_handler.py
+++ b/backend/src/handler/igdb_handler.py
@@ -32,31 +32,30 @@ class IGDBHandler():
     def get_platform_details(self, slug: str) -> tuple:
         igdb_id: str = ""
         name: str = ""
-        url_logo: str = ""
         try:
             res_details: dict = requests.post("https://api.igdb.com/v4/platforms/", headers=self.headers,
-                                              data=f"fields id, name, platform_logo; where slug=\"{slug}\";").json()[0]
+                                              data=f"fields id, name; where slug=\"{slug}\";").json()[0]
             igdb_id = res_details['id']
             name = res_details['name']
         except IndexError:
             log.warning("platform not found in igdb")
         if not name: name = slug
-        return igdb_id, name, url_logo
+        return {'igdb_id': igdb_id, 'name': name}
 
 
     @check_twitch_token
-    def get_rom_details(self, filename: str, p_igdb_id: int, r_igdb_id: str) -> dict:
+    def get_rom_details(self, filename: str, p_igdb_id: int, r_igdb_id_search: str) -> dict:
         filename_no_ext: str = filename.split('.')[0]
-        igdb_id: str = ""
+        r_igdb_id: str = ""
         slug: str = ""
         name: str = ""
         summary: str = ""
         url_cover: str = ""
 
-        if r_igdb_id:
+        if r_igdb_id_search:
             res_details: dict = requests.post("https://api.igdb.com/v4/games/", headers=self.headers,
-                                              data=f"fields id, slug, name, summary; where id={r_igdb_id};").json()[0]
-            igdb_id = res_details['id']
+                                              data=f"fields id, slug, name, summary; where id={r_igdb_id_search};").json()[0]
+            r_igdb_id = res_details['id']
             slug = res_details['slug']
             name = res_details['name']
             try:
@@ -71,7 +70,7 @@ class IGDBHandler():
 
                     res_details: dict = requests.post("https://api.igdb.com/v4/games/", headers=self.headers,
                                                       data=f"search \"{search_term}\";fields id, slug, name, summary; where platforms=[{p_igdb_id}] & category=0;").json()[0]
-                    igdb_id = res_details['id']
+                    r_igdb_id = res_details['id']
                     slug = res_details['slug']
                     name = res_details['name']
                     try:
@@ -82,7 +81,7 @@ class IGDBHandler():
                     try:
                         res_details: dict = requests.post("https://api.igdb.com/v4/games/", headers=self.headers,
                                                           data=f"search \"{search_term}\";fields name, id, slug, summary; where platforms=[{p_igdb_id}] & category=10;").json()[0]
-                        igdb_id = res_details['id']
+                        r_igdb_id = res_details['id']
                         slug = res_details['slug']
                         name = res_details['name']
                         try:
@@ -93,7 +92,7 @@ class IGDBHandler():
                         try:
                             res_details: dict = requests.post("https://api.igdb.com/v4/games/", headers=self.headers,
                                                               data=f"search \"{search_term}\";fields name, id, slug, summary; where platforms=[{p_igdb_id}];").json()[0]
-                            igdb_id = res_details['id']
+                            r_igdb_id = res_details['id']
                             slug = res_details['slug']
                             name = res_details['name']
                             try:
@@ -102,15 +101,15 @@ class IGDBHandler():
                                 pass
                         except IndexError:
                             log.warning(f"{filename} rom not found in igdb")
-        if igdb_id:
+        if r_igdb_id:
             try:
                 res_details: dict = requests.post("https://api.igdb.com/v4/covers/", headers=self.headers,
-                                                  data=f"fields url; where game={igdb_id};").json()[0]
+                                                  data=f"fields url; where game={r_igdb_id};").json()[0]
                 url_cover: str = f"https:{res_details['url']}"
             except IndexError:
                 log.warning(f"{name} cover not found in igdb")
         if not name: name = filename_no_ext
-        return (igdb_id, filename_no_ext, slug, name, summary, url_cover)
+        return (r_igdb_id, filename_no_ext, slug, name, summary, url_cover)
 
     
     @check_twitch_token

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -18,7 +18,7 @@ dbh: DBHandler = DBHandler()
 
 
 @app.patch("/platforms/{p_slug}/roms/{filename}")
-async def updateRom(req: Request, p_slug: str, filename: str):
+async def updateRom(req: Request, p_slug: str, filename: str) -> dict:
     """Updates rom details"""
 
     data: dict = await req.json()
@@ -42,7 +42,7 @@ async def updateRom(req: Request, p_slug: str, filename: str):
 
 
 @app.delete("/platforms/{p_slug}/roms/{filename}")
-async def delete_rom(p_slug: str, filename: str, filesystem: bool=False):
+async def delete_rom(p_slug: str, filename: str, filesystem: bool=False) -> dict:
     """Detele rom from filesystem and database"""
 
     log.info("deleting rom...")
@@ -52,28 +52,28 @@ async def delete_rom(p_slug: str, filename: str, filesystem: bool=False):
 
 
 @app.get("/platforms/{p_slug}/roms/{filename}")
-async def rom(p_slug: str, filename: str):
+async def rom(p_slug: str, filename: str) -> dict:
     """Returns one rom data of the desired platform"""
 
     return {'data':  dbh.get_rom(p_slug, filename)}
 
 
 @app.get("/platforms/{p_slug}/roms")
-async def roms(p_slug: str):
+async def roms(p_slug: str) -> dict:
     """Returns all roms of the desired platform"""
 
     return {'data':  dbh.get_roms(p_slug)}
 
 
 @app.get("/platforms")
-async def platforms():
+async def platforms() -> dict:
     """Returns platforms data"""
 
     return {'data': dbh.get_platforms()}
 
 
 @app.put("/scan")
-async def scan(req: Request, overwrite: bool=False):
+async def scan(req: Request, overwrite: bool=False) -> dict:
     """Scan platforms and roms and write them in database."""
 
     log.info("complete scaning...")
@@ -81,16 +81,16 @@ async def scan(req: Request, overwrite: bool=False):
     data: dict = await req.json()
     platforms = data['platforms'] if data['platforms'] else fs.get_platforms()
     for p_slug in platforms:
-        p_igdb_id: str = fastapi.scan_platform(overwrite, p_slug, igdbh, dbh)
+        platform: str = fastapi.scan_platform(overwrite, p_slug, igdbh, dbh)
         for rom in fs.get_roms(p_slug):
-            fastapi.scan_rom(overwrite, rom, p_igdb_id, p_slug, igdbh, dbh)
+            fastapi.scan_rom(overwrite, rom, platform.igdb_id, p_slug, igdbh, dbh)
         fastapi.purge(dbh, p_slug=p_slug)
     fastapi.purge(dbh)
     return {'msg': 'success'}
 
 
 @app.put("/search/roms/igdb")
-async def search_rom_igdb(req: Request):
+async def search_rom_igdb(req: Request) -> dict:
     """Get all the roms matched from igdb."""
 
     data: dict = await req.json()

--- a/backend/src/utils/fs.py
+++ b/backend/src/utils/fs.py
@@ -69,7 +69,7 @@ def get_platforms() -> list:
     """Gets all filesystem platforms
     
     Returns list with all the filesystem platforms found in the LIBRARY_BASE_PATH.
-    Automatically discards the default directory.
+    Automatically discards the reserved directories such resources or database directory.
     """
     try:
         platforms: list[str] = list(os.walk(LIBRARY_BASE_PATH))[0][1]

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,47 @@
+# v1.5 (_29-03-2023_)
+
+## Added
+ - Now RomM folder structure is more flexible to match two different patrons by priority:
+    - Structure 1 (priority high) - roms folder at root of library folder:
+    ```
+    library/
+    ├─ roms/
+    │  ├─ gbc/
+       │  ├─ rom_1.gbc
+       │  ├─ rom_2.gbc
+       │
+       ├─ gba/
+       │  ├─ rom_1.gba
+       │  ├─ rom_2.gba
+       │ 
+       ├─ gb/
+          ├─ rom_1.gb
+          ├─ rom_1.gb
+    ```
+    - Structure 2 (priority low) - roms folder inside each platform folder
+    ```
+    library/
+    ├─ gbc/
+    │  ├─ roms/
+    │     ├─ rom_1.gbc
+    │     ├─ rom_2.gbc
+    |
+    ├─ gba/
+    │  ├─ roms/
+    │     ├─ rom_1.gba
+    │     ├─ rom_2.gba
+    |
+    ├─ gb/
+    │  ├─ roms/
+    │     ├─ rom_1.gb
+    │     ├─ rom_1.gb
+    ```
+
+# v1.4.1 (_29-03-2023_)
+
+## Added
+ - Now you can use your games tags (like (USA) or (rev-1)) to filter in the gallery
+
 # v1.4 (_29-03-2023_)
 
 ## Added

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,14 +5,17 @@ import Navigation from '@/components/Navigation.vue'
 
 // Props
 useTheme().global.name.value = localStorage.getItem('theme') || 'dark'
-const refresh = ref(false)
+const refreshPlatforms = ref(false)
 const refreshRoms = ref(false)
 const snackbarShow = ref(false)
 const snackbarStatus = ref({})
 
 // Event listeners bus
 const emitter = inject('emitter')
-emitter.on('refresh', () => { refresh.value = !refresh.value })
+emitter.on('refresh', () => { 
+  refreshPlatforms.value = !refreshPlatforms.value 
+  refreshRoms.value = !refreshRoms.value
+})
 emitter.on('refreshRoms', () => { refreshRoms.value = !refreshRoms.value })
 emitter.on('snackbarScan', (snackbar) => {
   snackbarShow.value = true
@@ -23,7 +26,7 @@ emitter.on('snackbarScan', (snackbar) => {
 <template>
   <v-app>
     
-    <navigation :key="refresh"/>
+    <navigation :key="refreshPlatforms"/>
     
     <v-snackbar v-model="snackbarShow" :timeout="4000" location="top" class="mt-4">
         <v-icon :icon="snackbarStatus.icon" :color="snackbarStatus.color" class="ml-2 mr-2"/>

--- a/frontend/src/components/Navigation.vue
+++ b/frontend/src/components/Navigation.vue
@@ -25,36 +25,6 @@ const emitter = inject('emitter')
 emitter.on('gettingRoms', (flag) => { gettingRomsFlag.value = flag })
 
 // Functions
-async function getPlatforms() {
-    // Get the list of the platforms for the navigation drawer
-    console.log("Getting platforms...")
-    axios.get('/api/platforms').then((response) => {
-        console.log("Platforms loaded!")
-        console.log(response.data.data)
-        platforms.value = response.data.data
-    }).catch((error) => {console.log(error)})
-}
-
-function setFilter(filter) {
-    // Sets the roms filter
-    emitter.emit('romsFilter', filter)
-}
-
-async function selectPlatform(platform){    
-    // Select the current platform
-    if(mobile.value){drawer.value = false}
-    await router.push(import.meta.env.BASE_URL)
-    localStorage.setItem('currentPlatform', JSON.stringify(platform))
-    emitter.emit('currentPlatform', platform)
-    currentPlatform.value = platform
-}
-
-function toggleRail(){
-    // Toggle collapsed/expand platform navigation drawer
-    rail.value = !rail.value
-    localStorage.setItem('rail', rail.value)
-}
-
 async function scan() {
     // Complete scan or by platform
     console.log("scanning...")
@@ -74,18 +44,47 @@ async function scan() {
         emitter.emit('snackbarScan', {'msg': "Couldn't complete scan. Something went wrong...", 'icon': 'mdi-close-circle', 'color': 'red'})
     })
     scanning.value = false
-    // if (!platforms.length){emitter.emit('refresh')}else{emitter.emit('refresh')}
     emitter.emit('refresh')
+}
+
+async function getPlatforms() {
+    // Get the list of the platforms for the navigation drawer
+    console.log("Getting platforms...")
+    axios.get('/api/platforms').then((response) => {
+        console.log("Platforms loaded!")
+        console.log(response.data.data)
+        platforms.value = response.data.data
+    }).catch((error) => {console.log(error)})
+}
+
+async function selectPlatform(platform){    
+    // Select the current platform
+    if(mobile.value){drawer.value = false}
+    await router.push(import.meta.env.BASE_URL)
+    localStorage.setItem('currentPlatform', JSON.stringify(platform))
+    emitter.emit('currentPlatform', platform)
+    currentPlatform.value = platform
+}
+
+function uploadRom() {
+    console.log("uploading rom")
+}
+
+function setFilter(filter) {
+    // Sets the roms filter
+    emitter.emit('romsFilter', filter)
+}
+
+function toggleRail(){
+    // Toggle collapsed/expand platform navigation drawer
+    rail.value = !rail.value
+    localStorage.setItem('rail', rail.value)
 }
 
 function toggleTheme() {
     // Toggle dark/light theme
     theme.global.name.value = darkMode.value ? "dark" : "light"
     darkMode.value ? localStorage.setItem('theme', 'dark') : localStorage.setItem('theme', 'light')
-}
-
-function uploadRom() {
-    console.log("uploading rom")
 }
 
 getPlatforms()

--- a/readme.md
+++ b/readme.md
@@ -33,25 +33,43 @@ For now, it is only available as a docker [image](https://hub.docker.com/r/zurdi
 
 ## ⚠️ Folder structure
 
-To allow RomM scan your retro games library, it should follow the following structure:
+RomM accepts two different folder structure by priority:
+  - Structure 1 (priority high) - roms folder at root of library folder:
+  ```
+  library/
+  ├─ roms/
+  │  ├─ gbc/
+      │  ├─ rom_1.gbc
+      │  ├─ rom_2.gbc
+      │
+      ├─ gba/
+      │  ├─ rom_1.gba
+      │  ├─ rom_2.gba
+      │ 
+      ├─ gb/
+        ├─ rom_1.gb
+        ├─ rom_1.gb
+  ```
+  - Structure 2 (priority low) - roms folder inside each platform folder
+  ```
+  library/
+  ├─ gbc/
+  │  ├─ roms/
+  │     ├─ rom_1.gbc
+  │     ├─ rom_2.gbc
+  |
+  ├─ gba/
+  │  ├─ roms/
+  │     ├─ rom_1.gba
+  │     ├─ rom_2.gba
+  |
+  ├─ gb/
+  │  ├─ roms/
+  │     ├─ rom_1.gb
+  │     ├─ rom_1.gb
+  ```
 
-```
-library/
-├─ gbc/
-│  ├─ roms/
-│     ├─ rom_1.gbc
-│     ├─ rom_2.gbc
-|
-├─ gba/
-│  ├─ roms/
-│     ├─ rom_1.gba
-│     ├─ rom_2.gba
-|
-├─ gb/
-│  ├─ roms/
-│     ├─ rom_1.gb
-│     ├─ rom_1.gb
-```
+RomM will try to find the structure 1. If it doesn't exists, RomM will try to find structure 2.
 
 # Preview
 


### PR DESCRIPTION
## Added
 - Now RomM folder structure is more flexible to match two different patrons by priority:
    - Structure 1 (priority high) - roms folder at root of library folder:
    ```
    library/
    ├─ roms/
    │  ├─ gbc/
       │  ├─ rom_1.gbc
       │  ├─ rom_2.gbc
       │
       ├─ gba/
       │  ├─ rom_1.gba
       │  ├─ rom_2.gba
       │ 
       ├─ gb/
          ├─ rom_1.gb
          ├─ rom_1.gb
    ```
    - Structure 2 (priority low) - roms folder inside each platform folder
    ```
    library/
    ├─ gbc/
    │  ├─ roms/
    │     ├─ rom_1.gbc
    │     ├─ rom_2.gbc
    |
    ├─ gba/
    │  ├─ roms/
    │     ├─ rom_1.gba
    │     ├─ rom_2.gba
    |
    ├─ gb/
    │  ├─ roms/
    │     ├─ rom_1.gb
    │     ├─ rom_1.gb
    ```