### PR TITLE
Pagination for large libraries

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -17,9 +17,9 @@ HIGH_PRIO_STRUCTURE_PATH: str = f"{LIBRARY_BASE_PATH}/roms"
 
 # DEFAULT RESOURCES
 DEFAULT_URL_COVER_L: str = "https://images.igdb.com/igdb/image/upload/t_cover_big/nocover.png"
-DEFAULT_PATH_COVER_L: str = f"default/default/cover/big.png"
+DEFAULT_PATH_COVER_L: str = "default/default/cover/big.png"
 DEFAULT_URL_COVER_S: str = "https://images.igdb.com/igdb/image/upload/t_cover_small/nocover.png"
-DEFAULT_PATH_COVER_S: str = f"default/default/cover/small.png"
+DEFAULT_PATH_COVER_S: str = "default/default/cover/small.png"
 
 # IGDB
 CLIENT_ID: str = os.environ.get('CLIENT_ID')

--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -6,7 +6,7 @@ router = APIRouter()
 
 
 @router.get("/platforms", status_code=200)
-def platforms() -> dict:
+def platforms():
     """Returns platforms data"""
 
-    return {'data': dbh.get_platforms()}
+    return dbh.get_platforms()

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -64,7 +64,7 @@ def rom(id: int):
 
 @router.get("/platforms/{p_slug}/roms", status_code=200)
 def roms(
-    p_slug: str, size: int = 50, cursor: str = "", search_term: str = ""
+    p_slug: str, size: int = 60, cursor: str = "", search_term: str = ""
 ) -> CursorPage[RomSchema]:
     """Returns all roms of the desired platform"""
     with dbh.session.begin() as session:

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -63,11 +63,22 @@ def rom(id: int):
 
 
 @router.get("/platforms/{p_slug}/roms", status_code=200)
-def roms(p_slug: str, size: int = 50, cursor: str = "") -> CursorPage[RomSchema]:
+def roms(
+    p_slug: str, size: int = 50, cursor: str = "", search_term: str = ""
+) -> CursorPage[RomSchema]:
     """Returns all roms of the desired platform"""
-    with dbh.session.begin() as s:
+    with dbh.session.begin() as session:
         cursor_params = CursorParams(size=size, cursor=cursor)
-        return paginate(s, dbh.get_roms(p_slug), cursor_params)
+        qq = dbh.get_roms(p_slug)
+
+        if search_term:
+            return paginate(
+                session,
+                qq.filter(Rom.file_name.ilike(f'%{search_term}%')),
+                cursor_params,
+            )
+
+        return paginate(session, qq, cursor_params)
 
 
 @router.patch("/platforms/{p_slug}/roms/{id}", status_code=200)

--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -1,5 +1,5 @@
+from fastapi import APIRouter, Request
 import emoji
-from fastapi import APIRouter
 
 from logger.logger import log, COLORS
 from handler import igdbh
@@ -7,10 +7,14 @@ from handler import igdbh
 router = APIRouter()
 
 
-@router.get("/search/roms/igdb", status_code=200)
-async def search_rom_igdb(rom: str, search_term: str = "", search_by: str = "") -> dict:
+@router.put("/search/roms/igdb", status_code=200)
+async def search_rom_igdb(
+    req: Request, search_term: str = "", search_by: str = ""
+) -> dict:
     """Get all the roms matched from igdb."""
 
+    data: dict = await req.json()
+    rom: dict = data["rom"]
     log.info(emoji.emojize(":magnifying_glass_tilted_right: IGDB Searching"))
     matched_roms: list = []
 
@@ -31,6 +35,7 @@ async def search_rom_igdb(rom: str, search_term: str = "", search_by: str = "") 
         )
 
     log.info("Results:")
