### PR TITLE
Always use download API to bypass SW cache

### DIFF
--- a/frontend/src/components/Game/Card/ActionBar.vue
+++ b/frontend/src/components/Game/Card/ActionBar.vue
@@ -15,24 +15,13 @@ const downloadUrl = `${window.location.origin}${props.rom.download_path}`;
   <v-card-text>
     <v-row>
       <v-col class="pa-0">
-        <template v-if="rom.multi">
-          <v-btn
-            @click="downloadRomApi(rom)"
-            :disabled="downloadStore.value.includes(rom.file_name)"
-            icon="mdi-download"
-            size="x-small"
-            variant="text"
-          />
-        </template>
-        <template v-else>
-          <v-btn
-            :href="downloadUrl"
-            download
-            icon="mdi-download"
-            size="x-small"
-            variant="text"
-          />
-        </template>
+        <v-btn
+          @click="downloadRomApi(rom)"
+          :disabled="downloadStore.value.includes(rom.file_name)"
+          icon="mdi-download"
+          size="x-small"
+          variant="text"
+        />
         <v-btn
           icon="mdi-content-save-all"
           size="x-small"

--- a/frontend/src/components/Game/ListItem/Item.vue
+++ b/frontend/src/components/Game/ListItem/Item.vue
@@ -64,24 +64,13 @@ const downloadUrl = `${window.location.origin}${props.rom.download_path}`;
       lg="1"
       class="d-flex justify-center align-center mr-4"
     >
-      <template v-if="rom.multi">
-        <v-btn
-          @click="downloadRomApi(rom)"
-          :disabled="downloadStore.value.includes(rom.file_name)"
-          icon="mdi-download"
-          size="x-small"
-          variant="text"
-        />
-      </template>
-      <template v-else>
-        <v-btn
-          :href="downloadUrl"
-          download
-          icon="mdi-download"
-          size="x-small"
-          variant="text"
-        />
-      </template>
+      <v-btn
+        @click="downloadRomApi(rom)"
+        :disabled="downloadStore.value.includes(rom.file_name)"
+        icon="mdi-download"
+        size="x-small"
+        variant="text"
+      />
       <v-btn
         icon="mdi-content-save-all"
         size="x-small"

--- a/frontend/src/views/Details.vue
+++ b/frontend/src/views/Details.vue
@@ -183,28 +183,15 @@ onBeforeMount(() => {
         </v-row>
         <v-row class="pl-3 pr-3 action-buttons">
           <v-col class="pa-0">
-            <template v-if="rom.multi">
-              <v-btn
-                @click="downloadRomApi(rom, filesToDownload)"
-                :disabled="downloadStore.value.includes(rom.file_name)"
-                rounded="0"
-                color="primary"
-                block
-              >
-                <v-icon icon="mdi-download" size="large" />
-              </v-btn>
-            </template>
-            <template v-else>
-              <v-btn
-                :href="downloadUrl"
-                download
-                rounded="0"
-                color="primary"
-                block
-              >
-                <v-icon icon="mdi-download" size="large" />
-              </v-btn>
-            </template>
+            <v-btn
+              @click="downloadRomApi(rom, filesToDownload)"
+              :disabled="downloadStore.value.includes(rom.file_name)"
+              rounded="0"
+              color="primary"
+              block
+            >
+              <v-icon icon="mdi-download" size="large" />
+            </v-btn>
           </v-col>
           <v-col class="pa-0">
             <v-btn rounded="0" block :disabled="!saveFiles"


### PR DESCRIPTION
The service worker that's auto-loaded by `vite-plugin-pwa` sometimes intercepts download requests and returns a bad response. Using the `/download`API endpoint should allow us to bypass it completely.

@zurdi15 Since I can't reproduce this on my local environment, I can't 100% guarantee this will fix the issue (there's nothing to say the axios request won't get cached as well). That being said, the only games that aren't experiencing the bug on my local instance are multi-file ones that go through the endpoint.

(Hopefully) fixes #297 