### PR TITLE
Update platform rom counts after scan/delete

### DIFF
--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -1,12 +1,29 @@
 from fastapi import APIRouter
+from pydantic import BaseModel
 
 from handler import dbh
 
 router = APIRouter()
 
 
+class PlatformSchema(BaseModel):
+    igdb_id: str
+    sgdb_id: str
+
+    slug: str
+    name: str
+
+    logo_path: str
+    fs_slug: str
+
+    n_roms: int
+
+    class Config(BaseModel.Config):
+        orm_mode = True
+
+
 @router.get("/platforms", status_code=200)
-def platforms():
+def platforms() -> list[PlatformSchema]:
     """Returns platforms data"""
 
     return dbh.get_platforms()

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -162,6 +162,7 @@ def delete_rom(p_slug: str, id: int, filesystem: bool = False) -> dict:
     rom: Rom = dbh.get_rom(id)
     log.info(f"Deleting {rom.file_name} from database")
     dbh.delete_rom(id)
+    dbh.update_n_roms(p_slug)
 
     if filesystem:
         log.info(f"Deleting {rom.file_name} from filesystem")

--- a/backend/endpoints/scan.py
+++ b/backend/endpoints/scan.py
@@ -67,6 +67,7 @@ async def scan(
 
             dbh.add_rom(scanned_rom)
         dbh.purge_roms(scanned_platform.slug, [rom["file_name"] for rom in fs_roms])
+        dbh.update_n_roms(scanned_platform.slug)
     dbh.purge_platforms(fs_platforms)
 
     await sm.emit("scan:done")

--- a/backend/utils/fastapi.py
+++ b/backend/utils/fastapi.py
@@ -38,7 +38,6 @@ def scan_platform(fs_slug: str) -> Platform:
         log.warning(f"  {fs_slug} not found in IGDB")
 
     platform_attrs.update(platform)
-    platform_attrs["n_roms"] = len(fs.get_roms(platform_attrs["fs_slug"]))
 
     return Platform(**platform_attrs)
 

--- a/backend/utils/fastapi.py
+++ b/backend/utils/fastapi.py
@@ -88,6 +88,8 @@ def scan_rom(
     else:
         igdbh_rom = igdbh.get_rom(rom_attrs["file_name"], platform.igdb_id)
 
+    rom_attrs.update(igdbh_rom)
+
     # Return early if not found in IGDB
     if not igdbh_rom["r_igdb_id"]:
         log.warning(
@@ -98,7 +100,6 @@ def scan_rom(
     log.info(emoji.emojize(f"\t   Identified as {igdbh_rom['r_name']} :alien_monster:"))
 
     # Update properties from IGDB
-    rom_attrs.update(igdbh_rom)
     rom_attrs.update(
         fs.get_cover(
             overwrite=overwrite,

--- a/backend/utils/tests/test_fastapi.py
+++ b/backend/utils/tests/test_fastapi.py
@@ -14,7 +14,6 @@ def test_scan_platform():
     assert platform.slug == "n64"
     assert platform.name == "Nintendo 64"
     assert platform.igdb_id == 4
-    assert platform.n_roms == 2
 
     try:
         platform = scan_platform("")

--- a/frontend/src/views/Details.vue
+++ b/frontend/src/views/Details.vue
@@ -95,6 +95,7 @@ async function updateRom(updatedData = { ...updatedRom.value }) {
 async function deleteRom() {
   await deleteRomApi(rom.value, deleteFromFs.value)
     .then((response) => {
+      emitter.emit("refreshPlatforms");
       emitter.emit("snackbarShow", {
         msg: response.data.msg,
         icon: "mdi-check-bold",

--- a/frontend/src/views/Gallery.vue
+++ b/frontend/src/views/Gallery.vue
@@ -31,6 +31,7 @@ emitter.on("filter", onFilterChange);
 
 socket.on("scan:done", () => {
   scanning.set(false);
+  emitter.emit("refreshPlatforms");
   emitter.emit("refreshGallery");
   emitter.emit("snackbarShow", {
     msg: "Scan completed successfully!",


### PR DESCRIPTION
After delete a ROM or purging the ROM list for a platform, call `update_n_roms` to update the count, based on the number of ROMs in the DB. Also refresh the platform list so the count updates (this can be improved at a later date).

Fixes #325 