+
     [
         log.info(f"\t - {COLORS['blue']}{rom['r_name']}{COLORS['reset']}")
         for rom in matched_roms

--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -8,22 +8,36 @@ router = APIRouter()
 
 
 @router.put("/search/roms/igdb", status_code=200)
-async def search_rom_igdb(req: Request, search_term: str = '', search_by: str = '') -> dict:
+async def search_rom_igdb(
+    req: Request, search_term: str = "", search_by: str = ""
+) -> dict:
     """Get all the roms matched from igdb."""
 
     data: dict = await req.json()
-    rom: dict = data['rom']
+    rom: dict = data["rom"]
     log.info(emoji.emojize(":magnifying_glass_tilted_right: IGDB Searching"))
     matched_roms: list = []
+
     if search_term:
         log.info(f"Searching by {search_by}: {search_term}")
-        if search_by == 'ID':
+        if search_by == "ID":
             matched_roms = igdbh.get_matched_rom_by_id(search_term)
-        elif search_by == 'Name':
-            matched_roms = igdbh.get_matched_roms_by_name(search_term, rom['p_igdb_id'])
+        elif search_by == "Name":
+            matched_roms = igdbh.get_matched_roms_by_name(search_term, rom["p_igdb_id"])
     else:
-        log.info(emoji.emojize(f":video_game: {rom['p_slug']}: {COLORS['orange']}{rom['file_name']}{COLORS['reset']}"))
-        matched_roms = igdbh.get_matched_roms(rom['file_name'], rom['p_igdb_id'], rom['p_slug'])
+        log.info(
+            emoji.emojize(
+                f":video_game: {rom['p_slug']}: {COLORS['orange']}{rom['file_name']}{COLORS['reset']}"
+            )
+        )
+        matched_roms = igdbh.get_matched_roms(
+            rom["file_name"], rom["p_igdb_id"], rom["p_slug"]
+        )
+
     log.info("Results:")
-    [log.info(f"\t - {COLORS['blue']}{rom['r_name']}{COLORS['reset']}") for rom in matched_roms]
-    return {'data': matched_roms, 'msg': 'success'}
+    [
+        log.info(f"\t - {COLORS['blue']}{rom['r_name']}{COLORS['reset']}")
+        for rom in matched_roms
+    ]
+
+    return {"roms": matched_roms, "msg": "success"}

--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -1,5 +1,5 @@
-from fastapi import APIRouter, Request
 import emoji
+from fastapi import APIRouter
 
 from logger.logger import log, COLORS
 from handler import igdbh
@@ -7,14 +7,10 @@ from handler import igdbh
 router = APIRouter()
 
 
-@router.put("/search/roms/igdb", status_code=200)
-async def search_rom_igdb(
-    req: Request, search_term: str = "", search_by: str = ""
-) -> dict:
+@router.get("/search/roms/igdb", status_code=200)
+async def search_rom_igdb(rom: str, search_term: str = "", search_by: str = "") -> dict:
     """Get all the roms matched from igdb."""
 
-    data: dict = await req.json()
-    rom: dict = data["rom"]
     log.info(emoji.emojize(":magnifying_glass_tilted_right: IGDB Searching"))
     matched_roms: list = []
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi_pagination import add_pagination
 
 from config import DEV_PORT, DEV_HOST
 from handler.socket_manager import SocketManager
@@ -17,6 +18,8 @@ app.add_middleware(
 app.include_router(search.router)
 app.include_router(platform.router)
 app.include_router(rom.router)
+
+add_pagination(app)
 
 sm = SocketManager()
 sm.mount_to("/ws", app)

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -16,7 +16,7 @@ class Rom(BaseModel):
     p_slug = Column(String(length=50))
     p_name = Column(String(length=150), default="")
 
-    file_name = Column(String(length=450))
+    file_name = Column(String(length=450), nullable=False)
     file_name_no_tags = Column(String(length=450))
     file_extension = Column(String(length=10), default="")
     file_path = Column(String(length=1000), default="")

--- a/backend/utils/fs.py
+++ b/backend/utils/fs.py
@@ -1,15 +1,14 @@
 import os
 import shutil
-from pathlib import Path
-
+import datetime
 import requests
+from pathlib import Path
 
 from config import LIBRARY_BASE_PATH, HIGH_PRIO_STRUCTURE_PATH, \
     RESOURCES_BASE_PATH, DEFAULT_URL_COVER_L, DEFAULT_PATH_COVER_L, DEFAULT_URL_COVER_S, DEFAULT_PATH_COVER_S
 from config.config_loader import ConfigLoader
-cl = ConfigLoader()
-from logger.logger import log
 from utils.exceptions import PlatformsNotFoundException, RomsNotFoundException, RomNotFoundError, RomAlreadyExistsException
+cl = ConfigLoader()
 
 
 # ========= Resources utils =========
@@ -53,7 +52,7 @@ def _get_cover_path(p_slug: str, file_name: str, size: str) -> str:
         file_name: name of rom file
         size: size of the cover -> big | small
     """
-    return f"{p_slug}/{file_name}/cover/{size}.png"
+    return f"{p_slug}/{file_name}/cover/{size}.png?timestamp={str(datetime.datetime.now().timestamp())}"
 
 
 def get_cover(overwrite: bool, p_slug: str, file_name: str, url_cover: str) -> tuple:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,7 @@
         "socket.io-client": "^4.6.1",
         "vue": "^3.2.13",
         "vue-router": "^4.0.0",
-        "vuetify": "^3.1.15",
+        "vuetify": "^3.3.3",
         "webfontloader": "^1.0.0"
       },
       "devDependencies": {
@@ -6171,9 +6171,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.1.15.tgz",
-      "integrity": "sha512-uxB4UCrP+hFyJaoSsVObAGBRD73qq5ga7HULepzGoMeUWap2H99mcqmMdN/a/Yp4ODK3gT8EcUeph3EgEcsArQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.3.3.tgz",
+      "integrity": "sha512-oLpm6L6Zvf4b7Ua8V3INnUkGoxbi04O68ymEbBDLrPFzmIkzAcwd9L/2Ega582PRJnjTBBZapa6KdmosvhVvgA==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },
@@ -6182,12 +6182,16 @@
         "url": "https://github.com/sponsors/johnleider"
       },
       "peerDependencies": {
+        "typescript": ">=4.7",
         "vite-plugin-vuetify": "^1.0.0-alpha.12",
         "vue": "^3.2.0",
         "vue-i18n": "^9.0.0",
         "webpack-plugin-vuetify": "^2.0.0-alpha.11"
       },
       "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
         "vite-plugin-vuetify": {
           "optional": true
         },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@mdi/font": "7.0.96",
         "axios": "^1.3.4",
-        "axios-cache-interceptor": "^1.1.1",
         "core-js": "^3.8.3",
         "file-saver": "^2.0.5",
         "jszip": "^3.10.1",
@@ -2442,25 +2441,6 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/axios-cache-interceptor": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-1.1.1.tgz",
-      "integrity": "sha512-FX2fGHECGE8bhFs4cLZ9FSu1oG4zRoDLKuw2FaYmZCHyrGeg703h751rFD01ICWm3WYb+3/BwrYsv5HOICO2AA==",
-      "dependencies": {
-        "cache-parser": "^1.2.4",
-        "fast-defer": "^1.1.7",
-        "object-code": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/arthurfiorette/axios-cache-interceptor?sponsor=1"
-      },
-      "peerDependencies": {
-        "axios": "^1"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
@@ -2597,11 +2577,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/cache-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/cache-parser/-/cache-parser-1.2.4.tgz",
-      "integrity": "sha512-O0KwuHuJnbHUrghHi2kGp0SxnWSIBXTYt7M8WVhW0kbPRUNUKoE/Of6e1rRD6AAxmfxFunKnt90yEK09D+sc5g=="
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -3580,11 +3555,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
-    },
-    "node_modules/fast-defer": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/fast-defer/-/fast-defer-1.1.7.tgz",
-      "integrity": "sha512-tJ01ulDWT2WhqxMKS20nXX6wyX2iInBYpbN3GO7yjKwXMY4qvkdBRxak9IFwBLlFDESox+SwSvqMCZDfe1tqeg=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -4799,11 +4769,6 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
-    },
-    "node_modules/object-code": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/object-code/-/object-code-1.2.4.tgz",
-      "integrity": "sha512-uGq4ETUuWe+GA586NXEriiaozNuff+YNFXlpD8cVrM1GoiuTZpCABP+bZCWDrvQDoCiSTyiWAFHD/HF/iwhb2w=="
     },
     "node_modules/object-inspect": {
       "version": "1.12.3",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "core-js": "^3.8.3",
         "file-saver": "^2.0.5",
         "jszip": "^3.10.1",
+        "lodash": "^4.17.21",
         "mitt": "^3.0.0",
         "pinia": "^2.0.35",
         "roboto-fontface": "*",
@@ -4592,8 +4593,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mdi/font": "7.0.96",
         "axios": "^1.3.4",
+        "axios-cache-interceptor": "^1.1.1",
         "core-js": "^3.8.3",
         "file-saver": "^2.0.5",
         "jszip": "^3.10.1",
@@ -2441,6 +2442,25 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/axios-cache-interceptor": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-1.1.1.tgz",
+      "integrity": "sha512-FX2fGHECGE8bhFs4cLZ9FSu1oG4zRoDLKuw2FaYmZCHyrGeg703h751rFD01ICWm3WYb+3/BwrYsv5HOICO2AA==",
+      "dependencies": {
+        "cache-parser": "^1.2.4",
+        "fast-defer": "^1.1.7",
+        "object-code": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/arthurfiorette/axios-cache-interceptor?sponsor=1"
+      },
+      "peerDependencies": {
+        "axios": "^1"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
@@ -2577,6 +2597,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/cache-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/cache-parser/-/cache-parser-1.2.4.tgz",
+      "integrity": "sha512-O0KwuHuJnbHUrghHi2kGp0SxnWSIBXTYt7M8WVhW0kbPRUNUKoE/Of6e1rRD6AAxmfxFunKnt90yEK09D+sc5g=="
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -3555,6 +3580,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-defer": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/fast-defer/-/fast-defer-1.1.7.tgz",
+      "integrity": "sha512-tJ01ulDWT2WhqxMKS20nXX6wyX2iInBYpbN3GO7yjKwXMY4qvkdBRxak9IFwBLlFDESox+SwSvqMCZDfe1tqeg=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -4769,6 +4799,11 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
+    },
+    "node_modules/object-code": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/object-code/-/object-code-1.2.4.tgz",
+      "integrity": "sha512-uGq4ETUuWe+GA586NXEriiaozNuff+YNFXlpD8cVrM1GoiuTZpCABP+bZCWDrvQDoCiSTyiWAFHD/HF/iwhb2w=="
     },
     "node_modules/object-inspect": {
       "version": "1.12.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "socket.io-client": "^4.6.1",
     "vue": "^3.2.13",
     "vue-router": "^4.0.0",
-    "vuetify": "^3.1.15",
+    "vuetify": "^3.3.3",
     "webfontloader": "^1.0.0"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@mdi/font": "7.0.96",
     "axios": "^1.3.4",
-    "axios-cache-interceptor": "^1.1.1",
     "core-js": "^3.8.3",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "core-js": "^3.8.3",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
+    "lodash": "^4.17.21",
     "mitt": "^3.0.0",
     "pinia": "^2.0.35",
     "roboto-fontface": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@mdi/font": "7.0.96",
     "axios": "^1.3.4",
+    "axios-cache-interceptor": "^1.1.1",
     "core-js": "^3.8.3",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -20,7 +20,7 @@ useTheme().global.name.value = localStorage.getItem('theme') || 'rommDark'
 const emitter = inject('emitter')
 emitter.on('refresPlatforms', () => {
   fetchPlatformsApi()
-    .then((res) => { platforms.set(res.data.data) })
+    .then((res) => { platforms.set(res.data) })
     .catch((error) => { console.log(error);console.log("Couldn't fetch platforms") })
     refresPlatforms.value = !refresPlatforms.value
 })
@@ -32,7 +32,7 @@ emitter.on('refreshGallery', () => {
 
 onMounted(() => {
   fetchPlatformsApi()
-    .then((res) => { platforms.set(res.data.data) })
+    .then((res) => { platforms.set(res.data) })
     .catch((error) => { console.log(error);console.log("Couldn't fetch platforms") })
 })
 </script>

--- a/frontend/src/components/GameDetails/BackgroundHeader.vue
+++ b/frontend/src/components/GameDetails/BackgroundHeader.vue
@@ -4,7 +4,7 @@ const props = defineProps(['rom'])
 
 <template>
     <v-card class="header-background" position="absolute" rounded="0" flat>
-        <v-img :src="`/assets/romm/resources/${rom.path_cover_s}?reload=${Date.now()}`" class="header-background-img" cover/>
+        <v-img :src="`/assets/romm/resources/${rom.path_cover_s}`" class="header-background-img" cover/>
     </v-card>
 </template>
 

--- a/frontend/src/components/GameGallery/Card/Cover.vue
+++ b/frontend/src/components/GameGallery/Card/Cover.vue
@@ -12,8 +12,8 @@ const forceImgReload = Date.now()
             :value="rom.id"
             :key="rom.id"
             v-bind="hoverProps"
-            :src="`/assets/romm/resources/${rom.path_cover_l}?reload=${forceImgReload}`"
-            :lazy-src="`/assets/romm/resources/${rom.path_cover_s}?reload=${forceImgReload}`"
+            :src="`/assets/romm/resources/${rom.path_cover_l}`"
+            :lazy-src="`/assets/romm/resources/${rom.path_cover_s}`"
             class="cover"
             cover>
             <template v-slot:placeholder>

--- a/frontend/src/components/GameGallery/FilterBar.vue
+++ b/frontend/src/components/GameGallery/FilterBar.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { storeFilter } from '@/stores/filter'
 import { inject, ref, onMounted } from 'vue'
+import { debounce } from 'lodash';
 
 // Props
 const filter = storeFilter()
@@ -10,17 +11,14 @@ const filterValue = ref('')
 const emitter = inject('emitter')
 
 onMounted(() => { filterValue.value = filter.value })
+
+const filterRoms = debounce(() => {
+    filter.set(filterValue.value);
+    emitter.emit('filter');
+}, 500);
 </script>
 
 <template>
-
-    <v-text-field
-        @click:clear="filter.set('');emitter.emit('filter')" 
-        @keyup="filter.set(filterValue);emitter.emit('filter')" 
-        v-model="filterValue"
-        prepend-inner-icon="mdi-magnify"
-        label="search"
-        hide-details
-        clearable/>
-
+    <v-text-field @click:clear="filter.set(''); emitter.emit('filter')" @keyup="filterRoms" v-model="filterValue"
+        prepend-inner-icon="mdi-magnify" label="search" hide-details clearable />
 </template>

--- a/frontend/src/components/GameGallery/ListItem/Item.vue
+++ b/frontend/src/components/GameGallery/ListItem/Item.vue
@@ -5,7 +5,6 @@ import { storeDownloading } from '@/stores/downloading.js'
 
 // Props
 const props = defineProps(['rom'])
-const forceImgReload = Date.now()
 const saveFiles = ref(false)
 const downloading = storeDownloading()
 
@@ -33,8 +32,8 @@ const emitter = inject('emitter')
                     <v-avatar :rounded="0">
                         <v-progress-linear color="rommAccent1" :active="downloading.value.includes(rom.file_name)" :indeterminate="true" absolute/>
                         <v-img
-                        :src="`/assets/romm/resources/${rom.path_cover_s}?reload=${forceImgReload}`"
-                        :lazy-src="`/assets/romm/resources/${rom.path_cover_s}?reload=${forceImgReload}`"
+                        :src="`/assets/romm/resources/${rom.path_cover_s}`"
+                        :lazy-src="`/assets/romm/resources/${rom.path_cover_s}`"
                         min-height="150"/>
                     </v-avatar>
                 </template>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,19 +1,15 @@
-// Components
-import App from './App.vue'
+import { createApp } from "vue";
+import { registerPlugins } from "@/plugins";
 
-// Composables
-import { createApp } from 'vue'
-
-// Plugins
-import { registerPlugins } from '@/plugins'
+import App from "./App.vue";
 
 // Event bus
-import mitt from 'mitt'
-const emitter = mitt()
+import mitt from "mitt";
+const emitter = mitt();
 
-const app = createApp(App)
+const app = createApp(App);
 
-registerPlugins(app)
+registerPlugins(app);
 
-app.provide('emitter', emitter);
-app.mount('#app')
+app.provide("emitter", emitter);
+app.mount("#app");

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -4,7 +4,7 @@ import { setupCache } from "axios-cache-interceptor";
 const axios = setupCache(Axios); // axios instance with cache
 
 export async function fetchPlatformsApi() {
-  return axios.get("/api/platforms");
+  return axios.get("/api/platforms", { cache: false });
 }
 
 export async function fetchRomsApi({
@@ -19,7 +19,7 @@ export async function fetchRomsApi({
 }
 
 export async function fetchRomApi(platform, rom) {
-  return axios.get(`/api/platforms/${platform}/roms/${rom}`);
+  return axios.get(`/api/platforms/${platform}/roms/${rom}`, { cache: false });
 }
 
 export async function updateRomApi(rom, updatedRom) {
@@ -35,7 +35,8 @@ export async function deleteRomApi(rom, deleteFromFs) {
 }
 
 export async function searchRomIGDBApi(searchTerm, searchBy, rom) {
-  return axios.get(
-    `/api/search/roms/igdb/?search_term=${searchTerm}&search_by=${searchBy}&rom=${rom}`
+  return axios.put(
+    `/api/search/roms/igdb?search_term=${searchTerm}&search_by=${searchBy}`,
+    { rom: rom }
   );
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -4,8 +4,12 @@ export async function fetchPlatformsApi() {
   return axios.get("/api/platforms");
 }
 
-export async function fetchRomsApi(platform, cursor) {
-  const params = new URLSearchParams([['size', 50], ['cursor', cursor]]);
+export async function fetchRomsApi({ platform, cursor = "", size = 50, searchTerm = "" }) {
+  const params = new URLSearchParams([
+    ["size", size],
+    ["cursor", cursor],
+    ["search_term", searchTerm],
+  ]);
 
   return axios.get(`/api/platforms/${platform}/roms`, { params });
 }
@@ -26,9 +30,12 @@ export async function deleteRomApi(rom, deleteFromFs) {
   );
 }
 
-export async function searchRomApi(searchTerm, searchBy, rom) {
-  return axios.put(
-    `/api/search/roms/igdb?search_term=${searchTerm}&search_by=${searchBy}`,
-    { rom }
-  );
+export async function searchRomIGDBApi(searchTerm, searchBy, rom) {
+  const params = new URLSearchParams([
+    ["search_term", searchTerm],
+    ["search_by", searchBy],
+    ["rom", rom],
+  ]);
+
+  return axios.get("/api/search/roms/igdb", { params });
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -7,7 +7,7 @@ export async function fetchPlatformsApi() {
 export async function fetchRomsApi({
   platform,
   cursor = "",
-  size = 50,
+  size = 60,
   searchTerm = "",
 }) {
   return axios.get(

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,17 +1,21 @@
-import axios from "axios";
+import Axios from "axios";
+import { setupCache } from "axios-cache-interceptor";
+
+const axios = setupCache(Axios); // axios instance with cache
 
 export async function fetchPlatformsApi() {
   return axios.get("/api/platforms");
 }
 
-export async function fetchRomsApi({ platform, cursor = "", size = 50, searchTerm = "" }) {
-  const params = new URLSearchParams([
-    ["size", size],
-    ["cursor", cursor],
-    ["search_term", searchTerm],
-  ]);
-
-  return axios.get(`/api/platforms/${platform}/roms`, { params });
+export async function fetchRomsApi({
+  platform,
+  cursor = "",
+  size = 50,
+  searchTerm = "",
+}) {
+  return axios.get(
+    `/api/platforms/${platform}/roms?cursor=${cursor}&size=${size}&search_term=${searchTerm}`
+  );
 }
 
 export async function fetchRomApi(platform, rom) {
@@ -31,11 +35,7 @@ export async function deleteRomApi(rom, deleteFromFs) {
 }
 
 export async function searchRomIGDBApi(searchTerm, searchBy, rom) {
-  const params = new URLSearchParams([
-    ["search_term", searchTerm],
-    ["search_by", searchBy],
-    ["rom", rom],
-  ]);
-
-  return axios.get("/api/search/roms/igdb", { params });
+  return axios.get(
+    `/api/search/roms/igdb/?search_term=${searchTerm}&search_by=${searchBy}&rom=${rom}`
+  );
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,10 +1,7 @@
-import Axios from "axios";
-import { setupCache } from "axios-cache-interceptor";
-
-const axios = setupCache(Axios); // axios instance with cache
+import axios from "axios";
 
 export async function fetchPlatformsApi() {
-  return axios.get("/api/platforms", { cache: false });
+  return axios.get("/api/platforms");
 }
 
 export async function fetchRomsApi({
@@ -19,7 +16,7 @@ export async function fetchRomsApi({
 }
 
 export async function fetchRomApi(platform, rom) {
-  return axios.get(`/api/platforms/${platform}/roms/${rom}`, { cache: false });
+  return axios.get(`/api/platforms/${platform}/roms/${rom}`);
 }
 
 export async function updateRomApi(rom, updatedRom) {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,26 +1,34 @@
-import axios from 'axios'
+import axios from "axios";
 
-
-export async function fetchPlatformsApi () {
-    return axios.get('/api/platforms')
+export async function fetchPlatformsApi() {
+  return axios.get("/api/platforms");
 }
 
-export async function fetchRomsApi (platform) {
-    return axios.get(`/api/platforms/${platform}/roms`)
+export async function fetchRomsApi(platform, cursor) {
+  const params = new URLSearchParams([['size', 50], ['cursor', cursor]]);
+
+  return axios.get(`/api/platforms/${platform}/roms`, { params });
 }
 
-export async function fetchRomApi (platform, rom) {
-    return axios.get(`/api/platforms/${platform}/roms/${rom}`)
+export async function fetchRomApi(platform, rom) {
+  return axios.get(`/api/platforms/${platform}/roms/${rom}`);
 }
 
-export async function updateRomApi (rom, updatedRom) {
-    return axios.patch(`/api/platforms/${rom.p_slug}/roms/${rom.id}`, { updatedRom: updatedRom })
+export async function updateRomApi(rom, updatedRom) {
+  return axios.patch(`/api/platforms/${rom.p_slug}/roms/${rom.id}`, {
+    updatedRom,
+  });
 }
 
-export async function deleteRomApi (rom, deleteFromFs) {
-    return axios.delete(`/api/platforms/${rom.p_slug}/roms/${rom.id}?filesystem=${deleteFromFs}`)
+export async function deleteRomApi(rom, deleteFromFs) {
+  return axios.delete(
+    `/api/platforms/${rom.p_slug}/roms/${rom.id}?filesystem=${deleteFromFs}`
+  );
 }
 
-export async function searchRomApi (searchTerm, searchBy, rom) {
-    return axios.put(`/api/search/roms/igdb?search_term=${searchTerm}&search_by=${searchBy}`, { rom: rom })
+export async function searchRomApi(searchTerm, searchBy, rom) {
+  return axios.put(
+    `/api/search/roms/igdb?search_term=${searchTerm}&search_by=${searchBy}`,
+    { rom }
+  );
 }

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -1,7 +1,36 @@
 export const views = {
-    0:{'view': 'small', 'icon': 'mdi-view-module', 'size-lg': 1, 'size-md': 2, 'size-sm': 2, 'size-xs': 3, 'size-cols': 4},
-    1:{'view': 'big', 'icon': 'mdi-view-list', 'size-lg': 2, 'size-md': 3, 'size-sm': 3, 'size-xs': 6, 'size-cols': 6},
-    2:{'view': 'list', 'icon': 'mdi-view-comfy', 'size-lg': 12, 'size-md': 12, 'size-sm': 12, 'size-xs': 12, 'size-cols': 12}
-}
+  0: {
+    view: "small",
+    icon: "mdi-view-comfy",
+    "size-lg": 1,
+    "size-md": 2,
+    "size-sm": 2,
+    "size-xs": 3,
+    "size-cols": 4,
+  },
+  1: {
+    view: "big",
+    icon: "mdi-view-module",
+    "size-lg": 2,
+    "size-md": 3,
+    "size-sm": 3,
+    "size-xs": 6,
+    "size-cols": 6,
+  },
+  2: {
+    view: "list",
+    icon: "mdi-view-list",
+    "size-lg": 12,
+    "size-md": 12,
+    "size-sm": 12,
+    "size-xs": 12,
+    "size-cols": 12,
+  },
+};
 
-export function normalizeString(s) { return s.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g,"") }
+export function normalizeString(s) {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "");
+}

--- a/frontend/src/views/Details.vue
+++ b/frontend/src/views/Details.vue
@@ -87,7 +87,7 @@ onMounted(() => {
     fetchRomApi(route.params.platform, route.params.rom)
     .then(response => {
         rom.value = response.data
-        updatedRom.value = {...response.data.data}
+        updatedRom.value = response.data
         loading.value = false
     }).catch((error) => {
         console.log(error);

--- a/frontend/src/views/Details.vue
+++ b/frontend/src/views/Details.vue
@@ -106,7 +106,7 @@ onMounted(() => {
                 <v-row>
                     <v-col>
                         <v-card elevation="2" :loading="downloading.value.includes(rom.file_name) ? 'rommAccent1': null">
-                            <v-img :src="`/assets/romm/resources/${rom.path_cover_l}?reload=${Date.now()}`" :lazy-src="`/assets/romm/resources/${rom.path_cover_s}?reload=${Date.now()}`" cover>
+                            <v-img :src="`/assets/romm/resources/${rom.path_cover_l}`" :lazy-src="`/assets/romm/resources/${rom.path_cover_s}`" cover>
                                 <template v-slot:placeholder>
                                     <div class="d-flex align-center justify-center fill-height">
                                         <v-progress-circular color="rommAccent1" :width="2" :size="20" indeterminate/>

--- a/frontend/src/views/Details.vue
+++ b/frontend/src/views/Details.vue
@@ -2,7 +2,7 @@
 import { ref, inject, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useDisplay } from "vuetify"
-import { fetchRomApi, updateRomApi, deleteRomApi, searchRomApi } from '@/services/api.js'
+import { fetchRomApi, updateRomApi, deleteRomApi, searchRomIGDBApi } from '@/services/api.js'
 import { downloadRom, downloadSave } from '@/services/download.js'
 import { storeDownloading } from '@/stores/downloading.js'
 import BackgroundHeader from '@/components/GameDetails/BackgroundHeader.vue'
@@ -37,7 +37,7 @@ const emitter = inject('emitter')
 async function searchRomIGDB() {
     searching.value = true
     dialogSearchRom.value = true
-    await searchRomApi(searchTerm.value, searchBy.value, rom.value)
+    await searchRomIGDBApi(searchTerm.value, searchBy.value, rom.value)
     .then((response) => {
         matchedRoms.value = response.data.roms
     })

--- a/frontend/src/views/Details.vue
+++ b/frontend/src/views/Details.vue
@@ -39,7 +39,7 @@ async function searchRomIGDB() {
     dialogSearchRom.value = true
     await searchRomApi(searchTerm.value, searchBy.value, rom.value)
     .then((response) => {
-        matchedRoms.value = response.data.data
+        matchedRoms.value = response.data.roms
     })
     .catch((error) => {console.log(error)})
     searching.value = false
@@ -57,8 +57,8 @@ async function updateRom(updatedData={...updatedRom.value}) {
     if (renameAsIGDB.value) { updatedRom.value.file_name = updatedRom.value.file_name.replace(updatedRom.value.file_name_no_tags, updatedData.r_name) }
     await updateRomApi(rom.value, updatedRom.value)
     .then((response) => {
-        rom.value = response.data.data
-        updatedRom.value = {...response.data.data}
+        rom.value = response.data.rom
+        updatedRom.value = {...response.data.rom}
         emitter.emit('snackbarShow', {'msg': response.data.msg, 'icon': 'mdi-check-bold', 'color': 'green'})
         emitter.emit('refreshGallery')
     }).catch((error) => {
@@ -86,10 +86,13 @@ async function deleteRom() {
 onMounted(() => {
     fetchRomApi(route.params.platform, route.params.rom)
     .then(response => {
-        rom.value = response.data.data
+        rom.value = response.data
         updatedRom.value = {...response.data.data}
         loading.value = false
-    }).catch((error) => { console.log(error);loading.value = false })
+    }).catch((error) => {
+        console.log(error);
+        loading.value = false 
+    })
 })
 </script>
 

--- a/frontend/src/views/Details.vue
+++ b/frontend/src/views/Details.vue
@@ -70,7 +70,7 @@ async function updateRom(updatedData={...updatedRom.value}) {
 }
 
 async function deleteRom() {
-    await deleteRomApi(rom.value.p_slug, deleteFromFs.value)
+    await deleteRomApi(rom.value, deleteFromFs.value)
     .then((response) => {
         emitter.emit('snackbarShow', {'msg': response.data.msg, 'icon': 'mdi-check-bold', 'color': 'green'})
         router.push(`/platform/${rom.value.p_slug}`)

--- a/frontend/src/views/Gallery.vue
+++ b/frontend/src/views/Gallery.vue
@@ -72,7 +72,7 @@ async function fetchMoreSearch() {
   if (searchCursor.value === null) return;
   
   gettingRoms.value = true;
-  await fetchRomsApi({ platform: route.params.platform, cursor: searchCursor.value, size: 100, searchTerm: filter.value })
+  await fetchRomsApi({ platform: route.params.platform, cursor: searchCursor.value, searchTerm: filter.value })
     .then((response) => {
       filteredRoms.value = response.data.items;
       searchCursor.value = response.data.next_page;

--- a/frontend/src/views/Gallery.vue
+++ b/frontend/src/views/Gallery.vue
@@ -70,7 +70,7 @@ async function scan() {
 }
 
 async function fetchMoreSearch() {
-  if (searchCursor.value === null) return;
+  if (searchCursor.value === null || gettingRoms.value) return;
   
   gettingRoms.value = true;
   await fetchRomsApi({ platform: route.params.platform, cursor: searchCursor.value, searchTerm: filter.value })
@@ -100,7 +100,7 @@ function onFilterChange() {
 }
 
 async function fetchMoreRoms(platform) {
-  if (cursor.value === null) return;
+  if (cursor.value === null  || gettingRoms.value) return;
 
   gettingRoms.value = true;
   await fetchRomsApi({ platform, cursor: cursor.value })

--- a/frontend/src/views/Gallery.vue
+++ b/frontend/src/views/Gallery.vue
@@ -106,11 +106,24 @@ async function fetchMoreRoms(platform) {
     });
 }
 
-function onScroll({ target }) {
+function onListScroll({ target }) {
   if (!!filter.value) return;
   if (cursor.value === null) return;
+  
   // If we are at the bottom of the page, fetch more roms
   if (target.scrollTop + target.offsetHeight >= target.scrollHeight) {
+    fetchMoreRoms(route.params.platform);
+  }
+}
+
+function onGridScroll() {
+  if (!!filter.value) return;
+  if (cursor.value === null) return;
+
+  const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+
+  // If we are at the bottom of the page, fetch more roms
+  if (scrollTop + clientHeight >= scrollHeight) {
     fetchMoreRoms(route.params.platform);
   }
 }
@@ -135,7 +148,7 @@ onBeforeRouteUpdate(async (to, _) => {
   </v-app-bar>
 
   <template v-if="filteredRoms.length > 0 || gettingRoms">
-    <v-row v-show="galleryView.value != 2" no-gutters>
+    <v-row id="grid-view" v-show="galleryView.value != 2" no-gutters v-scroll="onGridScroll">
       <v-col v-for="rom in filteredRoms" class="pa-1" :key="rom.id" :cols="views[galleryView.value]['size-cols']"
         :xs="views[galleryView.value]['size-xs']" :sm="views[galleryView.value]['size-sm']"
         :md="views[galleryView.value]['size-md']" :lg="views[galleryView.value]['size-lg']">
@@ -152,7 +165,7 @@ onBeforeRouteUpdate(async (to, _) => {
           <v-divider class="border-opacity-100 mb-4 ml-2 mr-2" color="rommAccent1" :thickness="1" />
           <tbody>
             <!-- Height has to be set and exact -->
-            <v-virtual-scroll :items="filteredRoms" height="calc(100vh - 122px)" @scroll="onScroll">
+            <v-virtual-scroll :items="filteredRoms" height="calc(100vh - 122px)" @scroll="onListScroll">
               <template v-slot="{ item }">
                 <v-list-item :key="item.id" :value="item.id">
                   <game-list-item :rom="item" />

--- a/frontend/src/views/Gallery.vue
+++ b/frontend/src/views/Gallery.vue
@@ -25,6 +25,7 @@ const route = useRoute();
 // const sections = ['roms', 'firmwares']
 const currentSection = ref("roms");
 const roms = ref([]);
+const searchRoms = ref([]);
 const gettingRoms = ref(false);
 const filter = storeFilter();
 const filteredRoms = ref([]);
@@ -74,7 +75,8 @@ async function fetchMoreSearch() {
   gettingRoms.value = true;
   await fetchRomsApi({ platform: route.params.platform, cursor: searchCursor.value, searchTerm: filter.value })
     .then((response) => {
-      filteredRoms.value = response.data.items;
+      searchRoms.value = [...searchRoms.value, ...response.data.items];
+      filteredRoms.value = searchRoms.value;
       searchCursor.value = response.data.next_page;
     })
     .catch((error) => {
@@ -87,6 +89,7 @@ async function fetchMoreSearch() {
 
 function onFilterChange() {
   searchCursor.value = "";
+  searchRoms.value = [];
 
   if (filter.value === "") {
     filteredRoms.value = roms.value;
@@ -143,6 +146,7 @@ onBeforeRouteUpdate(async (to, _) => {
   searchCursor.value = "";
 
   roms.value = [];
+  searchRoms.value = [];
   filteredRoms.value = [];
 
   fetchMoreRoms(to.params.platform);

--- a/frontend/src/views/Gallery.vue
+++ b/frontend/src/views/Gallery.vue
@@ -126,7 +126,7 @@ onBeforeRouteUpdate(async (to, _) => {
   </v-app-bar>
 
   <template v-if="filteredRoms.length > 0 || gettingRoms">
-    <v-row v-show="galleryView.value != 2" id="card-view" no-gutters>
+    <v-row v-show="galleryView.value != 2" no-gutters>
       <v-col v-for="rom in filteredRoms" class="pa-1" :key="rom.id" :cols="views[galleryView.value]['size-cols']"
         :xs="views[galleryView.value]['size-xs']" :sm="views[galleryView.value]['size-sm']"
         :md="views[galleryView.value]['size-md']" :lg="views[galleryView.value]['size-lg']">
@@ -134,7 +134,7 @@ onBeforeRouteUpdate(async (to, _) => {
       </v-col>
     </v-row>
 
-    <v-row v-show="galleryView.value == 2" id="list-view" no-gutters>
+    <v-row v-show="galleryView.value == 2" no-gutters>
       <v-col :cols="views[galleryView.value]['size-cols']" :xs="views[galleryView.value]['size-xs']"
         :sm="views[galleryView.value]['size-sm']" :md="views[galleryView.value]['size-md']"
         :lg="views[galleryView.value]['size-lg']">
@@ -142,7 +142,13 @@ onBeforeRouteUpdate(async (to, _) => {
           <game-list-header />
           <v-divider class="border-opacity-100 mb-4 ml-2 mr-2" color="rommAccent1" :thickness="1" />
           <tbody>
-            <game-list-item v-for="rom in filteredRoms" :key="rom.id" :rom="rom" />
+            <v-virtual-scroll :items="filteredRoms" height="calc(100vh - 10.625em)">
+              <template v-slot="{ item }">
+                <v-list-item :key="item.id" :value="item.id">
+                  <game-list-item :rom="item" />
+                </v-list-item>
+              </template>
+            </v-virtual-scroll>
           </tbody>
         </v-table>
       </v-col>
@@ -155,7 +161,7 @@ onBeforeRouteUpdate(async (to, _) => {
     </template>
     <template v-else>
       <v-row class="justify-center align-center" no-gutters>
-        <v-btn @click="fetchMoreRoms(route.params.platform)" :disabled="cursor.value === null || !!filter.value"
+        <v-btn @click="fetchMoreRoms(route.params.platform)" :disabled="!!filter.value"
           rounded="0" variant="text" class="mr-0" icon>
           <v-icon>mdi-plus</v-icon>
         </v-btn>

--- a/frontend/src/views/Gallery.vue
+++ b/frontend/src/views/Gallery.vue
@@ -112,6 +112,8 @@ onMounted(async () => {
 
 onBeforeRouteUpdate(async (to, _) => {
   cursor.value = "";
+  roms.value = [];
+  filteredRoms.value = [];
   fetchMoreRoms(to.params.platform);
 });
 </script>

--- a/frontend/src/views/Gallery.vue
+++ b/frontend/src/views/Gallery.vue
@@ -113,7 +113,6 @@ onMounted(async () => {
 onBeforeRouteUpdate(async (to, _) => {
   cursor.value = "";
   roms.value = [];
-  filteredRoms.value = [];
   fetchMoreRoms(to.params.platform);
 });
 </script>
@@ -126,9 +125,9 @@ onBeforeRouteUpdate(async (to, _) => {
     <v-btn @click="scan" rounded="0" variant="text" class="mr-0" icon="mdi-magnify-scan" />
   </v-app-bar>
 
-  <template v-if="roms.length > 0 || gettingRoms">
+  <template v-if="filteredRoms.length > 0 || gettingRoms">
     <v-row v-show="galleryView.value != 2" id="card-view" no-gutters>
-      <v-col v-for="rom in filteredRoms" class="pa-1" :key="rom.file_name" :cols="views[galleryView.value]['size-cols']"
+      <v-col v-for="rom in filteredRoms" class="pa-1" :key="rom.id" :cols="views[galleryView.value]['size-cols']"
         :xs="views[galleryView.value]['size-xs']" :sm="views[galleryView.value]['size-sm']"
         :md="views[galleryView.value]['size-md']" :lg="views[galleryView.value]['size-lg']">
         <game-card :rom="rom" />
@@ -143,7 +142,7 @@ onBeforeRouteUpdate(async (to, _) => {
           <game-list-header />
           <v-divider class="border-opacity-100 mb-4 ml-2 mr-2" color="rommAccent1" :thickness="1" />
           <tbody>
-            <game-list-item v-for="rom in filteredRoms" :key="rom.file_name" :rom="rom" />
+            <game-list-item v-for="rom in filteredRoms" :key="rom.id" :rom="rom" />
           </tbody>
         </v-table>
       </v-col>

--- a/frontend/src/views/Gallery.vue
+++ b/frontend/src/views/Gallery.vue
@@ -106,6 +106,15 @@ async function fetchMoreRoms(platform) {
     });
 }
 
+function onScroll({ target }) {
+  if (!!filter.value) return;
+  if (cursor.value === null) return;
+  // If we are at the bottom of the page, fetch more roms
+  if (target.scrollTop + target.offsetHeight >= target.scrollHeight) {
+    fetchMoreRoms(route.params.platform);
+  }
+}
+
 onMounted(async () => {
   fetchMoreRoms(route.params.platform);
 });
@@ -142,7 +151,8 @@ onBeforeRouteUpdate(async (to, _) => {
           <game-list-header />
           <v-divider class="border-opacity-100 mb-4 ml-2 mr-2" color="rommAccent1" :thickness="1" />
           <tbody>
-            <v-virtual-scroll :items="filteredRoms" height="calc(100vh - 10.625em)">
+            <!-- Height has to be set and exact -->
+            <v-virtual-scroll :items="filteredRoms" height="calc(100vh - 122px)" @scroll="onScroll">
               <template v-slot="{ item }">
                 <v-list-item :key="item.id" :value="item.id">
                   <game-list-item :rom="item" />
@@ -153,20 +163,6 @@ onBeforeRouteUpdate(async (to, _) => {
         </v-table>
       </v-col>
     </v-row>
-
-    <template v-if="gettingRoms">
-      <v-row class="justify-center align-center" no-gutters>
-        <v-progress-circular color="rommAccent1" :width="3" :size="70" indeterminate />
-      </v-row>
-    </template>
-    <template v-else>
-      <v-row class="justify-center align-center" no-gutters>
-        <v-btn @click="fetchMoreRoms(route.params.platform)" :disabled="!!filter.value"
-          rounded="0" variant="text" class="mr-0" icon>
-          <v-icon>mdi-plus</v-icon>
-        </v-btn>
-      </v-row>
-    </template>
   </template>
 
   <template v-else>

--- a/frontend/src/views/Gallery.vue
+++ b/frontend/src/views/Gallery.vue
@@ -44,7 +44,7 @@ async function scan() {
   emitter.emit("snackbarShow", {
     msg: `Scanning ${route.params.platform}...`,
     icon: "mdi-loading mdi-spin",
-    color: "yellow",
+    color: "rommAccent1",
   });
   if (!socket.connected) socket.connect();
   socket.on("scan:done", () => {

--- a/poetry.lock
+++ b/poetry.lock
@@ -288,6 +288,39 @@ doc = ["mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-markdo
 test = ["anyio[trio] (>=3.2.1,<4.0.0)", "black (==23.1.0)", "coverage[toml] (>=6.5.0,<8.0)", "databases[sqlite] (>=0.3.2,<0.7.0)", "email-validator (>=1.1.1,<2.0.0)", "flask (>=1.1.2,<3.0.0)", "httpx (>=0.23.0,<0.24.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.982)", "orjson (>=3.2.1,<4.0.0)", "passlib[bcrypt] (>=1.7.2,<2.0.0)", "peewee (>=3.13.3,<4.0.0)", "pytest (>=7.1.3,<8.0.0)", "python-jose[cryptography] (>=3.3.0,<4.0.0)", "python-multipart (>=0.0.5,<0.0.7)", "pyyaml (>=5.3.1,<7.0.0)", "ruff (==0.0.138)", "sqlalchemy (>=1.3.18,<1.4.43)", "types-orjson (==3.6.2)", "types-ujson (==5.7.0.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0,<6.0.0)"]
 
 [[package]]
+name = "fastapi-pagination"
+version = "0.12.4"
+description = "FastAPI pagination"
+category = "main"
+optional = false
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "fastapi_pagination-0.12.4-py3-none-any.whl", hash = "sha256:0d3d25f8a2adf7d35b8a1fb382cd41cad44aaba79f534da5b9c589328fd42465"},
+    {file = "fastapi_pagination-0.12.4.tar.gz", hash = "sha256:1e05e9801bce824b53ba983180e412c38c1d92f35db7ebb57d286a6bbe611461"},
+]
+
+[package.dependencies]
+fastapi = ">=0.93.0"
+pydantic = ">=1.9.1"
+
+[package.extras]
+all = ["SQLAlchemy (>=1.3.20)", "asyncpg (>=0.24.0)", "beanie (>=1.11.9,<2.0.0)", "bunnet (>=1.1.0,<2.0.0)", "databases (>=0.6.0)", "django (<5.0.0)", "mongoengine (>=0.23.1,<0.28.0)", "motor (>=2.5.1,<4.0.0)", "orm (>=0.3.1)", "ormar (>=0.11.2)", "piccolo (>=0.89,<0.112)", "pony (>=0.7.16,<0.8.0)", "scylla-driver (>=3.25.6,<4.0.0)", "sqlakeyset (>=2.0.1680321678,<3.0.0)", "sqlmodel (>=0.0.8,<0.0.9)", "tortoise-orm (>=0.16.18,<0.20.0)"]
+asyncpg = ["SQLAlchemy (>=1.3.20)", "asyncpg (>=0.24.0)"]
+beanie = ["beanie (>=1.11.9,<2.0.0)"]
+bunnet = ["bunnet (>=1.1.0,<2.0.0)"]
+databases = ["databases (>=0.6.0)"]
+django = ["databases (>=0.6.0)", "django (<5.0.0)"]
+mongoengine = ["mongoengine (>=0.23.1,<0.28.0)"]
+motor = ["motor (>=2.5.1,<4.0.0)"]
+orm = ["databases (>=0.6.0)", "orm (>=0.3.1)"]
+ormar = ["ormar (>=0.11.2)"]
+piccolo = ["piccolo (>=0.89,<0.112)"]
+scylla-driver = ["scylla-driver (>=3.25.6,<4.0.0)"]
+sqlalchemy = ["SQLAlchemy (>=1.3.20)", "sqlakeyset (>=2.0.1680321678,<3.0.0)"]
+sqlmodel = ["sqlakeyset (>=2.0.1680321678,<3.0.0)", "sqlmodel (>=0.0.8,<0.0.9)"]
+tortoise = ["tortoise-orm (>=0.16.18,<0.20.0)"]
+
+[[package]]
 name = "greenlet"
 version = "2.0.2"
 description = "Lightweight in-process concurrent programming"
@@ -746,6 +779,21 @@ files = [
 plugins = ["importlib-metadata"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -891,6 +939,24 @@ files = [
     {file = "sniffio-1.3.0-py3-none-any.whl", hash = "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"},
     {file = "sniffio-1.3.0.tar.gz", hash = "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101"},
 ]
+
+[[package]]
+name = "sqlakeyset"
+version = "2.0.1684285512"
+description = "offset-free paging for sqlalchemy"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "sqlakeyset-2.0.1684285512-py3-none-any.whl", hash = "sha256:9b470842d50398666a8fd7c6ab831d8a0ea732a4feb01e4aeb852c9ab9548906"},
+    {file = "sqlakeyset-2.0.1684285512.tar.gz", hash = "sha256:1c559efdc2d68f68123b7e3e67e20ee737bcdc668f552a03e9bbc7a53a6b4b3b"},
+]
+
+[package.dependencies]
+packaging = ">=20.0"
+python-dateutil = "*"
+sqlalchemy = ">=1.3.11"
+typing_extensions = ">=4,<5"
 
 [[package]]
 name = "sqlalchemy"
@@ -1192,4 +1258,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "48254ec18794d503d7e43391f918e20e561ed52ee17dfc6d66c0b3437c551c49"
+content-hash = "cad622fecaa2ec7470b392e0bbc7c28142a46218b2f74c5cd1eddf695c8b2584"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ Unidecode = "1.3.6"
 emoji = "2.2.0"
 python-dotenv = "1.0.0"
 ipdb = "0.13.13"
+fastapi-pagination = "^0.12.4"
+sqlakeyset = "^2.0.1684285512"
 
 
 [build-system]


### PR DESCRIPTION
There's considerable slowdown (lag) in the app when the number of roms in a library hits 500+. This PR attempts to mitigate that issue in a couple ways.

### What changed?

* Introduce cursor-based pagination with [fastapi_pagination](https://uriyyo-fastapi-pagination.netlify.app/)
  * Gallery view holds next cursor value and requests further entries with it
  * ~~Add [axios-cache-interceptor](https://axios-cache-interceptor.js.org/) to cached cursored rom list requests~~
* Set `timestamp` on cover url when cover is updated
  * This allows for cache-busting images but only when required
* Move search to backend and use rom list endpoint with `ilike` filter
  * Add [lodash](https://lodash.com/) to debounce search input
* Fix accessing `file_name` when updating rom, but "Rename rom" not checked

### What's left?

- [x] Get [vue-virtual-scroller](https://github.com/Akryum/vue-virtual-scroller) working, at least for the list view.
- [x] Use `onScroll` instead of needing a dedicated button to load more

### How do I test this?

Either already have a very large library, or generate a ton of empty ZIP files and run a scan to load them in the DB.

```sh
for i in {0001..1000}; do touch "file_${i}.zip"; done
```

Closes #280 
Closes #89 