### PR TITLE
Patch in ps2/opl support for game scanning

### DIFF
--- a/backend/endpoints/scan.py
+++ b/backend/endpoints/scan.py
@@ -56,6 +56,7 @@ async def scan_platforms(paltforms: str, complete_rescan: bool):
                     "p_name": scanned_platform.name,
                     "file_name": scanned_rom.file_name,
                     "r_name": scanned_rom.r_name,
+                    "r_igdb_id": scanned_rom.r_igdb_id,
                 },
             )
 

--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -15,6 +15,7 @@ from .ps2_opl_index import opl_index
 
 redis_client = Redis(host=REDIS_HOST, port=REDIS_PORT, db=0, decode_responses=True)
 ps2_opl_regex = r"^([A-Z]{4}_\d{3}\.\d{2})\..*$"
+PS2_IGDB_ID = 8
 
 class IGDBHandler:
     def __init__(self) -> None:
@@ -120,7 +121,7 @@ class IGDBHandler:
 
         # Patch support for PS2 OPL filename format
         match = re.match(ps2_opl_regex, search_term)
-        if p_igdb_id == 8 and match:
+        if p_igdb_id == PS2_IGDB_ID and match:
             serial_code = match.group(1)
             index_entry = opl_index.get(serial_code, None)
             if index_entry:

--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -14,6 +14,11 @@ from logger.logger import log
 from utils.cache import cache
 from .ps2_opl_index import opl_index
 
+MAIN_GAME_CATEGORY = 0
+EXPANDED_GAME_CATEGORY = 10
+
+N_SCREENSHOTS = 5
+
 ps2_opl_regex = r"^([A-Z]{4}_\d{3}\.\d{2})\..*$"
 PS2_IGDB_ID = 8
 
@@ -52,7 +57,7 @@ class IGDBHandler:
         return res.json()
 
     def _search_rom(
-        self, search_term: str, p_igdb_id: int, category: int = None
+        self, search_term: str, p_igdb_id: int, category: int = 0
     ) -> dict:
         category_filter: str = f"& category={category}" if category else ""
         roms = self._request(
@@ -85,7 +90,7 @@ class IGDBHandler:
     def _search_screenshots(self, rom_id: str) -> list:
         screenshots = self._request(
             self.screenshots_url,
-            data=f"fields url; where game={rom_id}; limit 5;",
+            data=f"fields url; where game={rom_id}; limit {N_SCREENSHOTS};",
         )
 
         return [
@@ -128,8 +133,8 @@ class IGDBHandler:
                 search_term = index_entry["Name"]
 
         res = (
-            self._search_rom(uc(search_term), p_igdb_id, 0)
-            or self._search_rom(uc(search_term), p_igdb_id, 10)
+            self._search_rom(uc(search_term), p_igdb_id, MAIN_GAME_CATEGORY)
+            or self._search_rom(uc(search_term), p_igdb_id, EXPANDED_GAME_CATEGORY)
             or self._search_rom(uc(search_term), p_igdb_id)
         )
 

--- a/backend/handler/ps2_opl_index.py
+++ b/backend/handler/ps2_opl_index.py
@@ -1,0 +1,41593 @@
+opl_index = {
+  "SLES_556.71": {
+    "Name": "Fifa '14",
+    "Region": "PAL"
+  },
+  "SLES_556.72": {
+    "Name": "Fifa '14",
+    "Region": "PAL"
+  },
+  "SLES_556.73": {
+    "Name": "Pro Evolution Soccer 2014",
+    "Region": "PAL"
+  },
+  "SLES_556.74": {
+    "Name": "Pro Evolution Soccer 2014",
+    "Region": "PAL"
+  },
+  "SLES_556.75": {
+    "Name": "Pro Evolution Soccer 2014",
+    "Region": "PAL"
+  },
+  "SLES_556.76": {
+    "Name": "Pro Evolution Soccer 2014",
+    "Region": "PAL"
+  },
+  "SLUS_219.55": {
+    "Name": "Pro Evolution Soccer 2013",
+    "Region": "NTSC-U"
+  },
+  "SLPM_666.29": {
+    "Name": "Dirge of Cerberus - Final Fantasy VII International",
+    "Region": "NTSC-J"
+  },
+  "SLPS_259.15": {
+    "Name": "The King of Fighters 2002 - Unlimited Match",
+    "Region": "NTSC-J"
+  },
+  "SLPS_259.83": {
+    "Name": "The King of Fighters 2002 - Unlimited Match",
+    "Region": "NTSC-J"
+  },
+  "SCUS_901.74": {
+    "Name": "Toy Story 3 (PlayStation 2 Bundle)",
+    "Region": "NTSC-U"
+  },
+  "SCUS_943.46": {
+    "Name": "Singstar Latino",
+    "Region": "NTSC-U"
+  },
+  "SCUS_970.97": {
+    "Name": "Network Adapter Start-Up Disc",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.01": {
+    "Name": "Twisted Metal - Black",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SCUS_971.02": {
+    "Name": "Gran Turismo 3 - A-Spec",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.04": {
+    "Name": "ATV Off-Road Fury",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_971.05": {
+    "Name": "Fantavision",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.06": {
+    "Name": "NFL GameDay 2001",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.07": {
+    "Name": "NCAA GameBreaker 2001",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.08": {
+    "Name": "Cool Boarders 2001",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.09": {
+    "Name": "NCAA Final Four 2001",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.10": {
+    "Name": "NHL FaceOff 2001",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.11": {
+    "Name": "Dark Cloud",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.12": {
+    "Name": "Extermination",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.13": {
+    "Name": "Ico",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeClampMode": 2,
+    "vuClampMode": 1
+  },
+  "SCUS_971.14": {
+    "Name": "NBA ShootOut 2001",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.15": {
+    "Name": "Gran Turismo 3 - A-Spec [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.16": {
+    "Name": "Kiosk Demo Disc 2.01",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.17": {
+    "Name": "PlayStation 2 Demo Disc Version 2.1 [Need for Speed - Underground]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.18": {
+    "Name": "NFL GameDay 2001 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.20": {
+    "Name": "PlayStation Underground Demo Disc 4.4 [Disc1&2]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.21": {
+    "Name": "PlayStation Underground 4.3 [Disc2]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.22": {
+    "Name": "ATV Off-Road Fury [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.23": {
+    "Name": "Disney's Monsters Inc.",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.24": {
+    "Name": "Jak and Daxter - The Precursor Legacy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.25": {
+    "Name": "Frequency",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.26": {
+    "Name": "PlayStation 2 Demo Disc Version 2.2",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.27": {
+    "Name": "Kiosk Demo Disc 2.02",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.28": {
+    "Name": "Drakan - The Ancients' Gates",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SCUS_971.29": {
+    "Name": "Okage - Shadow King",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.30": {
+    "Name": "Hot Shots Golf 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.31": {
+    "Name": "NFL GameDay 2002",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.32": {
+    "Name": "Kinetica",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.33": {
+    "Name": "Getaway, The",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.34": {
+    "Name": "SOCOM - U.S. Navy SEALs",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.36": {
+    "Name": "NCAA Final Four 2002",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.40": {
+    "Name": "Mark of Kri, The",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SCUS_971.44": {
+    "Name": "PlayStation Underground 5.1",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.45": {
+    "Name": "Disney's Stitch - Experiment 626",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.46": {
+    "Name": "Disney's Treasure Planet",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.47": {
+    "Name": "Cool Boarders 2001 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.49": {
+    "Name": "Jampack Demo Disc - Summer 2001",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.50": {
+    "Name": "Formula One 2001",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_971.52": {
+    "Name": "Dark Cloud [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.53": {
+    "Name": "Vans Warped Tour '01 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.55": {
+    "Name": "PlayStation 2 Demo Disc Version 2.3",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.56": {
+    "Name": "Kiosk Demo Disc 2.03",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.57": {
+    "Name": "Frequency [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.58": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 049",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.59": {
+    "Name": "Ico [Demo]",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeClampMode": 2,
+    "vuClampMode": 1
+  },
+  "SCUS_971.60": {
+    "Name": "Extermination [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.61": {
+    "Name": "Kinetica [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.63": {
+    "Name": "Jampack Demo Disc - Winter 2001",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.64": {
+    "Name": "Twisted Metal Black [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.65": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 051",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.66": {
+    "Name": "PlayStation Underground Holiday 2001",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.67": {
+    "Name": "PaRappa the Rapper 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.69": {
+    "Name": "Drakan - The Ancients' Gates [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.70": {
+    "Name": "Jak and Daxter - The Precursor Legacy [Cingular Wireless Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.71": {
+    "Name": "Jak and Daxter - The Precursor Legacy [PS Underground Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.72": {
+    "Name": "World Tour Soccer 2002",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.73": {
+    "Name": "Jet X2O",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SCUS_971.74": {
+    "Name": "Kiosk Demo Disc 2.04",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.75": {
+    "Name": "NCAA Final Four 2002 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.76": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 053",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.77": {
+    "Name": "Downhill Domination",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.79": {
+    "Name": "Twisted Metal Black",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.81": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 055",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.82": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 056",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.83": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 057",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.84": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 058",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.85": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 059",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.86": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 060",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.87": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 061",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.88": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 062",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.89": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 063",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.90": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 064",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.91": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 065",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.92": {
+    "Name": "World Tour Soccer 2002 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.94": {
+    "Name": "NFL GameDay 2003",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.95": {
+    "Name": "Twisted Metal Black - Online",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.96": {
+    "Name": "Twisted Metal Black - Online [Demo]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.97": {
+    "Name": "War of the Monsters",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.98": {
+    "Name": "Sly Cooper and the Thievius Raccoonus",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_971.99": {
+    "Name": "Ratchet & Clank",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.00": {
+    "Name": "Kiosk Demo Disc 2.05",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.01": {
+    "Name": "Mark of Kri, The",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.03": {
+    "Name": "Wild ARMs 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_972.04": {
+    "Name": "NCAA Final Four 2003",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.05": {
+    "Name": "SOCOM - U.S. Navy SEALs [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.06": {
+    "Name": "PlayStation Underground Jampack Summer 2002",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.08": {
+    "Name": "Hot Shots Golf 3 & Parappa the Rapper 2 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.09": {
+    "Name": "Ratchet & Clank [E3 Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.10": {
+    "Name": "Sly Cooper and the Thievius Raccoonus [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.11": {
+    "Name": "ATV Off-Road Fury 2",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.12": {
+    "Name": "My Street (Online)",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SCUS_972.13": {
+    "Name": "Dark Cloud 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_972.14": {
+    "Name": "NCAA GameBreaker 2003",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.16": {
+    "Name": "PlayStation Underground Summer Sampler",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.17": {
+    "Name": "NBA Shootout 2003",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.18": {
+    "Name": "Kiosk Demo Disc 2.06",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.19": {
+    "Name": "Gran Turismo 3 - A-Spec - Nissan 350Z Edition",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.20": {
+    "Name": "NHL FaceOff 2003",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.22": {
+    "Name": "Mark of Kri [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.23": {
+    "Name": "NFL GameDay 2003 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.24": {
+    "Name": "Wild ARMs 3 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.26": {
+    "Name": "NCAA GameBreaker 2003 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.27": {
+    "Name": "Kiosk Demo Disc 2.07",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.29": {
+    "Name": "Dark Cloud 2 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.30": {
+    "Name": "SOCOM - U.S. Navy SEALs (Online)",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.31": {
+    "Name": "Arc the Lad - Twilight of the Spirits",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_972.32": {
+    "Name": "Getaway [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.33": {
+    "Name": "World Tour Soccer 2003",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.34": {
+    "Name": "Jampack Demo Disc - Winter 2002 [M-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.35": {
+    "Name": "Jampack Demo Disc - Winter 2002 [T-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.36": {
+    "Name": "World Tour Soccer 2003 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.38": {
+    "Name": "ATV Off-Road Fury 2 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.39": {
+    "Name": "Jet X2O [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.40": {
+    "Name": "Ratchet & Clank [EB Games Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.41": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 066",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.42": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 067",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.43": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 068",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.44": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 069",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.45": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 070",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.46": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 071",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.47": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 072",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.48": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 073",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.49": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 074",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.50": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 075",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.51": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 076",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.52": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 077",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.53": {
+    "Name": "NBA Shootout 2003 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.56": {
+    "Name": "MLB 2004",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.57": {
+    "Name": "MLB 2004 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.58": {
+    "Name": "Amplitude",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_972.59": {
+    "Name": "NHL FaceOff 2003 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.60": {
+    "Name": "War of the Monsters [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.61": {
+    "Name": "Kiosk Demo Disc 2.08",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.62": {
+    "Name": "Amplitude [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.63": {
+    "Name": "My Street [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.64": {
+    "Name": "Syphon Filter - The Omega Strain",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SCUS_972.65": {
+    "Name": "Jak II",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_972.66": {
+    "Name": "Final Fantasy XI [Disc1of2]",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_972.68": {
+    "Name": "Ratchet & Clank - Going Commando",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_972.69": {
+    "Name": "Final Fantasy XI [Disc2of2]",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SCUS_972.70": {
+    "Name": "Kiosk Demo Disc 2.09",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.71": {
+    "Name": "Final Fantasy XI - Online [Beta Version] [Disc1of2]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.72": {
+    "Name": "Final Fantasy XI - Online [Beta Version] [Disc2of2]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.73": {
+    "Name": "Jak II [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.74": {
+    "Name": "Jak II [Video Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.75": {
+    "Name": "SOCOM II - U.S. Navy SEALs",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1,
+    "VIF1StallHack": 1
+  },
+  "SCUS_972.76": {
+    "Name": "NFL GameDay 2004",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_972.77": {
+    "Name": "NCAA GameBreaker 2004",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.78": {
+    "Name": "NCAA Final Four 2004",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.79": {
+    "Name": "Jet Li - Rise to Honor",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_972.80": {
+    "Name": "Jampack Demo Disc - Summer 2003 [T-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.81": {
+    "Name": "Jampack Demo Disc - Summer 2003 [M-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.82": {
+    "Name": "Arc the Lad - Twilight of the Spirits [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_972.92": {
+    "Name": "Amplitude [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.12": {
+    "Name": "Jampack Demo Disc - Winter 2003 [T-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.13": {
+    "Name": "Jampack Demo Disc - Winter 2003 [M-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.15": {
+    "Name": "NCAA GameBreaker 2004 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.16": {
+    "Name": "Sly 2 - Band of Thieves",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_973.17": {
+    "Name": "NFL GameDay 2004 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.18": {
+    "Name": "NBA ShootOut 2004",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.19": {
+    "Name": "EyeToy - Play",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SCUS_973.21": {
+    "Name": "Kiosk Demo Disc 2.10",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.22": {
+    "Name": "Ratchet & Clank 2 - Going Commando [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.23": {
+    "Name": "Ratchet & Clank 2 - Going Commando [Retail Employees Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.24": {
+    "Name": "Kiosk Demo Disc 2.11",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.25": {
+    "Name": "NBA Shootout 2004 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.26": {
+    "Name": "MLB 2005",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.27": {
+    "Name": "MLB 2005 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.28": {
+    "Name": "Gran Turismo 4",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SCUS_973.29": {
+    "Name": "Downhill Domination [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.30": {
+    "Name": "Jak 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_973.31": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 078",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.32": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 079",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.33": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 080",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.34": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 081",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.35": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 082",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.36": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 083",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.37": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 084",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.38": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 085",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.39": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 086",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.40": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 087",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.41": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 088",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.42": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 089",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.45": {
+    "Name": "EyeToy - Groove",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SCUS_973.47": {
+    "Name": "MLB 2006",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.48": {
+    "Name": "NBA '06",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.53": {
+    "Name": "Ratchet and Clank - Up Your Arsenal",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_973.55": {
+    "Name": "Siren",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_973.56": {
+    "Name": "Network Adapter Start-Up Disc Ver.2.5",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.57": {
+    "Name": "Online Start-Up Disc 4.0",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_973.62": {
+    "Name": "Syphon Filter - Dark Mirror",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_973.65": {
+    "Name": "World Tour Soccer 2005",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.66": {
+    "Name": "SOCOM II - U.S. Navy SEALs [Public Beta v1.0]",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1,
+    "VIF1StallHack": 1
+  },
+  "SCUS_973.67": {
+    "Name": "Neopets - The Darkest Faerie",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_973.68": {
+    "Name": "SOCOM II - U.S. Navy SEALs [Regular Demo]",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1,
+    "VIF1StallHack": 1
+  },
+  "SCUS_973.69": {
+    "Name": "ATV Off-Road Fury 2",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_973.72": {
+    "Name": "Rise to Honor [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.73": {
+    "Name": "989 Sports 2004 Demo Disc",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.74": {
+    "Name": "Ratchet & Clank 2 - Going Commando & Jak II [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.77": {
+    "Name": "Syphon Filter - The Omega Strain [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.78": {
+    "Name": "EyeToy and EyeToy Play [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.79": {
+    "Name": "Athens 2004",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_973.80": {
+    "Name": "Final Fantasy XI - Online [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.81": {
+    "Name": "Ratchet & Clank 2 - Going Commando [GameStop Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.82": {
+    "Name": "NBA Shootout 2004 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.83": {
+    "Name": "Kiosk Demo Disc 2.12",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.84": {
+    "Name": "Gran Turismo Special Edition 2004 Toyota [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.92": {
+    "Name": "NBA '06 featuring The Life Vol.1 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.94": {
+    "Name": "Welcome to the World of Online Gaming for Your PlayStation 2 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.95": {
+    "Name": "HDD Utility Disc Ver.1.10",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.96": {
+    "Name": "World Tour Soccer 2005 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.98": {
+    "Name": "Siren [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_973.99": {
+    "Name": "God of War",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.00": {
+    "Name": "EyeToy - Groove",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.01": {
+    "Name": "Hot Shots Golf FORE!",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.02": {
+    "Name": "Killzone",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.03": {
+    "Name": "Athens 2004 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.05": {
+    "Name": "ATV Off-Road Fury 3",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SCUS_974.06": {
+    "Name": "Jampack Demo Disc Vol.10 - Summer 2004 [M-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.07": {
+    "Name": "Kiosk Demo Disc Q2-Q3 2004",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.08": {
+    "Name": "Getaway, The - Black Monday",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.09": {
+    "Name": "Gretzky NHL 2005",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.10": {
+    "Name": "Jampack Demo Disc Vol.10 [T-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.11": {
+    "Name": "Ratchet & Clank - Up Your Arsenal [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.12": {
+    "Name": "Jak 3 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.13": {
+    "Name": "Ratchet & Clank - Up Your Arsenal [Public Beta v1.0]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.14": {
+    "Name": "EyeToy - AntiGrav",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SCUS_974.15": {
+    "Name": "Sly 2 - Band of Thieves [E3 Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.16": {
+    "Name": "Rise of the Kasai",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SCUS_974.17": {
+    "Name": "Jampack Demo Disc Vol.11 [M-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.18": {
+    "Name": "Jampack Demo Disc Vol.11 [T-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.19": {
+    "Name": "Jampack Demo Disc Vol.12 [T-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.20": {
+    "Name": "Jampack Demo Disc Vol.12 [M-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.21": {
+    "Name": "Kiosk Demo Disc Q4-2004 - Q1-2005",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.22": {
+    "Name": "Kiosk Demo Disc Q1-Q2 2005",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.23": {
+    "Name": "Kiosk Demo Disc Q2-Q3 2005",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.24": {
+    "Name": "Kiosk Demo Disc Q3-Q4 2005",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.25": {
+    "Name": "Network Adapter Start-Up Disc Ver.3.0",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.27": {
+    "Name": "Hot Shots Golf FORE! [Online Public Beta]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.28": {
+    "Name": "Kiosk Demo Disc Q3-Q4 2004",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.29": {
+    "Name": "Jak X - Combat Racing",
+    "Region": "NTSC-U",
+    "Compat": 1
+  },
+  "SCUS_974.30": {
+    "Name": "Hot Shots Golf FORE! [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.31": {
+    "Name": "Killzone Public Beta V1.0",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.32": {
+    "Name": "Killzone [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.36": {
+    "Name": "Gran Turismo 4 [Online Public Beta]",
+    "Region": "NTSC-U",
+    "vuClampMode": 2
+  },
+  "SCUS_974.37": {
+    "Name": "ATV Offroad Fury 3 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.38": {
+    "Name": "EyeToy - Antigrav [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.40": {
+    "Name": "Jak and Daxter Trilogy [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.41": {
+    "Name": "Getaway - Black Monday [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.42": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 090",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.43": {
+    "Name": "Official U.S. PlayStation Magazine Demo Issue 91",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.44": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 092",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.45": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 093",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.46": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 094",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.47": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 095",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.48": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 096",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.49": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 097",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.50": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 098",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.51": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 099",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.52": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 100",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.53": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 101",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.54": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 102",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.55": {
+    "Name": "PlayStation Underground Holiday 2004 [M-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.56": {
+    "Name": "PlayStation Underground Holiday 2004 [T-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.57": {
+    "Name": "Sly 2 - Band of Thieves [Retail Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.60": {
+    "Name": "MLB 2006 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.62": {
+    "Name": "Rise of the Kasai [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.63": {
+    "Name": "World Tour Soccer 2006",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.64": {
+    "Name": "Sly 3 - Honor Amongst Thieves",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.65": {
+    "Name": "Ratchet - Deadlocked",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SCUS_974.66": {
+    "Name": "Gretzky NHL '06",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.67": {
+    "Name": "God of War [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.68": {
+    "Name": "EyeToy - Play 2",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SCUS_974.69": {
+    "Name": "Neopets - The Darkest Faerie [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.71": {
+    "Name": "Genji - Dawn of the Samurai",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.72": {
+    "Name": "Shadow of the Colossus",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.73": {
+    "Name": "World Tour Soccer 2006 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.74": {
+    "Name": "SOCOM 3 - U.S. Navy SEALs",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.75": {
+    "Name": "SOCOM 3 - U.S. Navy SEALs [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.78": {
+    "Name": "EyeToy - Kinetic",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.79": {
+    "Name": "ATV Off-Road Fury 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.81": {
+    "Name": "God of War II",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.82": {
+    "Name": "God of War II - The Colossus Battle [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.84": {
+    "Name": "Sly 3 - Honor Among Thieves [E3 Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.85": {
+    "Name": "Ratchet - Deadlocked [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.86": {
+    "Name": "Jak X - Combat Racing [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.87": {
+    "Name": "Ratchet - Deadlocked [Public Beta v.1]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.88": {
+    "Name": "Jak X - Combat Racing [Public Beta v.1]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.89": {
+    "Name": "SOCOM 3 - U.S. Navy SEALs [Public Beta v.1]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.90": {
+    "Name": "Rogue Galaxy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_974.91": {
+    "Name": "Jampack Demo Disc Vol.13 [T-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.92": {
+    "Name": "Jampack Demo Disc Vol.13 [M-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.93": {
+    "Name": "Jampack Demo Disc Vol.14 [T-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.94": {
+    "Name": "Jampack Demo Disc Vol.14 [M-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.95": {
+    "Name": "EyeToy - Play 2 [with Camera]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.97": {
+    "Name": "EyeToy - Kinetic [with Camera]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_974.98": {
+    "Name": "EyeToy - Play 3",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.00": {
+    "Name": "MLB '06 - The Show",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.01": {
+    "Name": "Ape Escape 3",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SCUS_975.02": {
+    "Name": "Tourist Trophy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_975.03": {
+    "Name": "MLB '06 - The Show [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.04": {
+    "Name": "Genji - Dawn of the Samurai [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.05": {
+    "Name": "Shadow of the Colossus [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.06": {
+    "Name": "Gretzky NHL '06 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.07": {
+    "Name": "EyeToy [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.09": {
+    "Name": "Jak II [Greatest Hits]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.10": {
+    "Name": "ATV Off-Road Fury 2 [Greatest Hits]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.11": {
+    "Name": "SOCOM II - U.S. Navy SEALs [Greatest Hits]",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1,
+    "VIF1StallHack": 1
+  },
+  "SCUS_975.12": {
+    "Name": "Gran Turismo 3 - A-Spec [Greatest Hits]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.13": {
+    "Name": "Ratchet & Clank - Going Commando [Greatest Hits]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.14": {
+    "Name": "ATV Off-Road Fury 3 [Greatest Hits]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.15": {
+    "Name": "Hot Shots Golf FORE! [Greatest Hits]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.16": {
+    "Name": "Jak 3 [Greatest Hits]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.17": {
+    "Name": "Killzone [Greatest Hits]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.18": {
+    "Name": "Ratchet and Clank - Up Your Arsenal [Greatest Hits]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.19": {
+    "Name": "Sly 2 - Band of Thieves [Greatest Hits]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.20": {
+    "Name": "Syphon Filter - The Omega Strain [Greatest Hits]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.23": {
+    "Name": "EyeToy - Operation Spy!",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.27": {
+    "Name": "Sly 3 - Honor Among Thieves [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.28": {
+    "Name": "PlayStation Underground Demo Disc - Holiday 2005 [T-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.29": {
+    "Name": "PlayStation Underground Demo Disc - Holiday 2005 [M-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.30": {
+    "Name": "ESA Foundation Compilation Set",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.31": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 103",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.32": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 104",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.33": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 105",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.34": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 106",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.35": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 107",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.36": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 108",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.37": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 109",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.38": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 110",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.39": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 111",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.40": {
+    "Name": "Official U.S. PlayStation Magazine Demo Disc 112",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.44": {
+    "Name": "NBA '07 featuring The Life Vol.2",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.45": {
+    "Name": "SOCOM - U.S. Navy SEALs - Combined Assault",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SCUS_975.48": {
+    "Name": "Ape Escape 3 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.54": {
+    "Name": "NBA '07 featuring The Life Vol.2 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.55": {
+    "Name": "Jak and Daxter Complete Trilogy [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.56": {
+    "Name": "MLB '07 - The Show",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.57": {
+    "Name": "Kiosk Demo Disc Q2-Q3 2006",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.58": {
+    "Name": "Jak and Daxter: The Lost Frontier",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.60": {
+    "Name": "SOCOM - U.S. Navy SEALs - Combined Assault [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.64": {
+    "Name": "Jampack Demo Disc Vol.15 [T-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.65": {
+    "Name": "Jampack Demo Disc Vol.15 [M-Rated]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.68": {
+    "Name": "MLB '07 - The Show [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.71": {
+    "Name": "SingStar Rocks! [with Microphone]",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_975.72": {
+    "Name": "Rogue Galaxy [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.79": {
+    "Name": "ATV Off-Road Fury 4 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.80": {
+    "Name": "SingStar Pop [with Microphone]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.83": {
+    "Name": "MLB '08 - The Show",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.84": {
+    "Name": "Syphon Filter: Logan's Shadow",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.89": {
+    "Name": "NBA '08 featuring The Life Vol.3",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.90": {
+    "Name": "SingStar Rocks! [Game Only]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.91": {
+    "Name": "SingStar Pop [Game Only]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.92": {
+    "Name": "Buzz! The Mega Quiz",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SCUS_975.94": {
+    "Name": "Buzz! The Hollywood Quiz [Bundle]",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SCUS_975.96": {
+    "Name": "Buzz! Junior Jungle Party",
+    "Region": "NTSC-U"
+  },
+  "SCUS_975.97": {
+    "Name": "Buzz! Jr. RoboJam [Bundle]",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SCUS_976.01": {
+    "Name": "Buzz! The Mega Quiz [Game Only]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.02": {
+    "Name": "Buzz! Jr. Jungle Party [Game Only]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.10": {
+    "Name": "Hot Shots Tennis",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SCUS_976.11": {
+    "Name": "SingStar Amped [with Microphone]",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_976.12": {
+    "Name": "SingStar Amped [Game Only]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.15": {
+    "Name": "Ratchet & Clank - Size Matters",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.16": {
+    "Name": "SingStar 80's",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_976.18": {
+    "Name": "SingStar 80's [Game Only]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.20": {
+    "Name": "Syphon Filter - Dark Mirror [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.21": {
+    "Name": "Twisted Metal - Head-On [Extra Twisted Edition]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_976.22": {
+    "Name": "SingStar 80's [with Microphone]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.23": {
+    "Name": "Secret Agent Clank",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCUS_976.27": {
+    "Name": "Singstar Pop Volume 2",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_976.26": {
+    "Name": "SingStar 90's",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.33": {
+    "Name": "Buzz! The Hollywood Quiz [Game Only]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.34": {
+    "Name": "Buzz! Jr. RoboJam [Game Only]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.36": {
+    "Name": "SingStar 90's [Game Only]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.40": {
+    "Name": "Singstar Legends",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_976.42": {
+    "Name": "Singstar Abba",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_976.43": {
+    "Name": "Singstar Queen",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.44": {
+    "Name": "MLB '09: The Show",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.51": {
+    "Name": "Singstar Country",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SCUS_976.53": {
+    "Name": "MLB '10: The Show",
+    "Region": "NTSC-U"
+  },
+  "SCUS_976.54": {
+    "Name": "MotorStorm Arctic Edge",
+    "Region": "NTSC-U",
+    "OPHFLagHack": 1
+  },
+  "SCUS_976.60": {
+    "Name": "Singstar Latino",
+    "Region": "NTSC-U"
+  },
+  "SCUS_978.69": {
+    "Name": "Amplitude P.O.D. [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.01": {
+    "Name": "Tekken Tag Tournament",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.02": {
+    "Name": "Ridge Racer V",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.03": {
+    "Name": "Portal Runner",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.04": {
+    "Name": "Army Men - Air Attack 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.05": {
+    "Name": "World Destruction League - Thunder Tanks",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.06": {
+    "Name": "Warriors of Might and Magic",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.07": {
+    "Name": "World Destruction League - War Jetz",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.08": {
+    "Name": "All-Star Baseball 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.09": {
+    "Name": "Surfing - H30",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.11": {
+    "Name": "Orphen - Scion of Sorcery",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.12": {
+    "Name": "Super Car Street Challenge",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.13": {
+    "Name": "Tony Hawk's Pro Skater 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.14": {
+    "Name": "Armored Core 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.15": {
+    "Name": "Eternal Ring",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.16": {
+    "Name": "Evergrace",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.17": {
+    "Name": "Maximo - Ghosts to Glory",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.18": {
+    "Name": "Onimusha - Warlords",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.21": {
+    "Name": "Kengo - Master of Bushido",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.24": {
+    "Name": "Legacy of Kain - Blood Omen 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.28": {
+    "Name": "No One Lives Forever",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.29": {
+    "Name": "Top Gear Daredevil",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.32": {
+    "Name": "Real Pool",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.34": {
+    "Name": "Unreal Tournament",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.35": {
+    "Name": "Baldur's Gate - Dark Alliance",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_200.37": {
+    "Name": "Run Like Hell - Hunt or Be Hunted",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.39": {
+    "Name": "Top Gear Dare Devil",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.40": {
+    "Name": "Gradius III & IV",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.41": {
+    "Name": "ESPN International Track & Field",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.42": {
+    "Name": "LEGO Racers 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.43": {
+    "Name": "Star Wars - Super Bombad Racing",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_200.44": {
+    "Name": "Star Wars - StarFighter",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.45": {
+    "Name": "Legend of Alon Dar, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.47": {
+    "Name": "Gauntlet - Dark Legacy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.48": {
+    "Name": "Legion - Legend of Excalibur",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.49": {
+    "Name": "MLB Slugfest 2003",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.50": {
+    "Name": "NBA Hoopz",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.51": {
+    "Name": "NFL Blitz 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.54": {
+    "Name": "Ready 2 Rumble Boxing - Round 2",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_200.56": {
+    "Name": "Spy Hunter",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.58": {
+    "Name": "Moto GP",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.62": {
+    "Name": "Grand Theft Auto III",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.63": {
+    "Name": "Midnight Club - Street Racing",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_200.64": {
+    "Name": "Oni",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.65": {
+    "Name": "Smuggler's Run",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.66": {
+    "Name": "Half-Life",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.69": {
+    "Name": "Bouncer",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.70": {
+    "Name": "Q-Ball Billiards Master",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.71": {
+    "Name": "Dead or Alive 2",
+    "Region": "NTSC-U",
+    "Compat": 1
+  },
+  "SLUS_200.72": {
+    "Name": "MX 2002 - featuring Ricky Carmichael",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.73": {
+    "Name": "Red Faction",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.74": {
+    "Name": "Summoner",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.75": {
+    "Name": "Disney's Jungle Book - Rhythm & Groove",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.76": {
+    "Name": "Disney's Tarzan Untamed",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_200.77": {
+    "Name": "Donald Duck Goin' Quackers",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.78": {
+    "Name": "Silent Scope",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.79": {
+    "Name": "Dynasty Warriors 2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.80": {
+    "Name": "GunGriffon Blaze",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.84": {
+    "Name": "Soldier of Fortune - Gold Edition",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_200.85": {
+    "Name": "Silpheed Lost Planet",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.86": {
+    "Name": "Commandos 2 - Men of Courage",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.87": {
+    "Name": "Army Men - Green Rogue",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.88": {
+    "Name": "Fur Fighters - Viggo's Revenge",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.89": {
+    "Name": "ESPN - Winter X Games - Snowboarding",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.90": {
+    "Name": "TimeSplitters",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.91": {
+    "Name": "4x4 Evolution",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.92": {
+    "Name": "Surfing H3O",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.93": {
+    "Name": "Madden NFL 2001",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.94": {
+    "Name": "X Squad",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.95": {
+    "Name": "SSX",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_200.96": {
+    "Name": "Swing Away Golf",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.97": {
+    "Name": "FIFA Soccer 2001",
+    "Region": "NTSC-U"
+  },
+  "SLUS_200.98": {
+    "Name": "Kessen",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_200.99": {
+    "Name": "Theme Park Rollercoaster",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.00": {
+    "Name": "NHL 2001",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.01": {
+    "Name": "NASCAR 2001",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.02": {
+    "Name": "NBA Live 2001",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.03": {
+    "Name": "F1 2000 Championship Edition",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.04": {
+    "Name": "Tiger Woods PGA Tour 2001",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.05": {
+    "Name": "MDK 2 - Armageddon",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.08": {
+    "Name": "Wild Wild Racing",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.09": {
+    "Name": "Rune - Viking Warlord",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.11": {
+    "Name": "Deus Ex - The Conspiracy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.12": {
+    "Name": "Star Trek - Shattered Universe",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.13": {
+    "Name": "Driving Emotion Type S",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.14": {
+    "Name": "Simpsons, The - Skateboarding",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.15": {
+    "Name": "Super Bust-A-Move",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.28": {
+    "Name": "ESPN - MLS Extra Time",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.30": {
+    "Name": "Street Fighter EX3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.31": {
+    "Name": "Dark Angel - Vampire Apocalypse",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.32": {
+    "Name": "Army Men - Sarge's Heroes 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.33": {
+    "Name": "High Heat Baseball 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.34": {
+    "Name": "Sky Odyssey",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.36": {
+    "Name": "Barbarian",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.38": {
+    "Name": "Rayman 2 - Revolution",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_201.39": {
+    "Name": "Simpsons, The - Road Rage",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.40": {
+    "Name": "NHL Hitz 2002",
+    "Region": "NTSC-U",
+    "Compat": 3,
+    "EETimingHack": 1
+  },
+  "SLUS_201.41": {
+    "Name": "CART Fury - Championship Racing",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_201.43": {
+    "Name": "ESPN - NBA 2 Night",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.44": {
+    "Name": "Metal Gear Solid 2 - Sons of Liberty",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.45": {
+    "Name": "Ring of Red",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.46": {
+    "Name": "Shadow of Destiny",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.47": {
+    "Name": "Aliens vs. Predator - Extinction",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.48": {
+    "Name": "Zone of the Enders",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.49": {
+    "Name": "Tribes - Aerial Assault",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.50": {
+    "Name": "Knockout Kings 2001",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_201.51": {
+    "Name": "Klonoa 2 - Lunatea's Veil",
+    "Region": "NTSC-U",
+    "Compat": 4,
+    "eeClampMode": 3
+  },
+  "SLUS_201.52": {
+    "Name": "Ace Combat 4 - Shattered Skies",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.53": {
+    "Name": "RC Revenge Pro",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.54": {
+    "Name": "NFL Quarterback Club 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.57": {
+    "Name": "Haven - Call of the King",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.58": {
+    "Name": "Heroes of Might and Magic",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.59": {
+    "Name": "Dave Mirra Freestyle BMX 2",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_201.60": {
+    "Name": "Winback - Covert Operations",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_201.62": {
+    "Name": "Aqua Aqua",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.64": {
+    "Name": "Project Eden",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.65": {
+    "Name": "Legacy of Kain - Soul Reaver 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.66": {
+    "Name": "ESPN - National Hockey Night",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.67": {
+    "Name": "Quake III - Revolution",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_201.68": {
+    "Name": "Triple Play 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.69": {
+    "Name": "Ephemeral Fantasia",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.70": {
+    "Name": "Adventures of Cookie & Cream, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.71": {
+    "Name": "Motor Mayhem - Vehicular Combat League",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.72": {
+    "Name": "Pryzm - Chapter One - The Dark Unicorn",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.73": {
+    "Name": "Unison",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.74": {
+    "Name": "Rumble Racing",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.75": {
+    "Name": "Mobile Suit Gundam - Journey to Jaburo",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.76": {
+    "Name": "NASCAR Heat 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.77": {
+    "Name": "Test Drive - Off-Road - Wide Open",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_201.78": {
+    "Name": "Giants - Citizen Kabuto",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.79": {
+    "Name": "X-Files - Resist or Serve",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.81": {
+    "Name": "Escape from Monkey Island",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_201.82": {
+    "Name": "Stretch Panic",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.83": {
+    "Name": "Tiny Toon Adventures - Defenders Of The Universe",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.84": {
+    "Name": "Resident Evil - CODE Veronica X",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.86": {
+    "Name": "Monster Jam - Maximum Destruction",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.87": {
+    "Name": "NBA Street",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.89": {
+    "Name": "Tokyo Xtreme Racer Zero",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_201.90": {
+    "Name": "Monster Rancher 3",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_201.91": {
+    "Name": "Defender",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.94": {
+    "Name": "Grandia II",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.95": {
+    "Name": "Dragon Rage",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.96": {
+    "Name": "Soccer America",
+    "Region": "NTSC-U"
+  },
+  "SLUS_201.97": {
+    "Name": "Pac-Man Fever",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.98": {
+    "Name": "Fire Blade",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_201.99": {
+    "Name": "Shaun Palmer's Pro Snowboarder",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_202.02": {
+    "Name": "Crazy Taxi",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.04": {
+    "Name": "Smuggler's Run 2 - Hostile Territory",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_202.05": {
+    "Name": "Casper Spirit Dimensions",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.06": {
+    "Name": "Army Men - RTS",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.07": {
+    "Name": "Le Mans - 24 Hours",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.08": {
+    "Name": "Sunny Garcia Surfing",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_202.09": {
+    "Name": "Midnight Club II",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.10": {
+    "Name": "18 Wheeler - American Pro Trucker",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.11": {
+    "Name": "Top Gun - Combat Zone",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.12": {
+    "Name": "Bloody Roar 3",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.13": {
+    "Name": "Test Drive",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_202.14": {
+    "Name": "State of Emergency",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.16": {
+    "Name": "Devil May Cry",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.17": {
+    "Name": "Arctic Thunder",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.18": {
+    "Name": "Stunt GP",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.19": {
+    "Name": "Time Crisis II",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.20": {
+    "Name": "Dead to Rights",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.21": {
+    "Name": "Vampire Night",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_202.22": {
+    "Name": "MTV - Music Generator 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.23": {
+    "Name": "Splashdown",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_202.24": {
+    "Name": "Pac-Man World 2",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.25": {
+    "Name": "Gadget Racers",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_202.26": {
+    "Name": "Batman - Vengeance",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.27": {
+    "Name": "Star Trek Voyager - Elite Force",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.28": {
+    "Name": "Silent Hill 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.29": {
+    "Name": "Jonny Moseley - Mad Trix",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.30": {
+    "Name": "Max Payne",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.31": {
+    "Name": "Herdy Gerdy",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_202.32": {
+    "Name": "Thunderstrike - Operation Phoenix",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.33": {
+    "Name": "Mobile Suit Gundam - Zeonic Front",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.34": {
+    "Name": "MX Rider",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.35": {
+    "Name": "Superman - Shadow of Apokolips",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.36": {
+    "Name": "Taz Wanted",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.37": {
+    "Name": "ESPN - X Games Skateboarding",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.38": {
+    "Name": "Crash Bandicoot - The Wrath of Cortex",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.39": {
+    "Name": "Driven",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.40": {
+    "Name": "Conflict Zone",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.41": {
+    "Name": "NCAA Football 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.42": {
+    "Name": "Legends of Wrestling",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.43": {
+    "Name": "Silent Scope 2 - Dark Silhouette",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.44": {
+    "Name": "RoboTech BattleCry",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.45": {
+    "Name": "Jeremy McGrath - Supercross World 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.46": {
+    "Name": "Capcom vs. SNK 2 - Mark of the Millennium 2001",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.47": {
+    "Name": "Tetris Worlds",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.49": {
+    "Name": "Armored Core 2 - Another Age",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.50": {
+    "Name": "Stuntman",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.51": {
+    "Name": "Harvest Moon - Save the Homeland",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.52": {
+    "Name": "UFC - Ultimate Fighting Championship - Throwdown",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.53": {
+    "Name": "Mummy Returns, The",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.55": {
+    "Name": "Gallop Racer 2001",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.57": {
+    "Name": "Frogger - The Great Quest",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.59": {
+    "Name": "Wizadry - Tale of the Forsaken Land",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.61": {
+    "Name": "ESPN - NBA 2 Night 2002",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.62": {
+    "Name": "Rugby 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.63": {
+    "Name": "Madden NFL 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.64": {
+    "Name": "F1 2001",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.65": {
+    "Name": "James Bond 007 - Agent Under Fire",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_202.66": {
+    "Name": "NASCAR - Thunder 2002",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.67": {
+    "Name": "dot Hack - Part 1 - Infection",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.68": {
+    "Name": "Star Wars - Racer Revenge",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.70": {
+    "Name": "Eve of Extinction",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.71": {
+    "Name": "Shifters",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.72": {
+    "Name": "Rayman Arena",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.73": {
+    "Name": "Namco Museum",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.74": {
+    "Name": "City Crisis",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.75": {
+    "Name": "Kessen 2",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.77": {
+    "Name": "Dynasty Warriors 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.78": {
+    "Name": "Yanya Caballista - City Skater",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.79": {
+    "Name": "X-Men - Next Dimension",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_202.80": {
+    "Name": "FIFA 2002",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.81": {
+    "Name": "NHL 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.82": {
+    "Name": "Victorious Boxers - Ippo's Road to Glory",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.83": {
+    "Name": "World of Outlaws - Sprint Cars 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.84": {
+    "Name": "Freaky Flyers",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.85": {
+    "Name": "Moto GP 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.86": {
+    "Name": "Smash Court Tennis - Pro Tournament",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.87": {
+    "Name": "Guilty Gear X",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.88": {
+    "Name": "Godai - Elemental Force",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.91": {
+    "Name": "Big Mutha Truckers",
+    "Region": "NTSC-U",
+    "Compat": 1
+  },
+  "SLUS_202.92": {
+    "Name": "Tsugunai - Atonement",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.93": {
+    "Name": "Star Wars - Jedi Starfighter",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.94": {
+    "Name": "Gitaroo Man",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeRoundMode": 1,
+    "vuRoundMode": 3
+  },
+  "SLUS_202.96": {
+    "Name": "Kao the Kangaroo - Round 2",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_202.97": {
+    "Name": "Return to Castle Wolfenstein - Operation Resurrection",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_202.98": {
+    "Name": "High Heat - Major League Baseball 2003",
+    "Region": "NTSC-U"
+  },
+  "SLUS_202.99": {
+    "Name": "Street Hoops - King of the Court",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.00": {
+    "Name": "Dark Summit",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.01": {
+    "Name": "Hidden Invasion",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.02": {
+    "Name": "Extreme-G Racing - XG3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.03": {
+    "Name": "NBA Live 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.05": {
+    "Name": "Simpsons, The - Road Rage",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_203.06": {
+    "Name": "Contra - Shattered Soldier",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.07": {
+    "Name": "Burnout",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.08": {
+    "Name": "ESPN - NFL Prime Time 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.09": {
+    "Name": "Jade Cocoon 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.10": {
+    "Name": "Gravity Games Bike - Street Vert. Dirt",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.11": {
+    "Name": "All-Star Baseball 2003",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.12": {
+    "Name": "Final Fantasy X",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "IPUWaitHack": 1
+  },
+  "SLUS_203.13": {
+    "Name": "Wave Rally",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.14": {
+    "Name": "TimeSplitters 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.15": {
+    "Name": "Spyro the Dragon - Enter the Dragonfly",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_203.16": {
+    "Name": "WWF SmackDown! - Just Bring It!",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.18": {
+    "Name": "King's Field IV",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.19": {
+    "Name": "Romance of the Three Kingdoms VII",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.20": {
+    "Name": "ESPN - International Winter Sports 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.21": {
+    "Name": "ESPN - Winter X Games - Snowboarding 2002",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.22": {
+    "Name": "NFL 2K2 - Sega Sports",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.23": {
+    "Name": "Virtua Fighter 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.24": {
+    "Name": "Paris Dakar Rally",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.25": {
+    "Name": "Bass Strike",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.26": {
+    "Name": "SSX Tricky",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.27": {
+    "Name": "Aggressive Inline",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.28": {
+    "Name": "Tekken 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.29": {
+    "Name": "Pro Race Driver",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.30": {
+    "Name": "NBA 2K2 - Sega Sports",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.31": {
+    "Name": "Minority Report - Everybody Runs",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.32": {
+    "Name": "NCAA March Madness 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.33": {
+    "Name": "Turok - Evolution",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_203.34": {
+    "Name": "Kelly Slater's Pro Surfer",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.35": {
+    "Name": "Matt Hoffman's Pro BMX 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.36": {
+    "Name": "Spider-Man - The Movie",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.37": {
+    "Name": "X-Men - Wolverines Revenge",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_203.39": {
+    "Name": "Bass Fishing Duel - Sega Sports",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.40": {
+    "Name": "RPG Maker 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.41": {
+    "Name": "Woody Woodpecker - Escape from Buzz Buzzard Park",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.42": {
+    "Name": "Top Angler - Real Bass Fishing",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.43": {
+    "Name": "Forever Kingdom",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_203.44": {
+    "Name": "Rez",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.45": {
+    "Name": "Mike Tyson - Heavyweight Boxing",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_203.46": {
+    "Name": "AirBlade",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.47": {
+    "Name": "Shadow Hearts",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.48": {
+    "Name": "Monopoly Party",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_203.49": {
+    "Name": "Scooby Doo! Night of 100 Frights",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.52": {
+    "Name": "Looney Tunes Space Race",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.53": {
+    "Name": "King's Field IV - The Ancient City",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.54": {
+    "Name": "Red Card Soccer 2003",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.55": {
+    "Name": "Tom & Jerry - War of the Whiskers",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.56": {
+    "Name": "Transworld Surf",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.57": {
+    "Name": "WTA Tour Tennis",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.58": {
+    "Name": "Malice",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_203.60": {
+    "Name": "Blade 2",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_203.61": {
+    "Name": "Rally Fusion - Race of Champions",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_203.62": {
+    "Name": "Need for Speed - Hot Pursuit 2",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SLUS_203.63": {
+    "Name": "Sled Storm",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.64": {
+    "Name": "Tiger Woods PGA Tour 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.65": {
+    "Name": "Pirates - Legend of Black Kat",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.66": {
+    "Name": "Triple Play 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.67": {
+    "Name": "Freekstyle",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.68": {
+    "Name": "Medal of Honor - Frontline",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.69": {
+    "Name": "Knockout Kings 2002",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_203.70": {
+    "Name": "Kingdom Hearts",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.71": {
+    "Name": "Thing, The",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_203.73": {
+    "Name": "Men in Black 2 - Alien Escape",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VIFFIFOHack": 1
+  },
+  "SLUS_203.74": {
+    "Name": "Hitman 2 - Silent Assassin",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_203.75": {
+    "Name": "Mister Mosquito",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.76": {
+    "Name": "Mad Maestro",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.77": {
+    "Name": "Metropolismania",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.78": {
+    "Name": "Salt Lake 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.79": {
+    "Name": "Dark Angel - James Cameron's",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.80": {
+    "Name": "Jurassic Park - Operation Genesis",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.81": {
+    "Name": "MX Superfly",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.82": {
+    "Name": "Mobile Suit Gundam - Federation vs. Zeon",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.83": {
+    "Name": "Vexx",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_203.84": {
+    "Name": "Skygunner",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.85": {
+    "Name": "WWE Crush Hour",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.86": {
+    "Name": "Lethal Skies - Elite Pilot - Team SW",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.87": {
+    "Name": "Suikoden III",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.88": {
+    "Name": "Fatal Frame",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.89": {
+    "Name": "Endgame",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.90": {
+    "Name": "Risk - Global Domination",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.91": {
+    "Name": "Terminator, The - Dawn of Fate",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_203.92": {
+    "Name": "Antz Extreme Racing",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.93": {
+    "Name": "Onimusha 2 - Samurai's Destiny",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.94": {
+    "Name": "Ecco the Dolphin - Defender of the Future",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_203.95": {
+    "Name": "GTC Africa",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.97": {
+    "Name": "Tenchu 3 - Wrath of Heaven",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_203.98": {
+    "Name": "Road Trip",
+    "Region": "NTSC-U"
+  },
+  "SLUS_203.99": {
+    "Name": "MTX Mototrax",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_204.00": {
+    "Name": "Mission Impossible - Operation Surma",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_204.02": {
+    "Name": "Britney's Dance Beat",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.03": {
+    "Name": "Evil Dead - A Fistful of Boomstick",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_204.04": {
+    "Name": "FIFA World Cup 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.05": {
+    "Name": "Downforce",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.06": {
+    "Name": "Pride FC - Fighting Championships",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.07": {
+    "Name": "Way of the Samurai",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.08": {
+    "Name": "Pitfall - The Lost Expedition",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_204.09": {
+    "Name": "Total Immersion Racing",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_204.12": {
+    "Name": "Hot Wheels - Velocity X",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.13": {
+    "Name": "Shadow Man - 2econd Coming",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_204.14": {
+    "Name": "Legaia 2 - Duel Saga",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.15": {
+    "Name": "BMX XXX",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_204.16": {
+    "Name": "Headhunter",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.17": {
+    "Name": "Grandia Xtreme",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.18": {
+    "Name": "Wakeboarding Unleashed featuring Shaun Murray",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_204.19": {
+    "Name": "WRC - World Rally Championship",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.20": {
+    "Name": "Star Wars - Bounty Hunter",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.21": {
+    "Name": "Battlestar Galactica",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_204.22": {
+    "Name": "Hulk, The",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_204.23": {
+    "Name": "Mortal Kombat - Deadly Alliance",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.24": {
+    "Name": "Scorpion King, The - Rise of the Akkadian",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_204.25": {
+    "Name": "Spongebob Squarepants - Revenge of the Flying Dutchman",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.28": {
+    "Name": "Fisherman's Bass Club",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.29": {
+    "Name": "Riding Spirits",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.30": {
+    "Name": "Savage Skies",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_204.31": {
+    "Name": "Wreckless - The Yakuza Missions",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.33": {
+    "Name": "SWAT - Global Strike Team",
+    "Region": "NTSC-U",
+    "Compat": 4,
+    "eeClampMode": 3
+  },
+  "SLUS_204.34": {
+    "Name": "Myst III - Exile",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.35": {
+    "Name": "Armored Core 3",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.36": {
+    "Name": "Guilty Gear X2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.37": {
+    "Name": "Dance Dance Revolution MAX",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.38": {
+    "Name": "NHL Hitz 2003",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.39": {
+    "Name": "Futurama",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.40": {
+    "Name": "Kya - Dark Lineage",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_204.41": {
+    "Name": "NASCAR - Dirt to Daytona",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_204.42": {
+    "Name": "Red Faction 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.43": {
+    "Name": "Rugrats - Royal Ransom",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.44": {
+    "Name": "Tankers",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.45": {
+    "Name": "Robot Alchemic Drive - RAD",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.46": {
+    "Name": "Agassi - Tennis Generation",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.48": {
+    "Name": "Summoner 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.52": {
+    "Name": "Egg Mania - Eggstreme Madness",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_204.53": {
+    "Name": "NCAA Football 2K3",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.54": {
+    "Name": "Enter the Matrix",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_204.55": {
+    "Name": "F1 2002",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.56": {
+    "Name": "Soccer Mania",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.57": {
+    "Name": "NFL 2K3 - Sega Sports",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.58": {
+    "Name": "Dr. Muto",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.59": {
+    "Name": "Shinobi",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.60": {
+    "Name": "Super Bust-A-Move 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.61": {
+    "Name": "BloodRayne",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.62": {
+    "Name": "Wipeout Fusion",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.63": {
+    "Name": "Dropship - United Peace Force",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_204.64": {
+    "Name": "Fugitive Hunter - War on Terror",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_204.65": {
+    "Name": "Alter Echo",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.66": {
+    "Name": "Gravenville - Ghost Master",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.67": {
+    "Name": "Tomb Raider - The Angel of Darkness",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "OPHFlagHack": 1
+  },
+  "SLUS_204.68": {
+    "Name": "Dynasty Tactics",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.69": {
+    "Name": "Xenosaga - Episode I - Der Wille zur Macht",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.70": {
+    "Name": "EverQuest - Online Adventures",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.71": {
+    "Name": "Rygar - The Legendary Adventure",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.72": {
+    "Name": "Micro Machines",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.73": {
+    "Name": "Rocket Power - Beach Bandits",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.74": {
+    "Name": "NFL Blitz 2003",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.75": {
+    "Name": "Dual Hearts",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.76": {
+    "Name": "NBA 2K3 - Sega Sports",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.77": {
+    "Name": "NHL 2K3 - Sega Sports",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.78": {
+    "Name": "Disney's PK - Out of the Shadows",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.80": {
+    "Name": "Tennis - Sega Sports",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.82": {
+    "Name": "Sphinx and the Cursed Mummy",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "OPHFLagHack": 1
+  },
+  "SLUS_204.83": {
+    "Name": "WWE Smackdown - Shut Your Mouth",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.84": {
+    "Name": "Devil May Cry 2 [Disc1of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.85": {
+    "Name": "Dino Stalker",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.86": {
+    "Name": "Marvel vs. Capcom 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.87": {
+    "Name": "MegaMan X7",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SLUS_204.88": {
+    "Name": "Star Ocean 3 - Till the End of Time [Disc1of2]",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLUS_204.89": {
+    "Name": "Whirl Tour",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.90": {
+    "Name": "Gladius",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.91": {
+    "Name": "RTX Red Rock",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.92": {
+    "Name": "Ninja Assault",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.93": {
+    "Name": "Gungrave",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.94": {
+    "Name": "Freestyle Metal X",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_204.95": {
+    "Name": "Battle Engine Aquila",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_204.96": {
+    "Name": "V-Rally 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_204.97": {
+    "Name": "Burnout 2 - Point of Impact",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuRoundMode": 1
+  },
+  "SLUS_204.98": {
+    "Name": "Auto Modellista",
+    "Region": "NTSC-U"
+  },
+  "SLUS_204.99": {
+    "Name": "Breath of Fire - Dragon Quarter",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.00": {
+    "Name": "Red Dead Revolver",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.02": {
+    "Name": "Colin McRae Rally 3",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.04": {
+    "Name": "Tony Hawk's Pro Skater 4",
+    "Region": "NTSC-U",
+    "vuRoundMode": "0"
+  },
+  "SLUS_205.05": {
+    "Name": "Mace Griffin - Bounty Hunter",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.06": {
+    "Name": "Black & Bruised",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.07": {
+    "Name": "Legends of Wrestling 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.08": {
+    "Name": "Indiana Jones and the Emperor's Tomb",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.09": {
+    "Name": "Soccer Slam - Sega Sports",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.10": {
+    "Name": "Star Wars - Clone Wars",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.11": {
+    "Name": "Hunter the Reckoning - Wayward",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.13": {
+    "Name": "NBA Starting Five",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.14": {
+    "Name": "Silent Scope 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.15": {
+    "Name": "Yu-Gi-Oh! The Duelists of the Roses",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.16": {
+    "Name": "Shrek - Super Party",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.17": {
+    "Name": "Haven - Call of the King",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.19": {
+    "Name": "Tak and The Power of Juju",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.20": {
+    "Name": "Lord of the Rings, The - The Fellowship of the Ring",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.21": {
+    "Name": "Mystic Heroes",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.22": {
+    "Name": "King of Route 66",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.23": {
+    "Name": "Crouching Tiger Hidden Dragon",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.24": {
+    "Name": "Fighter Maker 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.25": {
+    "Name": "Ejay Club World",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.26": {
+    "Name": "RockSteady ~~UNRELEASED~~",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.27": {
+    "Name": "Butt Ugly Martians - Zoom or Doom!",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.28": {
+    "Name": "Zapper - One Wicked Cricket",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.29": {
+    "Name": "Madden NFL 2003",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.30": {
+    "Name": "NCAA Football 2003",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.31": {
+    "Name": "NHL 2003",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SLUS_205.32": {
+    "Name": "Disney's Golf",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_205.33": {
+    "Name": "Shox",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.34": {
+    "Name": "Cabela's Big Game Hunter",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.35": {
+    "Name": "NASCAR Thunder 2003",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.36": {
+    "Name": "NBA Live 2003",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.37": {
+    "Name": "Jimmy Neutron - Boy Genius",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.38": {
+    "Name": "NCAA Basketball 2K3 - Sega Sports",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.39": {
+    "Name": "Fallout - Brotherhood of Steel",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.40": {
+    "Name": "Evolution Skateboarding",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.41": {
+    "Name": "NBA Ballers",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.43": {
+    "Name": "Metal Gear Solid 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.44": {
+    "Name": "Malice",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.45": {
+    "Name": "Zone of the Enders - The 2nd Runner",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.46": {
+    "Name": "Evolution Snowboarding",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_205.47": {
+    "Name": "Cubix Showdown",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.48": {
+    "Name": "Sub Rebellion",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.49": {
+    "Name": "Conflict - Desert Storm",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.50": {
+    "Name": "True Crime - Streets of L.A.",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_205.52": {
+    "Name": "Grand Theft Auto - Vice City",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.53": {
+    "Name": "Fisherman's Challenge",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.54": {
+    "Name": "Metal Gear Solid 2 - Substance",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.55": {
+    "Name": "Reel Fishing 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.56": {
+    "Name": "Reign of Fire",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.58": {
+    "Name": "Ferrari F355 Challenge",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.59": {
+    "Name": "Rocky",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.60": {
+    "Name": "Galerians - Ash",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.61": {
+    "Name": "Disaster Report",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.62": {
+    "Name": "dot Hack - Part 2 - Mutation",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.63": {
+    "Name": "dot Hack - Part 3 - Outbreak",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.64": {
+    "Name": "dot Hack - Part 4 - Quarantine",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.65": {
+    "Name": "Champions of Norrath",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.66": {
+    "Name": "Buffy the Vampire Slayer - Chaos Bleeds",
+    "Region": "NTSC-U",
+    "Compat": 4,
+    "EETimingHack": 1,
+    "OPHFLagHack": 1
+  },
+  "SLUS_205.67": {
+    "Name": "P.T.O. IV - Pacific Theater of Operations",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.68": {
+    "Name": "Hardhitter Tennis",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.69": {
+    "Name": "All-Star Baseball 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.70": {
+    "Name": "ATV Quad Power Racing 2",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.71": {
+    "Name": "Ty the Tasmanian Tiger",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.72": {
+    "Name": "Tiger Woods PGA Tour 2003",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.73": {
+    "Name": "Sims, The",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_205.74": {
+    "Name": "NCAA March Madness 2003",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.75": {
+    "Name": "Island Xtreme Stunts",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.76": {
+    "Name": "Harry Potter and The Chamber of Secrets",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.77": {
+    "Name": "Drome Racers",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.78": {
+    "Name": "Lord of the Rings, The - The Two Towers",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.79": {
+    "Name": "James Bond 007 - Nightfire",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.80": {
+    "Name": "FIFA Soccer 2003",
+    "Region": "NTSC-U",
+    "vuClampMode": 2
+  },
+  "SLUS_205.82": {
+    "Name": "Street Racing Syndicate",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.84": {
+    "Name": "Speed Kings",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_205.85": {
+    "Name": "Powerpuff Girls, The - Relish Rampage",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.86": {
+    "Name": "IHRA Drag Racing 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.87": {
+    "Name": "Driver 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.88": {
+    "Name": "Activision Anthology",
+    "Region": "NTSC-U"
+  },
+  "SLUS_205.90": {
+    "Name": "Spy Hunter 2",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_205.91": {
+    "Name": "DragonBall Z - Budokai",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.92": {
+    "Name": "HyperSonic Xtreme - HSX",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_205.93": {
+    "Name": "Magic Pengel - The Quest for Color",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.95": {
+    "Name": "Area 51",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.96": {
+    "Name": "UFC - Ultimate Fighting Championship - Sudden Impact",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.97": {
+    "Name": "Warhammer 40K - Fire Warrior",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_205.98": {
+    "Name": "Everblue 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_205.99": {
+    "Name": "Whiteout",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.01": {
+    "Name": "Rayman 3 - Hoodlum Havoc",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.02": {
+    "Name": "High Heat - Major League Baseball 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.03": {
+    "Name": "Mary-Kate & Ashley - Sweet Sixteen - Licensed to Drive",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.04": {
+    "Name": "MTV's Celebrity Deathmatch",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.05": {
+    "Name": "Big Mutha Truckers",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.06": {
+    "Name": "Bounty Hunter - Seek & Destroy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.07": {
+    "Name": "Disney's Extreme Skate Adventure",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuRoundMode": "0"
+  },
+  "SLUS_206.08": {
+    "Name": "Mobile Light Force 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.09": {
+    "Name": "Magix Music Maker",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_206.11": {
+    "Name": "World Series Baseball 2K3",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_206.13": {
+    "Name": "Tom Clancy's Ghost Recon",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.14": {
+    "Name": "Aero Elite - Combat Academy",
+    "Region": "NTSC-U",
+    "Compat": 1
+  },
+  "SLUS_206.15": {
+    "Name": "Fantastic 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.16": {
+    "Name": "Virtua Fighter 4 - Evolution",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.17": {
+    "Name": "Dynasty Warriors 3 - Xtreme Legends",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.18": {
+    "Name": "MLB Slugfest 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.19": {
+    "Name": "Starsky & Hutch",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.20": {
+    "Name": "Smash Cars",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.21": {
+    "Name": "Seven Samurai 20XX",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.22": {
+    "Name": "Silent Hill 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.23": {
+    "Name": "Winning Eleven 6",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.24": {
+    "Name": "Simpsons, The - Hit & Run",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.25": {
+    "Name": "Moto GP 3",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.26": {
+    "Name": "Deer Hunter",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.27": {
+    "Name": "Devil May Cry 2 [Disc2of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.28": {
+    "Name": "Disney's Finding Nemo",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.30": {
+    "Name": "Grand Prix Challenge",
+    "Region": "NTSC-U",
+    "Compat": 2,
+    "VIFFIFOHack": 1
+  },
+  "SLUS_206.31": {
+    "Name": "NFL Blitz Pro",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.32": {
+    "Name": "Extreme-G Racing Association - XGRA",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.33": {
+    "Name": "Clock Tower 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.34": {
+    "Name": "Summer Heat Beach Volleyball",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.35": {
+    "Name": "Muppets Party Cruise, Jim Henson's",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_206.36": {
+    "Name": "Suffering, The",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_206.37": {
+    "Name": "Chessmaster (Online)",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_206.38": {
+    "Name": "Backyard Wrestling - Don't Try This At Home",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_206.39": {
+    "Name": "Def Jam - Vendetta",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.40": {
+    "Name": "Saturday Night Speedway",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_206.41": {
+    "Name": "IndyCar Series",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.42": {
+    "Name": "Auto Modellista",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.43": {
+    "Name": "Soul Calibur 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.43BD": {
+    "Name": "Namco Transmission Demo Disc v1.03 [Soul Calibur II Pack-In]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.44": {
+    "Name": "Armored Core - Silent Line",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.45": {
+    "Name": "Time Crisis 3 [with Guncon]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.46": {
+    "Name": "Mark Davis Pro Bass Challenge",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.47": {
+    "Name": "Wallace & Gromit in Project Zoo",
+    "Region": "NTSC-U",
+    "Compat": 1
+  },
+  "SLUS_206.48": {
+    "Name": "NBA Jam 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.49": {
+    "Name": "Crash Bandicoot - Nitro Kart",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.50": {
+    "Name": "MVP Baseball 2003",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.51": {
+    "Name": "NBA Street 2",
+    "Region": "NTSC-U",
+    "vuClampMode": 2
+  },
+  "SLUS_206.52": {
+    "Name": "Tom Clancy's Splinter Cell",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_206.53": {
+    "Name": "Dynasty Warriors 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.55": {
+    "Name": "Hobbit, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.56": {
+    "Name": "X-Men Legends",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.57": {
+    "Name": "McFarlane Evil Prophecy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.58": {
+    "Name": "Freedom Fighters - The Battle for Liberty Island",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.59": {
+    "Name": "Piglet's Big Game",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.61": {
+    "Name": "Fairly Odd Parents, The - Breakin' Da Rules",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.62": {
+    "Name": "Gallop Racer 2003 - A New Breed",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.63": {
+    "Name": "Naval Ops - Warship Gunner",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.64": {
+    "Name": "Barbie Horse Adventures - Wild Horse Rescue",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.65": {
+    "Name": "Cabela's Deer Hunt - 2004 Season",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.66": {
+    "Name": "Disgaea - Hour of Darkness",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.68": {
+    "Name": "Transformers",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VIFFIFOHack": 1
+  },
+  "SLUS_206.69": {
+    "Name": "Resident Evil - Dead Aim",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.70": {
+    "Name": "Great Escape, The",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_206.71": {
+    "Name": "Mafia",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_206.72": {
+    "Name": "Final Fantasy X-2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.73": {
+    "Name": "Alias",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_206.74": {
+    "Name": "Virtual On Marz",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.76": {
+    "Name": "Lowrider",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_206.77": {
+    "Name": "XIII",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.78": {
+    "Name": "Unlimited SaGa",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.80": {
+    "Name": "SpongeBob SquarePants - The Battle for Bikini Bottoms",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.81": {
+    "Name": "Disney's The Haunted Mansion",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.82": {
+    "Name": "K1 World Grand Prix",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.83": {
+    "Name": "Lupin the 3rd - Treasure of the Sorcerer King",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_206.84": {
+    "Name": "Whiplash",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_206.85": {
+    "Name": "Ape Escape 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.86": {
+    "Name": "Splashdown - Rides Gone Wild",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_206.87": {
+    "Name": "RoadKill",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.88": {
+    "Name": "Psi-Ops - The Mindgate Conspiracy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.89": {
+    "Name": "Conflict - Desert Storm 2 - Back to Baghdad",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.90": {
+    "Name": "G1 Jockey 3",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.91": {
+    "Name": "NHL Hitz Pro",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.93": {
+    "Name": "F1 Career Challenge",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.94": {
+    "Name": "Onimusha 3 - Demon Siege",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.95": {
+    "Name": "Chaos Legion",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.96": {
+    "Name": "Jimmy Neutron - Boy Genius - Jet Fusion",
+    "Region": "NTSC-U"
+  },
+  "SLUS_206.97": {
+    "Name": "Cy Girls [Disc1of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_206.98": {
+    "Name": "SD Gundam Force Showdown",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeClampMode": 2
+  },
+  "SLUS_206.99": {
+    "Name": "Cowboy Bebop",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.01": {
+    "Name": "Scooby-Doo! Mystery Mayhem",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.02": {
+    "Name": "Monster Rancher 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.03": {
+    "Name": "Air Force - Delta Strike",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.04": {
+    "Name": "Backyard Basketball",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.05": {
+    "Name": "I-Ninja",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.06": {
+    "Name": "Kill Switch",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.07": {
+    "Name": "Spawn - Armageddon",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.09": {
+    "Name": "Batman - Rise of Sin-Tzu",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.10": {
+    "Name": "Onimusha - Blade Warriors",
+    "Region": "NTSC-U",
+    "Compat": 1
+  },
+  "SLUS_207.11": {
+    "Name": "Dance Dance Revolution MAX 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.12": {
+    "Name": "Gradius V",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.14": {
+    "Name": "Red Ninja - End of Honor",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.15": {
+    "Name": "WWII Paratroopers",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.16": {
+    "Name": "Teenage Mutant Ninja Turtles",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.18": {
+    "Name": "Sonic Heroes",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.19": {
+    "Name": "NCAA Football 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.20": {
+    "Name": "Romance of the Three Kingdoms VIII",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.21": {
+    "Name": "R Racing Evolution",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_207.22": {
+    "Name": "Maximo vs. Army of Zin",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.23": {
+    "Name": "Robin Hood - Defender of the Crown",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_207.24": {
+    "Name": "Firefighter FD 18",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_207.25": {
+    "Name": "Call of Duty - Finest Hour",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.26": {
+    "Name": "ESPN - NBA Basketball",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.27": {
+    "Name": "ESPN - NFL Football",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.28": {
+    "Name": "ESPN - NHL Hockey",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_207.29": {
+    "Name": "ESPN - College Hoops",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.30": {
+    "Name": "NARC",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.31": {
+    "Name": "Tony Hawk's Underground",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuRoundMode": "0"
+  },
+  "SLUS_207.32": {
+    "Name": "Drakengard",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SLUS_207.33": {
+    "Name": "Castlevania - Lament of Innocence",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.34": {
+    "Name": "Frogger's Adventures - The Rescue",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.35": {
+    "Name": "Lethal Skies 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.36": {
+    "Name": "Cabela's Dangerous Hunts",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.37": {
+    "Name": "Hot Wheels - World Race",
+    "Region": "NTSC-U",
+    "Compat": 4,
+    "EETimingHack": 1
+  },
+  "SLUS_207.38": {
+    "Name": "Van Helsing",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_207.40": {
+    "Name": "Mobile Suit Gundam - Encounters in Space",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.41": {
+    "Name": "Mojo!",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.42": {
+    "Name": "Chulip",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.43": {
+    "Name": "Prince of Persia - Sands of Time",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_207.44": {
+    "Name": "EverQuest - Online Adventures - Frontiers",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.45": {
+    "Name": "Shrek 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.46": {
+    "Name": "Rogue Ops",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.48": {
+    "Name": "Super Trucks Racing",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.49": {
+    "Name": "Rugby 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.50": {
+    "Name": "FIFA Soccer 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.51": {
+    "Name": "James Bond 007 - Everything or Nothing",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.52": {
+    "Name": "Madden NFL 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.53": {
+    "Name": "Medal of Honor - Rising Sun",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.54": {
+    "Name": "NASCAR Thunder 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.55": {
+    "Name": "NBA Live 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.56": {
+    "Name": "NHL 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.57": {
+    "Name": "Tiger Woods PGA Tour 2004",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_207.58": {
+    "Name": "Growlanser Generations [Disc1of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.59": {
+    "Name": "Growlanser Generations [Disc2of2]",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_207.60": {
+    "Name": "World Championship Pool 2004",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.61": {
+    "Name": "Dynasty Tactics 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.62": {
+    "Name": "Secret Weapons Over Normandy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.63": {
+    "Name": "Beyond Good and Evil",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_207.64": {
+    "Name": "Bombastic",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.65": {
+    "Name": "Resident Evil - Outbreak",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.66": {
+    "Name": "Fatal Frame 2 - Crimson Butterfly",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.67": {
+    "Name": "MX Unleashed",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.69": {
+    "Name": "Harry Potter - Quidditch World Cup",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.70": {
+    "Name": "Lord of the Rings, The - The Return of the King",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.71": {
+    "Name": "NCAA March Madness 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.72": {
+    "Name": "SSX 3",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_207.73": {
+    "Name": "Legacy of Kain - Defiance",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.74": {
+    "Name": "Culdcept",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.76": {
+    "Name": "Spider-Man 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.77": {
+    "Name": "Obscure",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_207.79": {
+    "Name": "DragonBall Z - Budokai 2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.80": {
+    "Name": "R-Type Final",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": "1 "
+  },
+  "SLUS_207.81": {
+    "Name": "Karaoke Revolution",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.82": {
+    "Name": "Blood Will Tell",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_207.84": {
+    "Name": "Italian Job, The",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.85": {
+    "Name": "Funkmaster Flex - Digital Hitz Factory",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.86": {
+    "Name": "Metal Arms - Glitch in the System",
+    "Region": "NTSC-U",
+    "Compat": 2,
+    "EETimingHack": 1
+  },
+  "SLUS_207.87": {
+    "Name": "WWE SmackDown! Here Comes the Pain",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.88": {
+    "Name": "Ford Racing 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.89": {
+    "Name": "Jeopardy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.90": {
+    "Name": "Wheel of Fortune",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.91": {
+    "Name": "Trivial Pursuit - Unhinged",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.92": {
+    "Name": "Goblin Commander - Unleash the Horde",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.93": {
+    "Name": "Gladiator - Sword of Vengeance",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_207.94": {
+    "Name": "ESPN - Major League Baseball",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.95": {
+    "Name": "Bloody Roar 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_207.96": {
+    "Name": "Monster 4x4 - Masters of Metal",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.97": {
+    "Name": "Dr. Seuss' The Cat in the Hat",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_207.98": {
+    "Name": "Starcraft - Ghost",
+    "Region": "NTSC-U"
+  },
+  "SLUS_207.99": {
+    "Name": "Terminator, The - Rise of the Machines",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_208.00": {
+    "Name": "Taiko Drum Master",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.01": {
+    "Name": "Midway Arcade Treasures",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.03": {
+    "Name": "Bard's Tale, The",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_208.04": {
+    "Name": "Forgotten Realms - Demon Stone",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.05": {
+    "Name": "Yu Yu Hakusho - Dark Tournament",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.06": {
+    "Name": "Space Channel 5 - Special Edition [Disc 1 of 2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.07": {
+    "Name": "Space Channel 5 - Special Edition [Disc 2 of 2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.09": {
+    "Name": "Godzilla - Save the Earth",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.10": {
+    "Name": "Nightshade",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.11": {
+    "Name": "Need for Speed - Underground",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_208.12": {
+    "Name": "Dynasty Warriors 4 - Extreme Edition",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.13": {
+    "Name": "Plague of Darkness",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.14": {
+    "Name": "Max Payne 2 - Fall of Max Payne",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SLUS_208.16": {
+    "Name": "American Idol",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.17": {
+    "Name": "Headhunter - Redemption",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.18": {
+    "Name": "Bionicle",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.20": {
+    "Name": "Tom Clancy's Ghost Recon - Jungle Storm",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_208.21": {
+    "Name": "Mobile Suit Gundam - Gundam vs. Zeta Gundam",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.22": {
+    "Name": "Galactic Wrestling",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.23": {
+    "Name": "Robotech - Invasion",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.24": {
+    "Name": "NASCAR Thunder 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.26": {
+    "Name": "Harry Potter and The Sorceror's Stone",
+    "Region": "NTSC-U",
+    "EETimingHack": 1
+  },
+  "SLUS_208.27": {
+    "Name": "Manhunt",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.28": {
+    "Name": "ShellShock - Nam '67",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.30": {
+    "Name": "Intellivision Lives!",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.31": {
+    "Name": "Tokyo Xtreme Racer 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.33": {
+    "Name": "MegaMan Anniversary Collection",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.34": {
+    "Name": "King of Fighters 2000 & 2001 [Disc1of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.36": {
+    "Name": "Digimon World 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.37": {
+    "Name": "Ribbit King",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.38": {
+    "Name": "All-Star Baseball 2005",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.39": {
+    "Name": "King of Fighters 2000 & 2001 [Disc2of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.40": {
+    "Name": "Wrath Unleashed",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_208.41": {
+    "Name": "NFL Street",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.42": {
+    "Name": "Sims, The - Bustin' Out",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.43": {
+    "Name": "Dead to Rights II",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_208.45": {
+    "Name": "Cold Winter",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.46": {
+    "Name": "Strike Force Bowling",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.47": {
+    "Name": "La Pucelle - Tactics",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.48": {
+    "Name": "LifeLine - Voice Action Adventure",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_208.49": {
+    "Name": "Carmen Sandiego - The Secret of The Stolen Drums",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_208.50": {
+    "Name": "Blowout",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.51": {
+    "Name": "Ace Combat 5 - The Unsung War",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_208.52": {
+    "Name": "Terminator 3, The - The Redemption",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.53": {
+    "Name": "Looney Tunes - Back in Action",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.54": {
+    "Name": "Cy Girls [Disc2of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.55": {
+    "Name": "Destruction Derby Arenas",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.56": {
+    "Name": "Spy Fiction",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.57": {
+    "Name": "Fight Club",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.58": {
+    "Name": "Corvette 50th Anniversary",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.59": {
+    "Name": "Future Tactics - The Uprising",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.60": {
+    "Name": "Nightmare Before Christmas, Tim Burton's The - Oogie's Revenge",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.61": {
+    "Name": "MTV Music Generator 3 - This is the Remix",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.62": {
+    "Name": "Bloodrayne 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.63": {
+    "Name": "Winning Eleven 7 World Soccer - International",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.64": {
+    "Name": "Punisher, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.65": {
+    "Name": "Backyard Baseball",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.66": {
+    "Name": "Asterix & Obelix XXL - Kick Buttix",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_208.67": {
+    "Name": "Astro Boy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.68": {
+    "Name": "MVP Baseball 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.69": {
+    "Name": "Judge Dredd - Dredd vs. Death",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_208.70": {
+    "Name": "Ultimate Spider-Man",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.71": {
+    "Name": "Naval Ops - Commander",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.72": {
+    "Name": "Juiced",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.73": {
+    "Name": "Silent Hill 4 - The Room",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.74": {
+    "Name": "DragonBall Z - Sagas",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.75": {
+    "Name": "Predator - Concrete Jungle",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.76": {
+    "Name": "Backyard Football 2006",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.77": {
+    "Name": "Crimson Sea 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.78": {
+    "Name": "Samurai Warriors",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.79": {
+    "Name": "Romance of the Three Kingdoms IX",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.80": {
+    "Name": "Fairly Odd Parents, The - Shadow Showdown",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.81": {
+    "Name": "Mortal Kombat - Deception",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.82": {
+    "Name": "Hitman - Contracts",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_208.83": {
+    "Name": "Tom Clancy's Rainbow Six 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.84": {
+    "Name": "Spyro - A Hero's Tail",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.85": {
+    "Name": "Red Star, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.86": {
+    "Name": "Sitting Ducks",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.87": {
+    "Name": "Adventures of Jimmy Neutron, The - Attack of the Twonkies",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.88": {
+    "Name": "Front Mission 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.89": {
+    "Name": "MLB Slugfest - Loaded",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.90": {
+    "Name": "Rocky - Legends",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.91": {
+    "Name": "Star Ocean 3 - Till the End of Time [Disc2of2]",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLUS_208.92": {
+    "Name": "Xenosaga - Episode II - Jenseits von Gut und Bose [Disc1of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.93": {
+    "Name": "Way of the Samurai 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.94": {
+    "Name": "Worms 3D",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_208.95": {
+    "Name": "Bujingai - The Forsaken City",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.96": {
+    "Name": "Monster Hunter",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.97": {
+    "Name": "Swords of Yi",
+    "Region": "NTSC-U"
+  },
+  "SLUS_208.98": {
+    "Name": "Star Wars Battlefront",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_208.99": {
+    "Name": "Samurai Jack - The Shadow of Aku",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.01": {
+    "Name": "FlatOut",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.02": {
+    "Name": "Shadow of Rome",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.03": {
+    "Name": "MegaMan X - Command Mission",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.04": {
+    "Name": "SpongeBob Squarepants - The Movie",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_209.05": {
+    "Name": "Incredibles, The",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.06": {
+    "Name": "Fight Night 2004",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.07": {
+    "Name": "Serious Sam - Next Encounter",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.08": {
+    "Name": "Guilty Gear Isuka",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.09": {
+    "Name": "Crash Bandicoot Twinsanity",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.10": {
+    "Name": "Test Drive - Eve of Destruction",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.11": {
+    "Name": "Shin Megami Tensei - Nocturne",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeRoundMode": "0 "
+  },
+  "SLUS_209.12": {
+    "Name": "Superbikes TT",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.13": {
+    "Name": "Inuyasha - The Secret of The Cursed Mask",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.15": {
+    "Name": "Metal Gear Solid 3 - Snake Eater",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.16": {
+    "Name": "Dance Dance Revolution Extreme",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.17": {
+    "Name": "Sonic Mega Collection Plus",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.18": {
+    "Name": "Super Monkey Ball Deluxe",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.19": {
+    "Name": "ESPN - NFL 2K5",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.20": {
+    "Name": "ESPN - NBA 2K5",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.21": {
+    "Name": "ESPN - NHL 2K5",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.22": {
+    "Name": "ESPN - College Hoops 2K5",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_209.23": {
+    "Name": "King of Fighters - Maximum Impact",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.24": {
+    "Name": "Duel Masters",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.25": {
+    "Name": "Shark Tale",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_209.26": {
+    "Name": "Harry Potter and The Prisoner of Azkaban",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.27": {
+    "Name": "Time Crisis - Crisis Zone",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.28": {
+    "Name": "Echo Night - Beyond",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.29": {
+    "Name": "Gundam Battle Assault 3 featuring Gundam Seed",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.30": {
+    "Name": "Choro Q",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.31": {
+    "Name": "Trigger Man",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.32": {
+    "Name": "Mercenaries - Playground of Destruction",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.33": {
+    "Name": "Smash Court Pro Tournament Tennis 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.34": {
+    "Name": "Death by Degrees",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.35": {
+    "Name": "IHRA Professional Drag Racing 2005",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.36": {
+    "Name": "UEFA Euro 2004",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.37": {
+    "Name": "Wild ARMs - Alter Code F",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.38": {
+    "Name": "Dynasty Warriors 4 - Empires",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.39": {
+    "Name": "Viewtiful Joe 2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.40": {
+    "Name": "Yu-Gi-Oh! Capsule Monster Coliseum",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.41": {
+    "Name": "Incredible Hulk, The - Ultimate Destruction",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.42": {
+    "Name": "Robots",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.43": {
+    "Name": "Heroes of the Pacific",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.44": {
+    "Name": "Power Rangers - Dino Thunder",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.45": {
+    "Name": "Destroy All Humans!",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.46": {
+    "Name": "Grand Theft Auto - San Andreas",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.47": {
+    "Name": "Winback 2nd Operation",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.48": {
+    "Name": "Crimson Tears",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.49": {
+    "Name": "Street Fighter Anniversary Collection",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.50": {
+    "Name": "Capcom Fighting Evolution",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.51": {
+    "Name": "Viewtiful Joe",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.52": {
+    "Name": "Tak 2 - The Staff of Dreams",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.53": {
+    "Name": "Shaman King - Power of Spirit",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.54": {
+    "Name": "Hot Wheels - Stunt Track Challenge",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.55": {
+    "Name": "Phantom Brave",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.56": {
+    "Name": "Leisure Suit Larry - Magna Cum Laude",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.57": {
+    "Name": "Scaler",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.58": {
+    "Name": "Tom Clancy's Splinter Cell - Pandora Tomorrow",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.59": {
+    "Name": "Dukes of Hazzard, The - Return of the General Lee",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.60": {
+    "Name": "MegaMan X8",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.61": {
+    "Name": "Neo Contra",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.62": {
+    "Name": "Castle of Shikigami 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.63": {
+    "Name": "Final Fantasy XII",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.64": {
+    "Name": "Devil May Cry 3",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeRoundMode": "0"
+  },
+  "SLUS_209.65": {
+    "Name": "Tony Hawk's Underground 2",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuRoundMode": "0"
+  },
+  "SLUS_209.66": {
+    "Name": "State of Emergency 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.67": {
+    "Name": "Enthusia Professional Racing",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SLUS_209.68": {
+    "Name": "Karaoke Revolution 2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.69": {
+    "Name": "S.L.A.I. - Steel Lancer Arena International - Phantom Crash",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.70": {
+    "Name": "Rumble Roses",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.71": {
+    "Name": "Metal Slug 4 & 5 [Disc1of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.72": {
+    "Name": "Samurai Showdown V",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.73": {
+    "Name": "Champions - Return to Arms",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.74": {
+    "Name": "Shin Megami Tensei - Digital Devil Saga",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_209.75": {
+    "Name": "One Piece - Grand Battle",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.76": {
+    "Name": "Ford Racing 3",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.77": {
+    "Name": "Virtua Fighter Cyber Generation",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.78": {
+    "Name": "Power Drome",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.79": {
+    "Name": "Suikoden IV",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.80": {
+    "Name": "Ys - The Ark of Napishtim",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_209.81": {
+    "Name": "Teenage Mutant Ninja Turtles 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.82": {
+    "Name": "Bad Boys 2",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.83": {
+    "Name": "Musashi Samurai Legend",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.84": {
+    "Name": "Resident Evil - Outbreak File #2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.85": {
+    "Name": "Under the Skin",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.86": {
+    "Name": "Armored Core Nexus [Evolution Disc]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.87": {
+    "Name": "Pool Paradise",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.88": {
+    "Name": "Playboy - The Mansion",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.89": {
+    "Name": "Polar Express, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.90": {
+    "Name": "Metal Slug 4 & 5 [Disc2of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.91": {
+    "Name": "NCAA Football 2005",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.92": {
+    "Name": "Catwoman",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_209.93": {
+    "Name": "Ghosthunter",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.94": {
+    "Name": "Full Metal Alchemist and The Broken Angel",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.95": {
+    "Name": "King of Fighters 2002 & 2003 [Disc1of2]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.96": {
+    "Name": "King of Fighters 2002 & 2003 [Disc2of2]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_209.97": {
+    "Name": "Midway Arcade Treasures 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.98": {
+    "Name": "DragonBall Z - Budokai 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_209.99": {
+    "Name": "Sega Superstars",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_210.00": {
+    "Name": "Madden NFL 2005",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_210.01": {
+    "Name": "NHL 2005",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.02": {
+    "Name": "Tiger Woods PGA Tour 2005",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_210.03": {
+    "Name": "NASCAR 2005 - Chase for the Cup",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.04": {
+    "Name": "Def Jam - Fight for NY",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.05": {
+    "Name": "Kingdom Hearts II",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.06": {
+    "Name": "Ghost in the Shell - Stane Alone Complex",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_210.07": {
+    "Name": "Kuon",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.08": {
+    "Name": "Katamari Damacy",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "mvuFlagSpeedHack": "0"
+  },
+  "SLUS_210.09": {
+    "Name": "Sega Classics Collection",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.10": {
+    "Name": "NanoBreaker",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.11": {
+    "Name": "Cabela's Big Game Hunter - 2005 Adventures",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.12": {
+    "Name": "Rapala Pro Fishing",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.13": {
+    "Name": "Crash 'N' Burn",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_210.14": {
+    "Name": "High Roller Casino",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.15": {
+    "Name": "Madagascar",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.16": {
+    "Name": "25 to Life",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.17": {
+    "Name": "Showdown - Legends of Wrestling",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.18": {
+    "Name": "Dog's Life",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.19": {
+    "Name": "Technic Beat",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_210.20": {
+    "Name": "GunGrave - OverDose",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.21": {
+    "Name": "Cabela's Deer Hunt - 2005 Season",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.22": {
+    "Name": "Prince of Persia - Warrior Within",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.25": {
+    "Name": "Madden NFL 2005 [Special Collectors Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.26": {
+    "Name": "Battlefield 2 - Mordern Combat",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.27": {
+    "Name": "Lord of the Rings, The - The Third Age",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.28": {
+    "Name": "World Championship Poker",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.29": {
+    "Name": "Midnight Club 3 - DUB Edition",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.30": {
+    "Name": "Outlaw Golf 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.31": {
+    "Name": "Gallop Racer 2004",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.32": {
+    "Name": "Marc Ecko's Getting Up - Contents Under Pressure",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_210.33": {
+    "Name": "Second Sight",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_210.34": {
+    "Name": "Magix Music Maker [Deluxe Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.35": {
+    "Name": "Major League Baseball 2K5",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.36": {
+    "Name": "Get On Da Mic",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.37": {
+    "Name": "Project - Snowblind",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_210.38": {
+    "Name": "Pinball Hall of Fame - The Gottlieb Collection",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.39": {
+    "Name": "TOCA Race Driver 2 - The Ultimate Racing Simulator",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.40": {
+    "Name": "Shield, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.41": {
+    "Name": "Shadow Hearts 2 - Covenant [Disc1of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.42": {
+    "Name": "Darkwatch",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.43": {
+    "Name": "Backyard Wrestling 2 - There Goes the Neighborhood",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.44": {
+    "Name": "Shadow Hearts 2 - Covenant [Disc2of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.45": {
+    "Name": "Conflict Vietnam",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.46": {
+    "Name": "King Arthur",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.47": {
+    "Name": "Cold Fear",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.48": {
+    "Name": "Evil Dead - Regeneration",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.49": {
+    "Name": "Outlaw Volleyball Remixed",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_210.50": {
+    "Name": "Burnout 3 - Takedown",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.51": {
+    "Name": "FIFA 2005",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_210.52": {
+    "Name": "Disney's Monsters Inc.",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.53": {
+    "Name": "Disney's Stitch 926",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.54": {
+    "Name": "Disney's Classics - Treasure Planet",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.56": {
+    "Name": "Cabal, The ~~CANCELLED~~",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.57": {
+    "Name": "Ty the Tasmanian Tiger 2 - Bush Rescue",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.58": {
+    "Name": "NBA Live 2005",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.59": {
+    "Name": "Tekken 5",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeClampMode": 1
+  },
+  "SLUS_210.60": {
+    "Name": "WWE SmackDown! vs. RAW",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.62": {
+    "Name": "Jaws Unleashed",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.63": {
+    "Name": "Shining Tears",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.64": {
+    "Name": "GoldenEye - Rogue Agent",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.65": {
+    "Name": "Need for Speed - Underground 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.66": {
+    "Name": "Urbz, The - Sims in the City",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.67": {
+    "Name": "Digimon Rumble Arena 2",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "FpuCompareHack": 1
+  },
+  "SLUS_210.68": {
+    "Name": "Vietcong - Purple Haze",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_210.69": {
+    "Name": "American Chopper",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.70": {
+    "Name": "Final Fantasy XI - Chains of Promathia",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.71": {
+    "Name": "Nightmare of Druaga",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.72": {
+    "Name": "Finny the Fish & The Seven Waters",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.73": {
+    "Name": "Nicktoons Movin'",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.74": {
+    "Name": "Guy Game, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.75": {
+    "Name": "Haunting Ground",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.76": {
+    "Name": "Atari Anthology",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.77": {
+    "Name": "Gauntlet - Seven Sorrows",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.78": {
+    "Name": "Lemony Snicket's A Series of Unfortunate Events",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.79": {
+    "Name": "Armored Core Nexus [Revolution Disc]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.80": {
+    "Name": "Samurai Warriors - Xtreme Legends",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_210.81": {
+    "Name": "Mortal Kombat - Deception [Premium Pack]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.82": {
+    "Name": "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.83": {
+    "Name": "LEGO Star Wars",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.84": {
+    "Name": "Winnie the Pooh's Rumbly Tumbly Adventure",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.86": {
+    "Name": "Big Mutha Truckers 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.87": {
+    "Name": "Mortal Kombat - Shaolin Monks",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.88": {
+    "Name": "Disney's Chicken Little",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.89": {
+    "Name": "Karaoke Revolution Volume 3",
+    "Region": "NTSC-U"
+  },
+  "SLUS_210.90": {
+    "Name": "Alien Homind",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.91": {
+    "Name": "Scooby-Doo! Unmasked",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.93": {
+    "Name": "Worms Forts - Under Siege!",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_210.94": {
+    "Name": "Midway Arcade Treasures 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.95": {
+    "Name": "DT Racer",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_210.96": {
+    "Name": "Ape Escape - Pumped & Primed",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_210.97": {
+    "Name": "MX World Tour featuring Jamie Little",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.98": {
+    "Name": "Frogger - Ancient Shadow",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_210.99": {
+    "Name": "Stolen",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_211.00": {
+    "Name": "NCAA March Madness 2005",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.01": {
+    "Name": "Mortal Kombat - Deception [Premium Pack]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.02": {
+    "Name": "Hard Rock Casino",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_211.03": {
+    "Name": "Commandos Strike Force",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_211.04": {
+    "Name": "MX vs. ATV Unleashed",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.05": {
+    "Name": "Tom Clancy's Ghost Recon 2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.06": {
+    "Name": "True Crime - New York City",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_211.07": {
+    "Name": "X-Men - The Official Game",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_211.08": {
+    "Name": "Hitman - Blood Money",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_211.09": {
+    "Name": "Drive to Survive",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.10": {
+    "Name": "Pirates of the Caribbean - The Legend of Jack Sparrow",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_211.11": {
+    "Name": "Scarface - The World is Yours",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_211.12": {
+    "Name": "L.A. Rush",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.13": {
+    "Name": "Atelier Iris - Eternal Mana",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.14": {
+    "Name": "NHRA Championship Drag Racing",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.15": {
+    "Name": "Okami",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.16": {
+    "Name": "187 - Ride or Die",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.17": {
+    "Name": "World Soccer - Winning Eleven 8 - International",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.18": {
+    "Name": "NFL Street 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.19": {
+    "Name": "Kessen 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.20": {
+    "Name": "Psychonauts",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.22": {
+    "Name": "Taito Legends",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.23": {
+    "Name": "DragonBall Z - Budokai 3 [Limited Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.24": {
+    "Name": "Delta Force - Black Hawk Down",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_211.25": {
+    "Name": "Airboure Troops - Countdown to D-Day",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.26": {
+    "Name": "NBA Street v3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.27": {
+    "Name": "Brave - The Search for Spirit Dancer",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_211.28": {
+    "Name": "Blitz - The League",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.29": {
+    "Name": "Tenchu 4 - Fatal Shadows",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.30": {
+    "Name": "SnoCross 2 featuring Blair Morgan",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.31": {
+    "Name": "Pump It Up - Exceed",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.32": {
+    "Name": "Stella Deus - The Gate of Eternity",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.33": {
+    "Name": "Xenosaga - Episode II - Jenseits von Gut und Bose [Disc2of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.34": {
+    "Name": "Resident Evil 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.35": {
+    "Name": "MVP Baseball 2005",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.36": {
+    "Name": "Graffiti Kingdom",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.37": {
+    "Name": "Tom Clancy's Splinter Cell - Chaos Theory",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_211.38": {
+    "Name": "X-Men Legends II - Rise of Apocalypse",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.39": {
+    "Name": "Gun",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_211.40": {
+    "Name": "Mobile Suit Gundam Seed - Never Ending Tomorrow",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.42": {
+    "Name": "Constantine",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.43": {
+    "Name": "Star Wars - Episode III - Revenge of the Sith",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.44": {
+    "Name": "Tom Clancy's Rainbow Six - Lockdown",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.45": {
+    "Name": "Full Spectrum Warrior",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_211.46": {
+    "Name": "Far East of Eden",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.47": {
+    "Name": "FIFA Street",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.48": {
+    "Name": "TimeSplitters - Future Perfect",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.49": {
+    "Name": "Yourself Fitness",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.50": {
+    "Name": "Beatdown - Fists of Vengeance",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.51": {
+    "Name": "Disney-Pixar's Cars",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.52": {
+    "Name": "Shin Megami Tensei - Digital Devil Saga 2",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_211.53": {
+    "Name": "Dynasty Warriors 5",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.54": {
+    "Name": "Killer 7",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.55": {
+    "Name": "Codename - Kids Next Door - Operation V.I.D.E.O.G.A.M.E.",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.56": {
+    "Name": "Without Warning",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.57": {
+    "Name": "Flipnic - Ultimate Pinball",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_211.58": {
+    "Name": "Rugby 2005",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.59": {
+    "Name": "Moto GP 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.60": {
+    "Name": "Tekken 5 [Demo]",
+    "Region": "NTSC-U",
+    "eeClampMode": 1
+  },
+  "SLUS_211.61": {
+    "Name": "Fight Night - Round 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.62": {
+    "Name": "Ford Mustang - The Legend Lives",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.63": {
+    "Name": "Brothers in Arms - Road to Hill 30",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.64": {
+    "Name": "Namco Museum - 50th Anniversary",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.65": {
+    "Name": "Arc the Lad - End of Darkness",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_211.66": {
+    "Name": "Full Metal Alchemist 2 - Curse of the Crimson Elixir",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.68": {
+    "Name": "Castlevania - Curse of Dakness",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuClampMode": "0"
+  },
+  "SLUS_211.69": {
+    "Name": "Rollercoaster Tycoon - The Peeps",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.70": {
+    "Name": "Makai Kingdom - Chronicles of the Sacred Tome",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.71": {
+    "Name": "Harvest Moon - A Wonderful Life [Special Edition]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.72": {
+    "Name": "Conflict - Global Terror",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_211.73": {
+    "Name": "Dora the Explorer - To the Purple Planet",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.74": {
+    "Name": "Dance Dance Revolution Extreme 2",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_211.75": {
+    "Name": "Bible Game, The",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.76": {
+    "Name": "World Championship Poker 2 featuring Howard Lederer",
+    "Region": "NTSC-U",
+    "Compat": 1
+  },
+  "SLUS_211.77": {
+    "Name": "In the Groove",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.78": {
+    "Name": "RPG Maker 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.79": {
+    "Name": "Colloseum - Road to Freedom",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.80": {
+    "Name": "Onimusha - Dawn of Dreams [Disc1]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.81": {
+    "Name": "D.I.C.E.",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.82": {
+    "Name": "TOCA Race Driver 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.83": {
+    "Name": "Teen Titans",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.84": {
+    "Name": "Teenage Mutant Ninja Turtles 3 - Mutant Nightmare",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.86": {
+    "Name": "NBA Ballers - Phenom",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.87": {
+    "Name": "Samurai Western",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.88": {
+    "Name": "America's Army - Rise of a Soldier",
+    "Region": "NTSC-U"
+  },
+  "SLUS_211.89": {
+    "Name": "Suffering, The - Ties That Bind",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_211.90": {
+    "Name": "Outlaw Tennis",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.91": {
+    "Name": "Crash Tag Team Racing",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_211.92": {
+    "Name": "Cabela's Outdoor Adventures 2006",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.93": {
+    "Name": "Inuyasha - Feudal Combat",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.94": {
+    "Name": "Phantasy Star Universe",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeRoundMode": "0"
+  },
+  "SLUS_211.95": {
+    "Name": "Breeders' Cup - World Thoroughbred Championships",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.96": {
+    "Name": "Indigo Prophecy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.97": {
+    "Name": "Shrek Superslam",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_211.98": {
+    "Name": "Batman Begins",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_211.99": {
+    "Name": "Medal of Honor - European Assault",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.00": {
+    "Name": "Armored Core - Nine Breaker",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.01": {
+    "Name": "Tales of Legendia",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.02": {
+    "Name": "Romance of the Three Kingdoms X",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.03": {
+    "Name": "Tomb Raider - Legend",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.04": {
+    "Name": "Victorious Boxers 2 - Fighting Spirit",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.05": {
+    "Name": "Aeon Flux",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.06": {
+    "Name": "Shining Force Neo",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.07": {
+    "Name": "Dragon Quest VIII - Journey of the Cursed King",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.08": {
+    "Name": "Tony Hawk's American Wasteland",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.09": {
+    "Name": "Urban Reign",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.12": {
+    "Name": "Spartan - Total Warrior",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.13": {
+    "Name": "Madden NFL '06",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.14": {
+    "Name": "NCAA Football 2006",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.15": {
+    "Name": "Warriors, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.16": {
+    "Name": "Soul Calibur III",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.17": {
+    "Name": "Incredibles, The - Rise of the Underminers",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.18": {
+    "Name": "Tak - The Great Juju Challenge",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.19": {
+    "Name": "Pac-Man World 3",
+    "Region": "NTSC-U",
+    "Compat": 4,
+    "EETimingHack": 1
+  },
+  "SLUS_212.20": {
+    "Name": "World Soccer - Winning Eleven 9 International",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.21": {
+    "Name": "Magna Carta - Tears of Blood",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.22": {
+    "Name": "Top Spin",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.23": {
+    "Name": "Karaoke Revolution Party",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_212.24": {
+    "Name": "Guitar Hero",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.25": {
+    "Name": "Bratz - Rock Angels",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.26": {
+    "Name": "Velocity",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.27": {
+    "Name": "DragonBall Z - Budokai Tenkaichi",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.28": {
+    "Name": "Call of Duty 2 - Big Red One",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.29": {
+    "Name": "Motocross Mania 3",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.30": {
+    "Name": "We Love Katamari",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuClampMode": 3,
+    "mvuFlagSpeedHack": "0"
+  },
+  "SLUS_212.31": {
+    "Name": "Sniper Elite",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_212.32": {
+    "Name": "College Hoops 2K6",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.33": {
+    "Name": "NBA 2K6",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.34": {
+    "Name": "NHL 2K6",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_212.35": {
+    "Name": "MLB 2k6",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.36": {
+    "Name": "Tokyo Xtreme Racer Drift",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.37": {
+    "Name": "And 1 Streetball",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.38": {
+    "Name": "Final Fight - Streetwise",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.39": {
+    "Name": "Beatmania",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.40": {
+    "Name": "Star Wars Battlefront II",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.41": {
+    "Name": "NHL '06",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.42": {
+    "Name": "Burnout Revenge",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.43": {
+    "Name": "Metal Gear Solid 3 - Subsistence",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.44": {
+    "Name": "Fatal Frame 3 - The Tormented",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.45": {
+    "Name": "Suikoden Tactics",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.46": {
+    "Name": "Charlie and the Chocolate Factory",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.47": {
+    "Name": "Jackie Chan Adventures",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.48": {
+    "Name": "Legend of Kay",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_212.49": {
+    "Name": "Yourself Fitness - Lifestyle",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.50": {
+    "Name": "Full Spectrum Warrior - Ten Hammers",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_212.51": {
+    "Name": "FlatOut 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.52": {
+    "Name": "SpongeBob Squarepants - Lights, Camera, PANTS!",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.53": {
+    "Name": "Ty the Tasmanian Tiger 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.54": {
+    "Name": "Zach Bell! Mamodo Battles",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.55": {
+    "Name": "Trapt",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.56": {
+    "Name": "IHRA Drag Racing - Sportsman Edition",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.58": {
+    "Name": "dot Hack - G.U. Vol.1 - Rebirth",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.59": {
+    "Name": "Stacked with Daniel Negreanu",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.60": {
+    "Name": "Ed, Edd, 'n Eddy - The Mis-Edventures",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.61": {
+    "Name": "Shadow the Hedgehog",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.62": {
+    "Name": "Radiata Stories",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLUS_212.63": {
+    "Name": "Romancing SaGa",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.64": {
+    "Name": "Tiger Woods PGA Tour 2006",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_212.65": {
+    "Name": "Sims 2, The",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_212.66": {
+    "Name": "NASCAR '06 - Total Team Control",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.67": {
+    "Name": "Need for Speed - Most Wanted",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.68": {
+    "Name": "24 - The Game",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.69": {
+    "Name": "Bully",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.70": {
+    "Name": "MS Saga - A New Dawn",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.71": {
+    "Name": "Driver - Parallel Lines",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_212.72": {
+    "Name": "Super Monkey Ball Adventure",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.73": {
+    "Name": "Matrix, The - Path of Neo",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.74": {
+    "Name": "Outrun 2006 - Coast 2 Coast",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.75": {
+    "Name": "River King - A Wonderful Journey",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.76": {
+    "Name": "Ford vs. Chevy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.77": {
+    "Name": "Barnyard",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.78": {
+    "Name": "SSX on Tour",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_212.79": {
+    "Name": "NBA Live '06",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.80": {
+    "Name": "FIFA '06",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.81": {
+    "Name": "Marvel Nemesis - Rise of the Imperfects",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_212.82": {
+    "Name": "James Bond 007 - From Russia with Love",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.83": {
+    "Name": "Total Overdose - A Gunslinger's Tale in Mexico",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.84": {
+    "Name": "Nicktoons Unite!",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.85": {
+    "Name": "Ultimate Spider-Man [Limited Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.86": {
+    "Name": "WWE SmackDown! vs. RAW 2006",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.87": {
+    "Name": "Prince of Persia - The Two Thrones",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.88": {
+    "Name": "American Chopper 2",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.89": {
+    "Name": "Sea World - Shamu's Big Adventure",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_212.90": {
+    "Name": "Ford Street Racing",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.91": {
+    "Name": "Suikoden V",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.92": {
+    "Name": "Wild ARMs 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.93": {
+    "Name": "Metal Saga",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "DMABusyHack": "1 "
+  },
+  "SLUS_212.94": {
+    "Name": "Mark Ecko's Getting Up - Contents Under Pressure [Special Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.95": {
+    "Name": "Tony Hawk's American Wasteland [Collector's Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.96": {
+    "Name": "Dance Factory",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_212.97": {
+    "Name": "Devil Kings",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_212.98": {
+    "Name": "NCAA March Madness '06",
+    "Region": "NTSC-U"
+  },
+  "SLUS_212.99": {
+    "Name": "Dynasty Warriors 5 - Xtreme Legends",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.00": {
+    "Name": "Over the Hedge",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_213.01": {
+    "Name": "World Series of Poker",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.03": {
+    "Name": "Rebel Raiders - Operation Nighthawk",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.04": {
+    "Name": "Justice League Heroes",
+    "Region": "NTSC-U",
+    "Compat": 4,
+    "vuClampMode": 2
+  },
+  "SLUS_213.05": {
+    "Name": "Arthur and the Invisibles",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.06": {
+    "Name": "Ghost Rider",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.07": {
+    "Name": "Ice Age 2 - The Meltdown",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_213.09": {
+    "Name": "Let's Ride - Silver Buckle Stables",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.10": {
+    "Name": "Brothers in Arms - Earned in Blood",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_213.11": {
+    "Name": "King Kong, Peter Jackson's - The Official Game of the Movie",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.12": {
+    "Name": "Wallace & Gromit - The Curse of the Were-Rabbit",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.13": {
+    "Name": "Friends - The One with all the Trivia",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.14": {
+    "Name": "Ruff Trigger - Vancore Conspiracy",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.15": {
+    "Name": "50cent - Bulletproof",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.16": {
+    "Name": "Capcom Classics Collection Vol.1",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.17": {
+    "Name": "Street Fighter Alpha Anthology",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.18": {
+    "Name": "Call of Duty 2 - Big Red One [Collector's Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.19": {
+    "Name": "Flow - Urban Dance Uprising",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.20": {
+    "Name": "Rogue Trooper",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_213.21": {
+    "Name": "Squadra Course Alfa Romeo",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.22": {
+    "Name": "Eragon",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.23": {
+    "Name": "Rampage - Total Destruction",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.24": {
+    "Name": "Major League Baseball 2K5 [World Series Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.25": {
+    "Name": "Harry Potter and The Goblet of Fire",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.26": {
+    "Name": "Shadow Hearts - From the New World",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.27": {
+    "Name": "Atelier Iris 2 - The Azoth of Destiny",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.28": {
+    "Name": "Pac-Man World Rally",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SLUS_213.29": {
+    "Name": "Karaoke Revolution Country - CMT Presents",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_213.30": {
+    "Name": "Monster Rancher 5",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.31": {
+    "Name": "Sonic Riders",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.32": {
+    "Name": "Real World Golf",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_213.33": {
+    "Name": "World Poker Tour 2K6",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.34": {
+    "Name": "Grandia III [Disc1of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.35": {
+    "Name": "Hustle, The - Detroit Streets - Kat's Story",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.36": {
+    "Name": "Zathura",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.37": {
+    "Name": "Arena Football - EA Sports",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.38": {
+    "Name": "Armored Core - Last Raven",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.39": {
+    "Name": "Puzzle Collection - Crosswords & More!",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.40": {
+    "Name": "World Championship Cards",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_213.41": {
+    "Name": "Stuart Little 3 - Big Photo Adventure",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_213.42": {
+    "Name": "MLB Slugfest 2006",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.43": {
+    "Name": "Samurai Champloo - Sidetracked",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.44": {
+    "Name": "Steambot Chronicles",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.45": {
+    "Name": "Grandia III [Disc2of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.46": {
+    "Name": "Ace Combat Zero - The Belkan War",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.47": {
+    "Name": "AMF Xtreme Bowling",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.48": {
+    "Name": "Yakuza",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.49": {
+    "Name": "Taito Legends 2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.50": {
+    "Name": "Cabela's Dangerous Hunts 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.51": {
+    "Name": "Need for Speed - Most Wanted [Black Edition]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.52": {
+    "Name": "Dai Senryaku VII Exceed",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.53": {
+    "Name": "Eureka Seven - Vol.1 - The New Wave",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.54": {
+    "Name": "Curious George",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.55": {
+    "Name": "Midnight Club 3 - DUB Edition Remix",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.56": {
+    "Name": "Tom Clancy's Splinter Cell - Double Agent",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.57": {
+    "Name": "Hummer Badlands",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.58": {
+    "Name": "Naruto - Ultimate Ninja",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.59": {
+    "Name": "Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc2of3]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.60": {
+    "Name": "Metal Gear Solid 3 - Subsistence [Limited Edition] [Disc3of3]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.61": {
+    "Name": "Devil May Cry 3 - Dante's Awakening [Special Edition]",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeRoundMode": "0"
+  },
+  "SLUS_213.62": {
+    "Name": "Onimusha - Dawn of Dreams [Disc2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.63": {
+    "Name": "Zatch Bell! Mamodo Fury",
+    "Region": "NTSC-U",
+    "Compat": 1
+  },
+  "SLUS_213.64": {
+    "Name": "One Piece - Pirates Carnival",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.65": {
+    "Name": "King of Fighters 2006, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.66": {
+    "Name": "Ultimate Board Game Collection",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.67": {
+    "Name": "MVP '06 - NCAA Baseball",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.68": {
+    "Name": "Rugby '06",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.69": {
+    "Name": "FIFA Street 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.70": {
+    "Name": "MegaMan X Collection",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.71": {
+    "Name": "Rapala Pro Tournament Fishing",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.72": {
+    "Name": "Legend of Spyro, The - A New Beginning",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.73": {
+    "Name": "Drakengard 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.74": {
+    "Name": "Marvel - Ultimate Alliance",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.75": {
+    "Name": "Torino 2006 - The Official Game of the XX Olympic Winter Games",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SLUS_213.76": {
+    "Name": "Black",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuClampMode": "0"
+  },
+  "SLUS_213.77": {
+    "Name": "Dance Dance Revolution SuperNOVA",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.79": {
+    "Name": "Cabela's African Safari",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.80": {
+    "Name": "Snoopy vs. The Red Baron",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuClampMode": 3
+  },
+  "SLUS_213.81": {
+    "Name": "Bode Miller Alpine Skiing",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SLUS_213.82": {
+    "Name": "Franklin - A Birthday Surprise",
+    "Region": "NTSC-U"
+  },
+  "SLUS_213.83": {
+    "Name": "Fight Night - Round 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.84": {
+    "Name": "Cabela's Alaskan Adventures",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.85": {
+    "Name": "Godfather, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.86": {
+    "Name": "Tales of the Abyss",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.87": {
+    "Name": "Warship Gunner 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.88": {
+    "Name": "Sopranos, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.89": {
+    "Name": "Xenosaga - Episode III - Also Sprach Zarathustra [Disc1of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.90": {
+    "Name": "Urban Chaos - Riot Response",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.91": {
+    "Name": "SpongeBob SquarePants - Creature from the Krusty Krab",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.92": {
+    "Name": "Shrek Smash and Crash",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_213.93": {
+    "Name": "Gallop Racer 2006",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.94": {
+    "Name": "TXR Drift 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.95": {
+    "Name": "Avatar - The Last Airbender",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.96": {
+    "Name": "Star Trek - Encounters",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.97": {
+    "Name": "Disgaea 2 - Cursed Memories",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_213.98": {
+    "Name": "Dynasty Warriors 5 - Empires",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_213.99": {
+    "Name": "Driver - Parallel Lines [Limited Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.00": {
+    "Name": "Monster House",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.01": {
+    "Name": "Equestriad",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.02": {
+    "Name": "Micro Machines v4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.03": {
+    "Name": "Backyard Baseball '07",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.04": {
+    "Name": "Final Fantasy XI - Treasures of Aht Urhgan",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.05": {
+    "Name": "Xiaolin Showdown",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.06": {
+    "Name": "Godfather, The - Collector's Edition",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.07": {
+    "Name": "NFL Head Coach",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.08": {
+    "Name": "FIFA World Cup '06",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.09": {
+    "Name": "LEGO Star Wars II - The Original Trilogy",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.10": {
+    "Name": "Mortal Kombat - Armageddon",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.11": {
+    "Name": "M2 Rock",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.12": {
+    "Name": "World Championship Poker featuring Howard Lederer - All-In",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.13": {
+    "Name": "Thrillville",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.14": {
+    "Name": "Delta Force - Team Sabre",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_214.15": {
+    "Name": "Ant Bully, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.16": {
+    "Name": "D1 Grand Prix",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.17": {
+    "Name": "Xenosaga - Episode III - Also Sprach Zarathustra [Disc2of2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.18": {
+    "Name": "Sprint Cars - Road to Knoxville",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.19": {
+    "Name": "Dirge of Cerberus - Final Fantasy VII",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.20": {
+    "Name": "Disney's Chicken Little - Ace in Action",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.21": {
+    "Name": "Spy Hunter - Nowhere to Run",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.22": {
+    "Name": "Tom Clancy's Ghost Recon - Advenced Warfighter",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.23": {
+    "Name": "Grand Theft Auto - Liberty City Stories",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.24": {
+    "Name": "NBA 2K7",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.25": {
+    "Name": "NHL 2K7",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_214.26": {
+    "Name": "Call of Duty 3",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SLUS_214.27": {
+    "Name": "WWE SmackDown! vs. RAW 2007",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.28": {
+    "Name": "Bionicle Heroes",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_214.30": {
+    "Name": "IGPX - Immortal Grand Prix",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.31": {
+    "Name": "Shin Megami Tensei - Devil Summoner - Raidou Kuzunoha vs. The Soulless Army",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.32": {
+    "Name": "NRA Gun Club",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.33": {
+    "Name": "FIFA Soccer '07",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.34": {
+    "Name": "Superman Returns - The Video Game",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.35": {
+    "Name": "One Piece - Grand Adventure",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.36": {
+    "Name": "Just Cause",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.37": {
+    "Name": "Disney's Kim Possible - What's the Switch",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.38": {
+    "Name": "Cartoon Network Racing",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_214.39": {
+    "Name": "Destroy All Humans! 2",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.40": {
+    "Name": "LarryBoy and the Bad Apple",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.41": {
+    "Name": "DragonBall Z - Budokai Tenkaichi 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.42": {
+    "Name": "Super DragonBall Z",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.43": {
+    "Name": "DaVinci Code, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.44": {
+    "Name": "Tony Hawk's Project 8",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.45": {
+    "Name": "Ar Tonelico",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.46": {
+    "Name": "Family Feud",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.47": {
+    "Name": "Guitar Hero II",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.48": {
+    "Name": "Rule of Rose",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.49": {
+    "Name": "Fast and the Furious, The - Tokyo Drift",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.50": {
+    "Name": "Super Trucks Racing 2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.51": {
+    "Name": "Grim Adventures of Billy & Mandy, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.52": {
+    "Name": "Valkyrie Profile 2 - Silmeria",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLUS_214.53": {
+    "Name": "Disney's Meet the Robinsons",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.54": {
+    "Name": "Shrek the Third",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.55": {
+    "Name": "Happy Feet",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.56": {
+    "Name": "Tony Hawk's Downhill Jam",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_214.57": {
+    "Name": "World Championship Paintball",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.58": {
+    "Name": "NHL '07",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.59": {
+    "Name": "NCAA Football '07",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.60": {
+    "Name": "NBA Live '07",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.61": {
+    "Name": "NASCAR '07",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.62": {
+    "Name": "Samurai Warriors 2",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.63": {
+    "Name": "Tom Clancy's Ghost Recon 2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.64": {
+    "Name": "Winning Eleven - Pro Evolution Soccer 2007",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.65": {
+    "Name": "Raiden III",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.66": {
+    "Name": "Plan, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.67": {
+    "Name": "Open Season",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.68": {
+    "Name": "Peanuts All-Star",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.69": {
+    "Name": "Nicktoons - Battle for Volcano Island",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.70": {
+    "Name": "Bratz - Forever Diamonds",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.71": {
+    "Name": "Tokobot Plus - Mysteries of the Karakuri",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.72": {
+    "Name": "World Pool Challenge '06",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.73": {
+    "Name": "Capcom Classics Collection Vol. 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.74": {
+    "Name": "History Channel - Civil War - A Nation Divided",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.75": {
+    "Name": "Final Fantasy XII [Collector's Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.76": {
+    "Name": "Madden NFL '07",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.77": {
+    "Name": "Madden NFL '07 [Hall of Fame Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.78": {
+    "Name": "Pirates - Legend of the Black Buccaneer",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.79": {
+    "Name": "Reservoir Dogs",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_214.80": {
+    "Name": "Dot Hack GU Volume 1 - Rebirth - Terminal Disc",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.81": {
+    "Name": "NCAA March Madness '07",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.82": {
+    "Name": "NFL Street 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.83": {
+    "Name": "Tiger Woods PGA Tour '07",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_214.84": {
+    "Name": "Flushed Away",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.85": {
+    "Name": "Backyard Basketball '07",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.86": {
+    "Name": "Eagle Eye Golf",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.87": {
+    "Name": "Art of Fighting Anthology",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_214.88": {
+    "Name": "dot Hack - G.U. Vol.2 - Reminisce",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.89": {
+    "Name": "dot Hack - G.U. Vol.3 - Redemption",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.90": {
+    "Name": "Test Drive Unlimited",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VIFFIFOHack": 1
+  },
+  "SLUS_214.91": {
+    "Name": "World Series of Poker - Tournament of Champions",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_214.92": {
+    "Name": "Scarface [Collector's Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.93": {
+    "Name": "Need for Speed - Carbon",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_214.94": {
+    "Name": "Need for Speed - Carbon [Collector's Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.95": {
+    "Name": "Sudoku, Carol Vorderman's",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_214.96": {
+    "Name": "ProStroke Golf - World Tour 2007",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_214.97": {
+    "Name": "Strawberry Shortcake - Adventures in the Land of Dreams",
+    "Region": "NTSC-U"
+  },
+  "SLUS_214.98": {
+    "Name": "Naruto - Uzumaki Chronicles",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "OPHFLagHack": 1
+  },
+  "SLUS_214.99": {
+    "Name": "Evolution GT",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.00": {
+    "Name": "Superbikes - Riding Challenge",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.01": {
+    "Name": "Raw Danger",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.03": {
+    "Name": "God Hand",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.36": {
+    "Name": "Sims 2, The - Pets",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.37": {
+    "Name": "NeoGeo Fatal Fury Collection",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.38": {
+    "Name": "Eureka Seven - Vol.2 - The New Vision",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.39": {
+    "Name": "Greg Hastings Tournament Paintball Max'd",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.40": {
+    "Name": "Karaoke Revolution Presents - American Idol",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_215.41": {
+    "Name": "Ratatouille",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.42": {
+    "Name": "Sega Genesis Collection",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.43": {
+    "Name": "Mortal Kombat - Armageddon [Kollector's Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.44": {
+    "Name": "Fantastic 4 - Rise of Silver Surfer",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_215.45": {
+    "Name": "Pirates of the Caribbean - At World's End",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.47": {
+    "Name": "NHRA - Countdown to the Championship 2007",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.48": {
+    "Name": "Mercury Meltdown - Remix",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.49": {
+    "Name": "Sopranos, The [Collector's Edition]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.50": {
+    "Name": "Metal Slug Anthology",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.51": {
+    "Name": "Dog Island, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.52": {
+    "Name": "Spider-Man 3",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_215.53": {
+    "Name": "Lumines Plus",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.54": {
+    "Name": "King of Fighters Collection, The - The Orochi Saga",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.55": {
+    "Name": "Tomb Raider - Anniversary",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.56": {
+    "Name": "Konami Kids Playground - Dinosaur Shapes & Colors",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.57": {
+    "Name": "Konami Kids Playground - Frogger Hop, Skip & Jumpin' Fun",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.58": {
+    "Name": "Konami Kids Playground - Toy Pals Fun with Numbers",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.59": {
+    "Name": "Konami Kids Playground - Alphabet Circus",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.60": {
+    "Name": "Family Guy - The Video Game",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.61": {
+    "Name": "Major League Baseball 2K7",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.63": {
+    "Name": "Horsez",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_215.64": {
+    "Name": "Atelier Iris 3 - Grand Phantasm",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.65": {
+    "Name": "Pirates of the Caribbean - At World's End",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.66": {
+    "Name": "Brunswick Pro Bowling",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.67": {
+    "Name": "Shining Force EXA",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.68": {
+    "Name": "Arena Football - Road to Glory",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.69": {
+    "Name": "Shin Megami Tensei - Persona 3",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VuClipFlagHack": 1
+  },
+  "SLUS_215.70": {
+    "Name": "Heatseeker",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_215.71": {
+    "Name": "Growlanser - Heritage of War",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.72": {
+    "Name": "Surf's Up",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.73": {
+    "Name": "Harley-Davidson - Race to the Rally",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.74": {
+    "Name": "Dawn of Mana",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.75": {
+    "Name": "Naruto - Ultimate Ninja 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.76": {
+    "Name": "Rayman - Raving Rabbids",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_215.77": {
+    "Name": "Odin Sphere",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.78": {
+    "Name": "Biker Mice from Mars",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_215.79": {
+    "Name": "Barbie in The 12 Dancing Princesses",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.80": {
+    "Name": "Pimp my Ride",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.81": {
+    "Name": "UEFA Champions League 2006-2007",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_215.82": {
+    "Name": "MVP '07 - NCAA Baseball",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.83": {
+    "Name": "Crash of the Titans",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.84": {
+    "Name": "Romance of the Three Kingdoms XI",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.85": {
+    "Name": "Samurai Warriors 2 - Empires",
+    "Region": "NTSC-U"
+  },
+  "SLUS_215.86": {
+    "Name": "Guitar Hero Encore - Rocks the '80s",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.87": {
+    "Name": "Made Man",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.88": {
+    "Name": "Avatar - The Last Airbender - The Burning Earth",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.89": {
+    "Name": "Pinball Hall of Fame - The Williams Collection",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.90": {
+    "Name": "Grand Theft Auto - Vice City Stories",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.91": {
+    "Name": "Ski-Doo Snow X Racing",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.92": {
+    "Name": "Adventures of Darwin, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.93": {
+    "Name": "Juiced 2 - Hot Import Nights",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_215.94": {
+    "Name": "Naruto - Uzumaki Chronicles 2",
+    "Region": "NTSC-U",
+    "OPHFLagHack": 1
+  },
+  "SLUS_215.95": {
+    "Name": "T.M.N.T. - Teenage Mutant Ninja Turtles",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_215.96": {
+    "Name": "Burnout - Dominator",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.97": {
+    "Name": "Medal of Honor - Vanguard",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.98": {
+    "Name": "Digimon World - Data Squad",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_215.99": {
+    "Name": "High School Musical - Sing It!",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.00": {
+    "Name": "Spider-Man - Friend or Foe",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.01": {
+    "Name": "Sprint Cars 2 - Showdown at Eldora",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.02": {
+    "Name": "Transformers - The Game",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_216.03": {
+    "Name": "Soul Nomad & The World Eaters",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.04": {
+    "Name": "GrimGrimoire",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.05": {
+    "Name": "Nicktoons - Attack of the Toybots",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.06": {
+    "Name": "Metropolismania 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.07": {
+    "Name": "Legend of Spyro, The - The Eternal Night",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.08": {
+    "Name": "Dance Dance Revolution - SuperNOVA 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.09": {
+    "Name": "Dance Dance Revolution - Disney Channel",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.11": {
+    "Name": "Thrillville - Off the Rails",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_216.12": {
+    "Name": "Legend of the Dragon",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.13": {
+    "Name": "Manhunt 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.14": {
+    "Name": "Star Wars - The Force Unleashed",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.15": {
+    "Name": "Wild Arms 5",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.16": {
+    "Name": "Tony Hawk's Proving Ground",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_216.18": {
+    "Name": "Plan, The",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.19": {
+    "Name": "Harry Potter and The Order of the Phoenix",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.20": {
+    "Name": "NCAA Football '08",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.21": {
+    "Name": "Shin Megami Tensei - Persona 3 FES",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VuClipFlagHack": 1
+  },
+  "SLUS_216.22": {
+    "Name": "Bee Movie Game",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_216.23": {
+    "Name": "BIGS, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.24": {
+    "Name": "Cabela's Trophy Bucks",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.25": {
+    "Name": "Cabela's Big Game Hunter III",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_216.26": {
+    "Name": "Stuntman - Ignition",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VIFFIFOHack": 1
+  },
+  "SLUS_216.27": {
+    "Name": "Jackass - The Game",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.28": {
+    "Name": "Hot Wheels - Beat That",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.29": {
+    "Name": "Samurai Showdown Anthology",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.30": {
+    "Name": "Star Trek - Conquest",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.31": {
+    "Name": "Phantasy Star Universe - Ambition of the Illuminus",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeRoundMode": "0"
+  },
+  "SLUS_216.32": {
+    "Name": "NHL 2K8",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_216.33": {
+    "Name": "Aqua Teen Hunger Force - Zombie Ninja Pro-Am",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.34": {
+    "Name": "Crazy Frog Racer",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.35": {
+    "Name": "Monster Jam",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.36": {
+    "Name": "Looney Tunes - Acme Arsenal",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_216.37": {
+    "Name": "Disney-Pixar's Cars - Mater-National",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.38": {
+    "Name": "Madden NFL '08",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_216.39": {
+    "Name": "NASCAR '08",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_216.40": {
+    "Name": "Rugby '08",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_216.41": {
+    "Name": "Innocent Life - Harvest Moon - Pure",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.42": {
+    "Name": "Sonic Riders - Zero Gravity",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.43": {
+    "Name": "Bratz - The Movie",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.44": {
+    "Name": "SpongeBob's Atlantis SquarePantis",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_216.45": {
+    "Name": "WWE SmackDown! vs. Raw 2008",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.46": {
+    "Name": "Tiger Woods PGA Tour '08",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_216.47": {
+    "Name": "NHL '08",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_216.48": {
+    "Name": "FIFA Soccer '08",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.49": {
+    "Name": "NBA Live '08",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.50": {
+    "Name": "Mercenaries 2 - World in Flames",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_216.51": {
+    "Name": "Noddy and the Magic Book",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.52": {
+    "Name": "Guilty Gear XX - Accent Core",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.53": {
+    "Name": "Kiki Kai Kai",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.54": {
+    "Name": "Kane & Lynch - Dead Men Sneak Preview",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.55": {
+    "Name": "CSI 3 - Dimensions of Murder",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.56": {
+    "Name": "World Superbikes '07",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.58": {
+    "Name": "Need for Speed - ProStreet",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.60": {
+    "Name": "Disney Princess - Enchanted Journey",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_216.61": {
+    "Name": "Ben 10 - Protector of Earth",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.62": {
+    "Name": "Warriors Orochi",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.63": {
+    "Name": "Cocoto - Fishing Master",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.64": {
+    "Name": "Sims 2, The - Castaway",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.65": {
+    "Name": "Simpsons Game, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.66": {
+    "Name": "Mountain Bike Adrenaline",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.68": {
+    "Name": "George of the Jungle",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.69": {
+    "Name": "NBA 2K8",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.70": {
+    "Name": "Backyard Football 2008",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.71": {
+    "Name": "MLB Power Pros",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.72": {
+    "Name": "Guitar Hero III - Legends of Rock",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.73": {
+    "Name": "College Hoops 2K8",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.74": {
+    "Name": "Petz - Dogz 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.75": {
+    "Name": "Petz - Catz 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.76": {
+    "Name": "Dancing with the Stars",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.77": {
+    "Name": "Golden Compass, The",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_216.78": {
+    "Name": "DragonBall Z - Budokai Tenkaichi 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.79": {
+    "Name": "Power Rangers - Super Legends",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.80": {
+    "Name": "Harvey Birdman - Attorney at Law",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.81": {
+    "Name": "Boogie",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_216.82": {
+    "Name": "Rock Band",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_216.83": {
+    "Name": "Yu-Gi-Oh! The Beginning of Destiny",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.84": {
+    "Name": "Barbie as The Island Princess",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_216.85": {
+    "Name": "Pro Evolution Soccer 2008",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.86": {
+    "Name": "World Series of Poker 2008 - Battle for the Bracelets",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.87": {
+    "Name": "King of Fighters XI, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.88": {
+    "Name": "MotoGP '07",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.89": {
+    "Name": "Petz - Horsez 2",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_216.90": {
+    "Name": "Alone in the Dark",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_216.91": {
+    "Name": "Swashbucklers - Blue vs. Grey",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.92": {
+    "Name": "Puzzle Quest - Challenge of the Warlords",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_216.93": {
+    "Name": "7 Wonders of the Ancient World",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_216.94": {
+    "Name": "Final Fantasy XI - Wings of the Goddess",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.97": {
+    "Name": "Iridium Runners",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_216.98": {
+    "Name": "NCAA March Madness '08",
+    "Region": "NTSC-U"
+  },
+  "SLUS_216.99": {
+    "Name": "UEFA Euro 2008",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.01": {
+    "Name": "MX vs. ATV - Untamed",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.02": {
+    "Name": "Fire Pro Wrestling - Returns",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.03": {
+    "Name": "Luxor - Pharaoh's Challenge",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.04": {
+    "Name": "Final Fantasy XI - Vana'diel Collection 2008",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_217.06": {
+    "Name": "Alvin and The Chipmunks",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.07": {
+    "Name": "Godzilla Unleashed",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.08": {
+    "Name": "NeoGeo Battle Coliseum",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.09": {
+    "Name": "Obscure - The Aftermath",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_217.10": {
+    "Name": "PopCap Hits Volume 1",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.11": {
+    "Name": "Biathlon 2008",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.12": {
+    "Name": "History Channel - Battle for the Pacific",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.14": {
+    "Name": "Baroque",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.15": {
+    "Name": "Cabela's Moster Bass",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.16": {
+    "Name": "Spiderwick Chronicles, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.17": {
+    "Name": "Dora the Explorer - Dora Saves the Mermaids",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.18": {
+    "Name": "Go Diego Go - Safari Rescue",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.19": {
+    "Name": "Karaoke Revolution Presents - American Idol Encore",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.20": {
+    "Name": "Arcana Heart",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.21": {
+    "Name": "Nobunaga's Ambition - Rise to Power",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.22": {
+    "Name": "Chaos Wars",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.23": {
+    "Name": "Fatal Fury Battle Archives Vol.2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.24": {
+    "Name": "SNK Arcade Classics Volume 1",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.25": {
+    "Name": "World Heroes Anthology",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.26": {
+    "Name": "Samurai Warriors 2 - Xtreme Legends",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.27": {
+    "Name": "Naruto - Ultimate Ninja 3",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.28": {
+    "Name": "Crash - Mind Over Mutant",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.29": {
+    "Name": "Major League Baseball 2K8",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.30": {
+    "Name": "Jumper",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.31": {
+    "Name": "Silent Hill - Origins",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.32": {
+    "Name": "El Tigre - The Adventures of Manny Rivera",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.33": {
+    "Name": "Sega Superstars Tennis",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.34": {
+    "Name": "Falling Stars",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.35": {
+    "Name": "Mana Khemia - Alchemists of Al-Revis",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "DMABusyHack": 1
+  },
+  "SLUS_217.36": {
+    "Name": "Wall-E",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.37": {
+    "Name": "Riding Star",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.38": {
+    "Name": "Nitro Bike",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.39": {
+    "Name": "Iron Man",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.40": {
+    "Name": "Guitar Hero - Aerosmith",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.41": {
+    "Name": "Sea Monsters - A Prehistoric Adventure",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.42": {
+    "Name": "Women's Volleyball Championship",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.43": {
+    "Name": "Code Lyoko - Quest for Infinity",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.44": {
+    "Name": "NASCAR '09",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_217.46": {
+    "Name": "Call Of Duty - World At War - Final Fronts",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.48": {
+    "Name": "MLB Power Pros 2008",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.50": {
+    "Name": "Hannah Montana - Spotlight World Tour",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.51": {
+    "Name": "Backyard Football 2009",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.52": {
+    "Name": "NCAA Football '09",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.53": {
+    "Name": "Monopoly",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_217.54": {
+    "Name": "CID the Dummy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.55": {
+    "Name": "Are You Smarter Than A 5th Grader - Make The Grade",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.56": {
+    "Name": "Chronicles of Narnia, The - Prince Caspian",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.57": {
+    "Name": "Kung Fu Panda",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.58": {
+    "Name": "Rock Band - Track Pack Vol.1",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_217.59": {
+    "Name": "LEGO Indiana Jones - The Original Adventures",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.60": {
+    "Name": "Jeep Thrills",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.61": {
+    "Name": "B-Boy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.63": {
+    "Name": "NHL 2K9",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_217.64": {
+    "Name": "Cake Mania - Baker's Challenge",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.65": {
+    "Name": "Incredible Hulk, The",
+    "Region": "NTSC-U",
+    "Compat": 1
+  },
+  "SLUS_217.66": {
+    "Name": "Pipemania",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.67": {
+    "Name": "Dance Dance Revolution X",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.68": {
+    "Name": "PopCap Hits Vol.2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.69": {
+    "Name": "Yakuza 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.70": {
+    "Name": "Madden NFL '09",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.71": {
+    "Name": "NHL 2009",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.72": {
+    "Name": "Tiger Woods PGA Tour '09",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.73": {
+    "Name": "PDC World Championship Darts 2008",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.74": {
+    "Name": "Dynasty Warriors 6",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.75": {
+    "Name": "Mummy, The - Tomb of the Dragon Emperor",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.76": {
+    "Name": "Fifa 2009",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.78": {
+    "Name": "Dokapon Kingdom",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.79": {
+    "Name": "Eternal Poison",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeClampMode": "0"
+  },
+  "SLUS_217.80": {
+    "Name": "Ferrari Challenge",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.81": {
+    "Name": "Guitar Hero - World Tour",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.82": {
+    "Name": "Shin Megami Tensei - Persona 4",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VuClipFlagHack": 1
+  },
+  "SLUS_217.82B": {
+    "Name": "Shin Megami Tensei - Persona 4",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "VuClipFlagHack": 1
+  },
+  "SLUS_217.83": {
+    "Name": "Space Chimps",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.85": {
+    "Name": "LEGO Batman",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.87": {
+    "Name": "TNA iMPACT!",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLUS_217.88": {
+    "Name": "Ar Tonelico 2 - Melody Of Metafalica",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeRoundMode": "0 "
+  },
+  "SLUS_217.89": {
+    "Name": "Cabela's Legendary Adventures",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.90": {
+    "Name": "Shrek's Carnival Craze",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.93": {
+    "Name": "DT Carnage",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_217.94": {
+    "Name": "Go, Diego, Go!: Great Dinosaur Rescue",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.95": {
+    "Name": "Totally Spies! Totally Party",
+    "Region": "NTSC-U"
+  },
+  "SLUS_217.97": {
+    "Name": "Tak - Guardians Of Gross",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_217.98": {
+    "Name": "Shepherd's Crossing",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_217.99": {
+    "Name": "Kingdom Hearts Re: Chain of Memories",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.00": {
+    "Name": "Rock Band 2",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_218.01": {
+    "Name": "Need For Speed - Undercover",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.02": {
+    "Name": "Naked Brothers Band - The Video Game",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.04": {
+    "Name": "Avatar - The Last Airbender - Into The Inferno",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.05": {
+    "Name": "Hasbro Family Game Night",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.06": {
+    "Name": "Barbie Horse Adventures - Riding Camp",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.07": {
+    "Name": "Monster Jam - Urban Assault",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.08": {
+    "Name": "Harry Potter and the Half-Blood Prince",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.09": {
+    "Name": "Backyard Football 2009",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.10": {
+    "Name": "WWE SmackDown vs. Raw 2009",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.11": {
+    "Name": "MotoGP 08",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.12": {
+    "Name": "Speed Racer",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_218.13": {
+    "Name": "James Bond 007 - Quantum Of Solace",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.14": {
+    "Name": "Disney - Think Fast",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_218.15": {
+    "Name": "Ben 10: Alien Force",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.16": {
+    "Name": "King Of Fighters 98 - Ultimate Match",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.17": {
+    "Name": "SBK Superbike World Chamipionship",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.18": {
+    "Name": "Spongebob Squarepants Featuring Nicktoons - Globs Of Doom",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.19": {
+    "Name": "High School Musical 3",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.20": {
+    "Name": "Legend Of Spyro - Dawn Of The Dragon",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.21": {
+    "Name": "Pro Evolution Soccer 2009",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.22": {
+    "Name": "Spiderman - Web Of Shadows",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SLUS_218.25": {
+    "Name": "Pro Bull - Riding Out Of The Chute",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.26": {
+    "Name": "Disney - Sing It",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_218.27": {
+    "Name": "PopStar Guitar",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.30": {
+    "Name": "Rock Band Track Pack - Volume 2",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_218.31": {
+    "Name": "Army Men - Soldiers Of Misfortune",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.34": {
+    "Name": "Goosebumps Horrorland - Happy Halloween",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_218.35": {
+    "Name": "History Channel - Civil War Secret Mission",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.36": {
+    "Name": "Secret Service - Ultimate Sacrifice",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.38": {
+    "Name": "Monster Lab",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.39": {
+    "Name": "Ski and Shoot",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.40": {
+    "Name": "Madagascar - Escape 2 Africa",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_218.41": {
+    "Name": "Cabelas - Dangerous Hunts 2009",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.42": {
+    "Name": "Dragonball Z Infinite World",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.43": {
+    "Name": "Guitar Hero - Metallica",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.44": {
+    "Name": "Bolt",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.45": {
+    "Name": "Shin Megami Tensei: Devil Summoner 2: Raidou Kuzunoha vs. King Abaddon",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.46": {
+    "Name": "Sonic Unleashed",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.47": {
+    "Name": "Guilty Gear XX - Accent Core Plus",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.48": {
+    "Name": "Rock Band Track Pack - AC/DC Live",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_218.49": {
+    "Name": "Winter Sports 2: The Next Challenge",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.50": {
+    "Name": "Baja 1000",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.51": {
+    "Name": "NCAA Basketball '09",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.52": {
+    "Name": "Tale Of Despereaux, The",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.53": {
+    "Name": "Shaun White Snowboarding",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_218.54": {
+    "Name": "Coraline",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_218.55": {
+    "Name": "NPPL Championship Paintball 2009",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.57": {
+    "Name": "Short Track Racing: Trading Paint",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.58": {
+    "Name": "Tomb Raider Underworld",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_218.60": {
+    "Name": "The Bigs 2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.61": {
+    "Name": "Disney Sing It! High School Musical 3: Senior Year",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.62": {
+    "Name": "Naruto Shippuden - Ultimate Ninja 4",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.63": {
+    "Name": "Suzuki TT Superbikes: Real Road Racing Championship",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.64": {
+    "Name": "Disney Pixar - Up",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.65": {
+    "Name": "Guitar Hero 5",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.66": {
+    "Name": "Guitar Hero - Smash Hits",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_218.67": {
+    "Name": "Guitar Hero: Van Halen",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.68": {
+    "Name": "Nobunagas Ambition - Iron Triangle",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.69": {
+    "Name": "Trivial Pursuit",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.70": {
+    "Name": "Monsters VS Aliens",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_218.71": {
+    "Name": "Major League Baseball 2K9",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.72": {
+    "Name": "Pimp my Ride - Street Racing",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.73": {
+    "Name": "Dynasty Warriors - Gundam 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.74": {
+    "Name": "Jelly Belly: Ballistic Beans",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.75": {
+    "Name": "M&Ms Adventure",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.76": {
+    "Name": "Rock Band Track Pack: Classic Rock",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_218.77": {
+    "Name": "Tiger Woods PGA Tour 10",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.78": {
+    "Name": "Ice Age 3 - Dawn of the Dinosaurs",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.79": {
+    "Name": "Marvel - Ultimate Alliance 2",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.80": {
+    "Name": "X-Men Origins - Wolverine",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "FpuCompareHack": 1
+  },
+  "SLUS_218.81": {
+    "Name": "Transformers: Revenge of the Fallen",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_218.82": {
+    "Name": "Ghostbusters",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.83": {
+    "Name": "Cars Race-O-Rama",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.84": {
+    "Name": "Backyard Baseball '10",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.85": {
+    "Name": "Indiana Jones and the Staff of Kings",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.86": {
+    "Name": "G.I. Joe: The Rise of Cobra",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.88": {
+    "Name": "Rock Band Country Track Pack",
+    "Region": "NTSC-U",
+    "Compat": 3
+  },
+  "SLUS_218.89": {
+    "Name": "Rock Band Metal Track Pack",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.90": {
+    "Name": "Mana Khemia 2 : Fall Of Alchemy",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.91": {
+    "Name": "G-Force",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.92": {
+    "Name": "NCAA Football 10",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.93": {
+    "Name": "Madden NFL 10",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.95": {
+    "Name": "Astro Boy: The Video Game",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.96": {
+    "Name": "The Secret Saturdays: Beasts of the 5th Sun",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_218.98": {
+    "Name": "Band Hero",
+    "Region": "NTSC-U"
+  },
+  "SLUS_218.99": {
+    "Name": "Silent Hill - Shattered Memories",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_219.00": {
+    "Name": "Scooby-Doo! First Frights",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.01": {
+    "Name": "WWE SmackDown vs. Raw 2010",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_219.02": {
+    "Name": "Bakugan Battle Brawlers",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.04": {
+    "Name": "Teenage Mutant Ninja Turtles: Smash-Up",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.05": {
+    "Name": "FIFA Soccer 10",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.06": {
+    "Name": "Cabela's Outdoor - Adventures 2010",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.07": {
+    "Name": "Jurassic - The Hunted",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.08": {
+    "Name": "NBA 2K10",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.09": {
+    "Name": "DJ Hero",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.10": {
+    "Name": "Marvel Super Hero Squad",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.13": {
+    "Name": "Star Wars The Clone Wars: Republic Heroes",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.14": {
+    "Name": "NHL 2K10",
+    "Region": "NTSC-U",
+    "Compat": 2
+  },
+  "SLUS_219.15": {
+    "Name": "The Lord of the Rings: Aragorn's Quest",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_219.17": {
+    "Name": "Dance Dance Revolution X2 (Bundle)",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.18": {
+    "Name": "Pro Evolution Soccer 2010",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_219.19": {
+    "Name": "Backyard Football 2010",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.21": {
+    "Name": "Ben 10: Alien Force - Vilgax Attacks",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_219.23": {
+    "Name": "Dora the Explorer: Dora Saves the Crystal Kingdom",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.26": {
+    "Name": "Ni Hao, Kai-Lan: Super Game Day",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.27": {
+    "Name": "Sakura Wars: So Long, My Love [English - Disc 1]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_219.28": {
+    "Name": "Scooby-Doo! and the Spooky Swamp",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.29": {
+    "Name": "Major League Baseball 2K10",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.30": {
+    "Name": "Sakura Wars: So Long, My Love [Japanese - Disc 2]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_219.31": {
+    "Name": "Toy Story 3",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.32": {
+    "Name": "NCAA Football 11",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.33": {
+    "Name": "Despicable Me",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.34": {
+    "Name": "Rapala Pro Bass Fishing 2010",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.35": {
+    "Name": "Cabela's North American Adventures",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.36": {
+    "Name": "NBA 2K11",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_219.37": {
+    "Name": "Madden NFL 11",
+    "Region": "NTSC-U",
+    "Compat": 5,
+    "vuClampMode": 3
+  },
+  "SLUS_219.38": {
+    "Name": "Ben 10 Ultimate Alien: Cosmic Destruction",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.39": {
+    "Name": "WWE SmackDown vs. Raw 2011",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_219.40": {
+    "Name": "WWE All-Stars",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.41": {
+    "Name": "FIFA Soccer 11",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_219.42": {
+    "Name": "Pro Evolution Soccer 2011",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_219.44": {
+    "Name": "Dora's Big Birthday Adventure",
+    "Region": "NTSC-U"
+  },
+  "SLUS_219.46": {
+    "Name": "Madden NFL 12",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_270.29": {
+    "Name": "Disney Sing It [Bundle]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_270.30": {
+    "Name": "High School Musical 3: Senior Year DANCE! [w/Mat]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_270.34": {
+    "Name": "Disney Sing It! High School Musical 3: Senior Year",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.02": {
+    "Name": "Red Faction [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.04": {
+    "Name": "Klonoa 2 - Lunatea's Veil [Trade Demo]",
+    "Region": "NTSC-U",
+    "eeClampMode": 3
+  },
+  "SLUS_280.06": {
+    "Name": "Burnout [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.07": {
+    "Name": "All-Star Baseball 2003 [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.08": {
+    "Name": "Sky Gunner [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.09": {
+    "Name": "UFC - Throwdown [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.10": {
+    "Name": "Star Wars - Jedi Starfighter [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.12": {
+    "Name": "Tekken 4 [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.13": {
+    "Name": "Dual Hearts [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.14": {
+    "Name": "Matt Hoffman's Pro BMX 2 [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.15": {
+    "Name": "Gun Grave [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.16": {
+    "Name": "Shinobi [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.19": {
+    "Name": "Haven - Call of the King [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.20": {
+    "Name": "Everquest Online Adventures [Beta Vol.1.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.21": {
+    "Name": "Everquest Online Adventures [Beta Vol.2.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.23": {
+    "Name": "dot Hack - Part 1 - Infection [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.25": {
+    "Name": "Disaster Report [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.26": {
+    "Name": "Everquest Online Adventures [Beta Vol.3.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.27": {
+    "Name": "Black & Bruised [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.29": {
+    "Name": "High Heat - Major League Baseball 2004 [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.31": {
+    "Name": "Auto Modelista - Public Beta Volume 2.0",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.32": {
+    "Name": "dot Hack - Part 2 - Mutation [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.37": {
+    "Name": "Kya - Dark Lineage [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.39": {
+    "Name": "Rogue Ops [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.40": {
+    "Name": "Transformers [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.43": {
+    "Name": "Test Drive - Eve of Destruction [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.44": {
+    "Name": "ChoroQ [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.45": {
+    "Name": "Shin Megami Tensei - Nocturne [Trade Demo]",
+    "Region": "NTSC-U",
+    "eeRoundMode": "0 "
+  },
+  "SLUS_280.46": {
+    "Name": "Guilty Gear Isuka [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.49": {
+    "Name": "Shin Megami Tensei - Digital Devil Saga [Trade Demo]",
+    "Region": "NTSC-U",
+    "EETimingHack": 1
+  },
+  "SLUS_280.50": {
+    "Name": "Stella Deus - The Gate of Eternity [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.51": {
+    "Name": "Samurai Western [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.53": {
+    "Name": "Magna Carta [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.54": {
+    "Name": "Combat Elite - WWII Paratroopers [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.56": {
+    "Name": "State of Emergency 2 [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.61": {
+    "Name": "Steambot Chronicles [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.62": {
+    "Name": "Shin Megami Tensei - Digital Devil Saga 2 [Trade Demo]",
+    "Region": "NTSC-U",
+    "EETimingHack": 1
+  },
+  "SLUS_280.63": {
+    "Name": "Rule of Rose [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_280.64": {
+    "Name": "Shin Megami Tensei - Devil Summoner [Trade Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.01": {
+    "Name": "ESPN Winter Games Snowboarding [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.03": {
+    "Name": "Metal Gear Solid 2 - Sons of Liberty [Demo]",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SLUS_290.04": {
+    "Name": "Unison & Dead or Alive 2 Hardcore [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.05": {
+    "Name": "Red Faction [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.06": {
+    "Name": "MX 2002 - featuring Ricky Carmichael [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.08": {
+    "Name": "ESPN X Games Skateboarding [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.09": {
+    "Name": "Devil May Cry [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.10": {
+    "Name": "Crash Bandicoot - The Wrath of Cortex [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.11": {
+    "Name": "WWF SmackDown! - Just Bring It [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.12": {
+    "Name": "Top Gun - Combat Zones [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.13": {
+    "Name": "Victorious Boxers - Ippo's Road to Glory [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.15": {
+    "Name": "Dark Summit [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.16": {
+    "Name": "ESPN International Winter Sports [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.17": {
+    "Name": "Airblade [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.19": {
+    "Name": "High Heat - Major League Baseball 2003 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.20": {
+    "Name": "Sky Gunner [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.21": {
+    "Name": "Aggressive Inline [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.22": {
+    "Name": "UFC - Throwdown [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.25": {
+    "Name": "R.A.D. - Robot Alchemic Drive [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.26": {
+    "Name": "MX Superfly [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.27": {
+    "Name": "Red Faction II [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.29": {
+    "Name": "Summoner 2 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.30": {
+    "Name": "Fire Blade [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.32": {
+    "Name": "Egg Mania - Eggstreme Madness [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.33": {
+    "Name": "Dual Hearts [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.34": {
+    "Name": "Tekken 4 [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.35": {
+    "Name": "Eidos Demo Disc",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.36": {
+    "Name": "Scorpion King, The - Rise of the Akkadian [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.37": {
+    "Name": "Dance Dance Revolution Max [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.38": {
+    "Name": "Haven - Call of the King [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.40": {
+    "Name": "Dr. Muto [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.42": {
+    "Name": "dot Hack - Part 1 - Infection [Ragular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.44": {
+    "Name": "Pride FC - Fighting Championships [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.45": {
+    "Name": "Black & Bruised [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.47": {
+    "Name": "Def Jam - Vendetta [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.48": {
+    "Name": "Splinter Cell [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.49": {
+    "Name": "Warhammer 40,000 - Fire Warrior [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.50": {
+    "Name": "Everquest Online Adventures [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.53": {
+    "Name": "NBA Street Vol.2 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.54": {
+    "Name": "Splashdown - Rides Gone Wild [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.55": {
+    "Name": "dot Hack - Part 2 - Mutation [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.56": {
+    "Name": "Alter Echo [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.57": {
+    "Name": "Sphinx and the Shadow of Set [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.58": {
+    "Name": "Soul Calibur II [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.59": {
+    "Name": "Hunter the Reckoning - Wayward [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.60": {
+    "Name": "Gladius [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.61": {
+    "Name": "Freaky Flyers [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.63": {
+    "Name": "Everquest Online Adventures - Frontiers [Public Beta Ver.1.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.65": {
+    "Name": "dot Hack - Part 3 - Outbreak [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.67": {
+    "Name": "Tak and the Power of Juju [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.68": {
+    "Name": "Crash Nitro Kart [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.69": {
+    "Name": "Prince of Persia - The Sands of Time [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.70": {
+    "Name": "XIII [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.71": {
+    "Name": "Namco Transmission Demo Disc v1.03 [Regular Release]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.73": {
+    "Name": "Need for Speed - Underground [Demo]",
+    "Region": "NTSC-U",
+    "EETimingHack": 1
+  },
+  "SLUS_290.74": {
+    "Name": "Dance Dance Revolution Max 2 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.77": {
+    "Name": "I-Ninja [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.79": {
+    "Name": "NCAA March Madness 2004 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.80": {
+    "Name": "Whiplash [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.81": {
+    "Name": "Metal Arms - Glitch in the System [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.82": {
+    "Name": "Beyond Good and Evil [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.83": {
+    "Name": "Maximo vs. The Army of Zin [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.84": {
+    "Name": "dot Hack - Part 4 - Quarantine [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.86": {
+    "Name": "FIFA Soccer 2004 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.87": {
+    "Name": "Square Enix Sampler Disc Vol.1",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.88": {
+    "Name": "Champions of Norrath - Realms of EverQuest [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.89": {
+    "Name": "Resident Evil Outbreak [Public Beta 1.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.91": {
+    "Name": "MX Unleashed [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.93": {
+    "Name": "NFL Street [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.95": {
+    "Name": "James Bond 007 - Everything or Nothing [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.96": {
+    "Name": "Final Night 2004 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_290.98": {
+    "Name": "Square Enix Sampler Disc Vol.2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.00": {
+    "Name": "Ribbit King [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.01": {
+    "Name": "Crash Twinsanity & Spyro - A Hero's Tail [Demo]",
+    "Region": "NTSC-U",
+    "XgKickHack": "1  "
+  },
+  "SLUS_291.04": {
+    "Name": "Galactic Wrestling - Featuring Ultimate Muscle [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.07": {
+    "Name": "Transformers [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.08": {
+    "Name": "Def Jam - Fight For NY [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.10": {
+    "Name": "Monster Hunter [Public Beta Vol.1 - Ver.1.01]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.11": {
+    "Name": "Asterix & Obilex XXL - Kick Buttix [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.13": {
+    "Name": "Burnout 3 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.16": {
+    "Name": "WWE SmackDown! vs. RAW [Public Beta Vol.1.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.17": {
+    "Name": "Battlefield 2 - Modern Combat [Public Beta Vol.1.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.18": {
+    "Name": "Need for Speed - Underground 2 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.23": {
+    "Name": "Ghost in the Shell - Stand Alone Complex [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.24": {
+    "Name": "Fight Club [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.25": {
+    "Name": "Konami Preview Disc",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.26": {
+    "Name": "Champions - Return to Arms [Demo]",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLUS_291.29": {
+    "Name": "25 to Life [Public Beta Vol.1.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.30": {
+    "Name": "Crash 'N' Burn [Public Beta Vol.1.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.31": {
+    "Name": "Project Snowblind [Public Beta Vol.1.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.32": {
+    "Name": "S.L.A.I. - Steel Lancer Arena International - Phantom Crash [Public Beta Vol.1.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.34": {
+    "Name": "Namco Transmission Demo Disc Vol.2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.37": {
+    "Name": "Mercenaries [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.38": {
+    "Name": "Punisher [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.39": {
+    "Name": "Shadow of Rome [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.40": {
+    "Name": "MX vs. ATV Unleashed [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.41": {
+    "Name": "NBA Street v3 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.45": {
+    "Name": "Final Night - Round 2 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.48": {
+    "Name": "Incredible Hulk, The - Ultimate Destruction [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.49": {
+    "Name": "Flipnic - Ultimate Pinball [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.50": {
+    "Name": "Destroy All Humans! [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.52": {
+    "Name": "Battlefield 2 - Modern Combat [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.53": {
+    "Name": "Burnout Revenge [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.54": {
+    "Name": "NHL '06 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.55": {
+    "Name": "Need for Speed - Most Wanted [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.56": {
+    "Name": "Marvel Nemesis - Rise of the Imperfects [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.57": {
+    "Name": "Dragon Quest VIII - Journey of the Cursed King [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.59": {
+    "Name": "One Piece - Grand Battle [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.60": {
+    "Name": "FIFA '06 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.61": {
+    "Name": "SSX On Tour [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.62": {
+    "Name": "NBA Live '06 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.63": {
+    "Name": "NCAA March Madness '06 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.64": {
+    "Name": "Star Wars Battlefront II [Online Public Beta]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.67": {
+    "Name": "James Bond 007 - From Russia with Love, Need for Speed - Most Wanted, SSX World Tour [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.68": {
+    "Name": "James Bond 007 - From Russia with Love [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.69": {
+    "Name": "Resident Evil 4 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.70": {
+    "Name": "Total Overdose - A Gunslinger's Tale in Mexico [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.71": {
+    "Name": "Final Fantasy XII [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.73": {
+    "Name": "Sims 2, The [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.74": {
+    "Name": "Namco Transmission Demo Disc Vol.3.1",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.75": {
+    "Name": "Namco Transmission Demo Disc Vol.3.2",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.78": {
+    "Name": "TOCA Race Driver 3 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.79": {
+    "Name": "Sonic Riders [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.80": {
+    "Name": "Black [Demo]",
+    "Region": "NTSC-U",
+    "vuClampMode": "0"
+  },
+  "SLUS_291.85": {
+    "Name": "Driver - Parallel Lines [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.88": {
+    "Name": "Steambot Chronicles [Regular Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.89": {
+    "Name": "FIFA World Cup - Germany 2006 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.91": {
+    "Name": "Hitman - Blood Money & Urban Chaos [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.92": {
+    "Name": "Test Drive Unlimited [Public Beta Vol.1.0]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.93": {
+    "Name": "Need for Speed - Carbon [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.94": {
+    "Name": "FIFA '07 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.95": {
+    "Name": "Yakuza [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.96": {
+    "Name": "Destroy All Humans! 2 [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.97": {
+    "Name": "Flushed Away [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SLUS_291.98": {
+    "Name": "Guitar Hero II [Demo]",
+    "Region": "NTSC-U"
+  },
+  "PAPX_905.12": {
+    "Name": "Gran Turismo 4 - Toyota Prius [Trial]",
+    "Region": "NTSC-J",
+    "vuClampMode": 2
+  },
+  "PBPX_955.03": {
+    "Name": "Gran Turismo 3 - A-Spec [PS2 Bundle]",
+    "Region": "NTSC-U"
+  },
+  "PBPX_955.17": {
+    "Name": "Network Adapter Start-Up Disc",
+    "Region": "NTSC-U"
+  },
+  "PBPX_952.01": {
+    "Name": "Dead or Alive 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "PBPX_955.24": {
+    "Name": "Gran Turismo 4 - Prologue",
+    "Region": "NTSC-Unk",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "PCPX_966.49": {
+    "Name": "Gran Turismo 4 [Demo]",
+    "Region": "NTSC-J",
+    "Compat": 4,
+    "vuClampMode": 2
+  },
+  "SCAJ_100.01": {
+    "Name": "Makai Senki Disgaea",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_100.03": {
+    "Name": "Taiko no Tatsujin Doki",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_100.04": {
+    "Name": "Time Crisis 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_100.06": {
+    "Name": "Taiko no Tatsujin 3 - Appare Sandaime",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_100.07": {
+    "Name": "Taiko no Tatsujin - Waku Waku Anime Matsuri",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_100.08": {
+    "Name": "Taiko no Tatsujin Atsumare Yonndaime",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_100.09": {
+    "Name": "Psikyo Shooting Collection Vol.1 - Strikers 1&2",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_100.10": {
+    "Name": "Mahjong Party - Play Mahjong with Swimsuit Beauty",
+    "Region": "NTSC-Unk",
+    "Compat": 5
+  },
+  "SCAJ_100.11": {
+    "Name": "Taiko no Tatsujin Go! Go! Godaime",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_100.12": {
+    "Name": "Taiko Drum Master",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_100.13": {
+    "Name": "Taiko no Tatsujin - Tobikkiri! Anime Special",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_100.14": {
+    "Name": "Taiko no Tatsujin Wai Wai Happy Muyome",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_100.15": {
+    "Name": "Taiko No Tatsujin Doka! To Omori 7Daime",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.01": {
+    "Name": "Ratchet and Clank",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.02": {
+    "Name": "Gallop Racer 6 - Revolution",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.03": {
+    "Name": "Warrior in Argus",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.04": {
+    "Name": "dot Hack Vol.3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.05": {
+    "Name": "Guilty Gear XX",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.06": {
+    "Name": "Gunbarl Collection with Time Crisis",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.07": {
+    "Name": "Xi(sai) Go",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.08": {
+    "Name": "V-Rally 3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.09": {
+    "Name": "Herdy Gerdy",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.10": {
+    "Name": "Bakusou Dekotora Densetsu 3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.11": {
+    "Name": "Armored Core 3 - Silent Line",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.12": {
+    "Name": "Venus & Braves",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.13": {
+    "Name": "Moto GP 3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.14": {
+    "Name": "Time Splitter",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.15": {
+    "Name": "Shin Megami Tensei 3 - Nocturine",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.16": {
+    "Name": "Warrior of Argus",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.17": {
+    "Name": "Sly Cooper",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.18": {
+    "Name": "This is Football 2003",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.19": {
+    "Name": "Arc the Lad - Twilight of the Spirits",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.20": {
+    "Name": "Drag-on Dragoon",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.21": {
+    "Name": "Metal Slug 3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.22": {
+    "Name": "Super Robot Wars - Alpha 2nd",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.23": {
+    "Name": "Soul Calibur II",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.24": {
+    "Name": "dot Hack Vol.4",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.25": {
+    "Name": "Grand Prix Challenge",
+    "Region": "NTSC-Unk",
+    "VIFFIFOHack": 1
+  },
+  "SCAJ_200.26": {
+    "Name": "Generation of Chaos 3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.27": {
+    "Name": "Tenchu 3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.28": {
+    "Name": "Tales of Destiny 2",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.29": {
+    "Name": "R-Type Final",
+    "Region": "NTSC-Unk",
+    "Compat": 5,
+    "EETimingHack": "1 "
+  },
+  "SCAJ_200.32": {
+    "Name": "Mosquito - Let's Go Hawaiian",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.33": {
+    "Name": "Guilty Gear XX #Reload",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.34": {
+    "Name": "Summon Night 3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.35": {
+    "Name": "Deat to Rights",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.37": {
+    "Name": "Monster Farm 4",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.38": {
+    "Name": "Arc the Lad - Twilight of the Spirits",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.39": {
+    "Name": "Sidewinder V",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.40": {
+    "Name": "King of Fighters 2001, The",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.41": {
+    "Name": "Energy Airforce - Aim Strike!",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.43": {
+    "Name": "Chain Drive",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.44": {
+    "Name": "Tomb Raider - The Angel of Darkness",
+    "Region": "NTSC-Unk",
+    "OPHFlagHack": 1
+  },
+  "SCAJ_200.45": {
+    "Name": "Shadow Tower Abyss",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.46": {
+    "Name": "Siren",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.47": {
+    "Name": "Time Crisis 3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.48": {
+    "Name": "R - Racing Evolution",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.50": {
+    "Name": "Fatal Frame 2 - Crimson Butterfly",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.55": {
+    "Name": "Battle Gear 3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.56": {
+    "Name": "Bujingai",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.57": {
+    "Name": "Front Mission 4",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.58": {
+    "Name": "Terminator 3 - Rise of the Machines",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.59": {
+    "Name": "Minna no Golf 4",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.60": {
+    "Name": "Time Crisis 3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.61": {
+    "Name": "Seven Samurai 20XX",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.62": {
+    "Name": "Crouching Tiger, Hidden Dragon",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.63": {
+    "Name": "Popolocrois - The Law of the Moon",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.64": {
+    "Name": "Nebula - Echo Night",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.65": {
+    "Name": "EyeToy - Play [with Camera]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.66": {
+    "Name": "Gran Turismo 4 - Prologue",
+    "Region": "NTSC-Unk",
+    "vuClampMode": 2
+  },
+  "SCAJ_200.67": {
+    "Name": "GunGrave O.D.",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.68": {
+    "Name": "Final Fantasy X-2 International",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.69": {
+    "Name": "Gallop Racer - Lucky 7",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.70": {
+    "Name": "Star Ocean 3 [Director's Cut]",
+    "Region": "NTSC-Unk",
+    "VuAddSubHack": 1
+  },
+  "SCAJ_200.72": {
+    "Name": "Ghost in the Shell - Stand Alone Complex",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.73": {
+    "Name": "Jak and Daxter II",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.74": {
+    "Name": "King of Fighters 2002, The",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.75": {
+    "Name": "Dragon Quest V - Bride of the Sky",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.76": {
+    "Name": "Armored Core - Nexus",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.78": {
+    "Name": "Kuon",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.79": {
+    "Name": "Katamari Damacy",
+    "Region": "NTSC-Unk",
+    "mvuFlagSpeedHack": "0"
+  },
+  "SCAJ_200.80": {
+    "Name": "Kaena",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.81": {
+    "Name": "Xenosaga Freaks",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.82": {
+    "Name": "GunGrave OD",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.83": {
+    "Name": "Bakuso! Mountain Bikers",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.84": {
+    "Name": "MLB '04",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.85": {
+    "Name": "Sakurazaka Shouboutai",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.86": {
+    "Name": "Xenosaga Episode II - Jenseits von Gut und Bose [Disc1of2]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.87": {
+    "Name": "Xenosaga Episode II - Jenseits von Gut und Bose [Disc2of2]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.88": {
+    "Name": "UO Nanatsu no Mizu to Densetsu no Nushi",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.89": {
+    "Name": "Athens 2004",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.90": {
+    "Name": "Gacha Mecha Stadium - Saru Battle",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.92": {
+    "Name": "Samurai Spirits Zero",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.93": {
+    "Name": "Tenchu Kurenai",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.94": {
+    "Name": "Minna no Golf 4 [PlayStation 2 The Best]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.95": {
+    "Name": "Digital Devil Saga - Avatar Tuner",
+    "Region": "NTSC-Unk",
+    "EETimingHack": 1
+  },
+  "SCAJ_200.96": {
+    "Name": "Guilty Gear Isuka",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.97": {
+    "Name": "EyeToy - FuriFuri Dance Tengoku",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.98": {
+    "Name": "EyeToy - Oosawagi! Ukkiiuki Game",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_200.99": {
+    "Name": "Ico",
+    "Region": "NTSC-Unk",
+    "Compat": 5,
+    "eeClampMode": 2,
+    "vuClampMode": 1
+  },
+  "SCAJ_201.00": {
+    "Name": "Tenchu Kurenai",
+    "Region": "NTSC-Ch-J"
+  },
+  "SCAJ_201.01": {
+    "Name": "EyeToy - Saru",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.02": {
+    "Name": "Tales of Symphonia",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.04": {
+    "Name": "Ace Combat 5 - The Unsung War",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.05": {
+    "Name": "Armored Core - Ninebreaker",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.07": {
+    "Name": "Bakufuu Slash!! Kizna Arashi",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.08": {
+    "Name": "Arc the Lad - Generation",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.09": {
+    "Name": "Ratchet & Clank 3 - Up your Arsenal",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.10": {
+    "Name": "Dragon Quest VIII - Sora to Daichi to Norowareshi Himegimi",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.11": {
+    "Name": "Crash Bandicoot 5",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.12": {
+    "Name": "Tales of Rebirth",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.13": {
+    "Name": "Dragon Quest & Final Fantasy in Itadaki Street",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.14": {
+    "Name": "Tsukiyo ni Saraba",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.15": {
+    "Name": "Yoshitsune Eiyuuden",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.16": {
+    "Name": "Death by Degrees - Tekken - Nina Williams",
+    "Region": "NTSC-Ch-J"
+  },
+  "SCAJ_201.17": {
+    "Name": "Fuun Bakumatsuden",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.18": {
+    "Name": "Radiata Stories",
+    "Region": "NTSC-J",
+    "VuAddSubHack": 1
+  },
+  "SCAJ_201.19": {
+    "Name": "Gladiator - Road to Freedom",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.20": {
+    "Name": "Digital Devil Saga - Avatar Tuner 2",
+    "Region": "NTSC-Unk",
+    "EETimingHack": 1
+  },
+  "SCAJ_201.21": {
+    "Name": "Armored Core - Formula Front",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.22": {
+    "Name": "Swords of Destiny",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.23": {
+    "Name": "Wild ARMs - The 4th Detonator",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.24": {
+    "Name": "Romancing Saga - Minstrel Song",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.25": {
+    "Name": "Tekken 5",
+    "Region": "NTSC-Unk",
+    "eeClampMode": 1
+  },
+  "SCAJ_201.26": {
+    "Name": "Tekken 5",
+    "Region": "NTSC-Unk",
+    "eeClampMode": 1
+  },
+  "SCAJ_201.27": {
+    "Name": "EyeToy - Play 2 [with Camera]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.28": {
+    "Name": "EyeToy - Play 2",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.29": {
+    "Name": "Ponkotsu Roman Daikatsugeki Bumpy Trot",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.30": {
+    "Name": "Namco x Capcom",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.31": {
+    "Name": "namCollection - Namco 50th Anniversary",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.32": {
+    "Name": "Drag-On Dragon 2 - Fuuin no Kurenai (Love Red, Ambivalence Black)",
+    "Region": "NTSC-J"
+  },
+  "SCAJ_201.33": {
+    "Name": "Kagero 2 - Dark Illusion",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.34": {
+    "Name": "Genji",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.35": {
+    "Name": "Minna Daisuki Katamari Damacy",
+    "Region": "NTSC-Unk",
+    "vuClampMode": 3,
+    "mvuFlagSpeedHack": "0"
+  },
+  "SCAJ_201.36": {
+    "Name": "Ace Combat 5 - The Unsung War [PlayStation2 The Best]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.37": {
+    "Name": "Musashiden II - Blademaster",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.38": {
+    "Name": "Ape Escape 3",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.39": {
+    "Name": "New Zero - Rei - Irezumi no Sei",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.40": {
+    "Name": "Bleach - Erabareshi Tamashi",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.41": {
+    "Name": "Grandia III",
+    "Region": "NTSC-J"
+  },
+  "SCAJ_201.43": {
+    "Name": "Armored Core - Last Raven",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.44": {
+    "Name": "Saru Gechu 3 (Ape Escape 3)",
+    "Region": "NTSC-Ch-J"
+  },
+  "SCAJ_201.45": {
+    "Name": "Tales of Legendia",
+    "Region": "NTSC-J"
+  },
+  "SCAJ_201.46": {
+    "Name": "Shadow of the Colossus",
+    "Region": "NTSC-Ch-E-J"
+  },
+  "SCAJ_201.47": {
+    "Name": "Heavy Metal Thunder",
+    "Region": "NTSC-J"
+  },
+  "SCAJ_201.48": {
+    "Name": "Tokyo Bus Guide 2",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.49": {
+    "Name": "Kingdom Hearts - Final Mix [Ultimate Hits]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.50": {
+    "Name": "Critical Velocity",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.51": {
+    "Name": "MotoGP 4",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.52": {
+    "Name": "Urban Reign",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.53": {
+    "Name": "Code Age Commanders",
+    "Region": "NTSC-J"
+  },
+  "SCAJ_201.54": {
+    "Name": "Prince of Persia - Warrior Within",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.55": {
+    "Name": "Yoshitsune Eiyuuden Syura",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.56": {
+    "Name": "Gallop Racer 8 - Live Horse Racing",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.57": {
+    "Name": "Ratchet & Clank 4th - GiriGiri Gingano Giga-battle",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.58": {
+    "Name": "Ikusa Gami",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.59": {
+    "Name": "Soul Calibur III",
+    "Region": "NTSC-Ch-E-J"
+  },
+  "SCAJ_201.60": {
+    "Name": "Yoshitsuneki",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.61": {
+    "Name": "Siren 2",
+    "Region": "NTSC-J",
+    "XgKickHack": 1
+  },
+  "SCAJ_201.62": {
+    "Name": "Rogue Galaxy",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.63": {
+    "Name": "Tales of the Abyss",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.64": {
+    "Name": "Kingdom Hearts II",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.65": {
+    "Name": "Bleach - Hanatareshi Yabou",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.66": {
+    "Name": "Front Mission 5 - Scars of the War",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.67": {
+    "Name": "Siren 2",
+    "Region": "NTSC-Ch-J",
+    "XgKickHack": 1
+  },
+  "SCAJ_201.68": {
+    "Name": "Rule of Rose",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.69": {
+    "Name": "Dirge of Cerberus - Final Fantasy VII",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.70": {
+    "Name": "Tourist Trophy",
+    "Region": "NTSC-Ch",
+    "Compat": 2
+  },
+  "SCAJ_201.71": {
+    "Name": "Zettai Zetsumei Toshi 2 - Itetsuita Kioku Tachi",
+    "Region": "NTSC-J"
+  },
+  "SCAJ_201.72": {
+    "Name": "Final Fantasy XII",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.73": {
+    "Name": "Ace Combat Zero - The Belkan War",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.75": {
+    "Name": "Dragon Quest - Shonen Yangus to Fushigi no Dungeon",
+    "Region": "NTSC-J"
+  },
+  "SCAJ_201.76": {
+    "Name": "Curious George",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.77": {
+    "Name": "Valkyrie Profile 2 - Silmeria",
+    "Region": "NTSC-Unk",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SCAJ_201.78": {
+    "Name": "Ape Escape - Million Monkeys",
+    "Region": "NTSC-Unk",
+    "Compat": 5
+  },
+  "SCAJ_201.79": {
+    "Name": "Xenosaga Episode III - Also Sprach Zarathustra [Disc1of2]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.80": {
+    "Name": "Xenosaga Episode III - Also Sprach Zarathustra [Disc2of2]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.81": {
+    "Name": "Minna no Tennis",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.82": {
+    "Name": "Tales of Destiny",
+    "Region": "NTSC-Unk",
+    "FpuMulHack": 1
+  },
+  "SCAJ_201.83": {
+    "Name": "Wild ARMs - The Vth Vanguard",
+    "Region": "NTSC-J"
+  },
+  "SCAJ_201.84": {
+    "Name": "Seiken Densetsu 4",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.85": {
+    "Name": "Super Robot Taisen - Original Generations",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.88": {
+    "Name": "Final Fantasy XII - International - Zodiac Job System",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.90": {
+    "Name": "God of War II",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.91": {
+    "Name": "Super Robot Taisen OG - Original Generations Gaiden [Limited Edition]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.92": {
+    "Name": "Super Robot Taisen OG - Original Generations Gaiden",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.93": {
+    "Name": "Tales of Destiny [Director's Cut] [Premium Box]",
+    "Region": "NTSC-Unk",
+    "FpuMulHack": 1
+  },
+  "SCAJ_201.94": {
+    "Name": "Minna no Golf 4 [PlayStation 2 the Best]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.95": {
+    "Name": "Ape Escape 3 [PlayStation 2 the Best]",
+    "Region": "NTSC-Ch"
+  },
+  "SCAJ_201.96": {
+    "Name": "Shadow of the Colossus [PlayStation 2 the Best]",
+    "Region": "NTSC-Ch"
+  },
+  "SCAJ_201.97": {
+    "Name": "Valkyrie Profile 2 - Silmeria [Ultimate Hits]",
+    "Region": "NTSC-Unk",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SCAJ_201.98": {
+    "Name": "Everybody's Tennis [PlayStation 2 the Best]",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_201.99": {
+    "Name": "Tekken 5 [PlayStation 2 the Best]",
+    "Region": "NTSC-Unk",
+    "eeClampMode": 1
+  },
+  "SCAJ_250.02": {
+    "Name": "Shinobi",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_250.04": {
+    "Name": "Kingdom Hearts - Final Mix",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_250.08": {
+    "Name": "Initial D - Street Stage",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_250.12": {
+    "Name": "Final Fantasy X-2",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_250.26": {
+    "Name": "Kunoichi Shinobi",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_250.34": {
+    "Name": "Sakura Taisen Monogatari",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_250.37": {
+    "Name": "Astro Boy Atom",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_250.45": {
+    "Name": "Sakura Taisen V - Episode 0",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_250.47": {
+    "Name": "Dororo",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_300.01": {
+    "Name": "Xenosaga Episode I [PlayStation 2 The Best]",
+    "Region": "NTSC-Unk",
+    "Compat": 5
+  },
+  "SCAJ_300.02": {
+    "Name": "Wild ARMs - Alter Code F",
+    "Region": "NTSC-J"
+  },
+  "SCAJ_300.03": {
+    "Name": "Siren",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_300.04": {
+    "Name": "Waga Ryuomiyo - Pride of the Dragon Peace",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_300.05": {
+    "Name": "Gacha Mecha Stadium Saru Battle",
+    "Region": "NTSC-Unk"
+  },
+  "SCAJ_300.06": {
+    "Name": "Gran Turismo 4",
+    "Region": "NTSC-Unk",
+    "vuClampMode": 2
+  },
+  "SCAJ_300.07": {
+    "Name": "Gran Turismo 4",
+    "Region": "NTSC-Unk",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SCAJ_300.08": {
+    "Name": "Gran Turismo 4 [PlayStation 2 The Best]",
+    "Region": "NTSC-Unk",
+    "vuClampMode": 2
+  },
+  "SCAJ_300.10": {
+    "Name": "God of War",
+    "Region": "NTSC-E"
+  },
+  "SCAJ_300.11": {
+    "Name": "God of War II",
+    "Region": "NTSC-E"
+  },
+  "SCKA_100.06": {
+    "Name": "Come on Baby",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.04": {
+    "Name": "Sly Cooper and the Thievius Raccoonus",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.08": {
+    "Name": "Tales of Destiny 2",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.09": {
+    "Name": "R-Type Final",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "EETimingHack": "1 "
+  },
+  "SCKA_200.10": {
+    "Name": "Jak II",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.11": {
+    "Name": "Ratchet and Clank 2",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.12": {
+    "Name": "Ark the Lad - jeongryeongui Hwanghon",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.14": {
+    "Name": "Dark Claud 2",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.15": {
+    "Name": "Time Crisis 3",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.16": {
+    "Name": "Soul Calibur 2",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SCKA_200.18": {
+    "Name": "The Getaway",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.19": {
+    "Name": "Siren",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.20": {
+    "Name": "SOCOM II - U.S. Navy SEALs",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "EETimingHack": 1,
+    "VIF1StallHack": 1
+  },
+  "SCKA_200.22": {
+    "Name": "Gran Turismo 4 Prologue",
+    "Region": "NTSC-K",
+    "vuClampMode": 2
+  },
+  "SCKA_200.23": {
+    "Name": "Fatal Frame 2",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.25": {
+    "Name": "Katamari Damacy",
+    "Region": "NTSC-K",
+    "mvuFlagSpeedHack": "0"
+  },
+  "SCKA_200.26": {
+    "Name": "Gungrave O.D.",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.27": {
+    "Name": "Ghost in the Shell - Stand Alone Complex",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.28": {
+    "Name": "Ico [PlayStation2 Big Hit Series]",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "eeClampMode": 2,
+    "vuClampMode": 1
+  },
+  "SCKA_200.29": {
+    "Name": "Gran Turismo Concept 2002 Tokyo-Seoul [PlayStation 2 Big Hit Series]",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.32": {
+    "Name": "Syphon Filter - The Omega Virus",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.33": {
+    "Name": "Smash Court Professional Tournament 2 [Limited Edition]",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.34": {
+    "Name": "Time Crisis 3 [PlayStation 2 Big Hit Series]",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.35": {
+    "Name": "Hot Shots Golf 3 [PlayStation 2 Big Hit Series]",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.38": {
+    "Name": "Time Crisis - Crisis Zone",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.39": {
+    "Name": "Tekken Nina Williams In Death By Degree",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.40": {
+    "Name": "Jak 3",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.43": {
+    "Name": "Magna Carta",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.44": {
+    "Name": "Sly Cooper 2 Band of Thieves",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.47": {
+    "Name": "Armored Core Nine Breaker",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.48": {
+    "Name": "Killzone",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.49": {
+    "Name": "Tekken 5",
+    "Region": "NTSC-K",
+    "eeClampMode": 1
+  },
+  "SCKA_200.50": {
+    "Name": "Tales of Legendia",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.51": {
+    "Name": "Minna Daisuki Katamari Damacy",
+    "Region": "NTSC-K",
+    "vuClampMode": 3,
+    "mvuFlagSpeedHack": "0"
+  },
+  "SCKA_200.52": {
+    "Name": "Genji",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.53": {
+    "Name": "SOCOM II - U.S. Navy SEALs [PlayStation 2 Big Hit Series]",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "EETimingHack": 1,
+    "VIF1StallHack": 1
+  },
+  "SCKA_200.54": {
+    "Name": "Tales of Destiny 2 [PlayStation 2 Big Hit Series]",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.55": {
+    "Name": "Mystic Nights",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.56": {
+    "Name": "LuluRara - Powered by Zillerner [with USB microphone]",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.58": {
+    "Name": "Bumpy Trot",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.59": {
+    "Name": "Soul Calibur III",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.60": {
+    "Name": "Ratchet - Deadlocked",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.61": {
+    "Name": "Wanda to Kyozou (Shadow of the Colossus)",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.62": {
+    "Name": "Ape Escape 3",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.63": {
+    "Name": "Sly Cooper 3 Honor Among Thieves",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.64": {
+    "Name": "SOCOM 3 - U.S. Navy SEALs",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.69": {
+    "Name": "Siren 2",
+    "Region": "NTSC-K",
+    "XgKickHack": 1
+  },
+  "SCKA_200.70": {
+    "Name": "Ace Combat Zero - The Belkan War",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.71": {
+    "Name": "MLB '06 - The Show",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.72": {
+    "Name": "LuluRara 2 [with USB microphone]",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.73": {
+    "Name": "Final Fantasy XII",
+    "Region": "NTSC-J"
+  },
+  "SCKA_200.78": {
+    "Name": "Killzone [PlayStation 2 Big Hit Series]",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.79": {
+    "Name": "Valkyrie Profile 2 - Silmeria",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SCKA_200.81": {
+    "Name": "Tekken 5 [PlayStation 2 Big Hit Series]",
+    "Region": "NTSC-K",
+    "eeClampMode": 1
+  },
+  "SCKA_200.86": {
+    "Name": "Shin Onimusha - Dawn of Dreams [Disc1of2]",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.87": {
+    "Name": "Shin Onimusha - Dawn of Dreams [Disc2of2]",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.90": {
+    "Name": "God Hand",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_200.92": {
+    "Name": "K-1 World Grand Prix 2006",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.96": {
+    "Name": "Barnyard",
+    "Region": "NTSC-K"
+  },
+  "SCKA_200.99": {
+    "Name": "Persona 3",
+    "Region": "NTSC-K",
+    "VuClipFlagHack": 1
+  },
+  "SCKA_201.01": {
+    "Name": "Seiken Densetsu 4 (Dawn of Mana)",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_201.07": {
+    "Name": "Odin Sphere",
+    "Region": "NTSC-K"
+  },
+  "SCKA_201.09": {
+    "Name": "Persona 3 - Fes [Independent Starting Version]",
+    "Region": "NTSC-K",
+    "VuClipFlagHack": 1
+  },
+  "SCKA_201.14": {
+    "Name": "Obscure II - The Aftermath",
+    "Region": "NTSC-K"
+  },
+  "SCKA_201.17": {
+    "Name": "Super Robot Taisen OG - Original Generations Gaiden",
+    "Region": "NTSC-K"
+  },
+  "SCKA_201.20": {
+    "Name": "Ratchet and Clank",
+    "Region": "NTSC-K"
+  },
+  "SCKA_201.32": {
+    "Name": "Shin Megami Tensei - Persona 4",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "VuClipFlagHack": 1
+  },
+  "SCKA_240.08": {
+    "Name": "SOCOM - U.S. Navy SEALs",
+    "Region": "NTSC-K"
+  },
+  "SCKA_300.01": {
+    "Name": "Gran Turismo 4",
+    "Region": "NTSC-K",
+    "vuClampMode": 2
+  },
+  "SCKA_300.02": {
+    "Name": "God of War",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCKA_300.06": {
+    "Name": "God of War 2",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCPS_110.01": {
+    "Name": "I.Q. Remix",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_110.02": {
+    "Name": "Fantavision",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_110.03": {
+    "Name": "Ico",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "eeClampMode": 2,
+    "vuClampMode": 1
+  },
+  "SCPS_110.04": {
+    "Name": "Bikkuri Mouse",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.05": {
+    "Name": "Sagashi ni Ikouyo - Go to Find It!",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.06": {
+    "Name": "Sky Gunner",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_110.07": {
+    "Name": "Tsuganai",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.08": {
+    "Name": "Boku to Mao",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SCPS_110.09": {
+    "Name": "Ka (Mosquito)",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SCPS_110.10": {
+    "Name": "Yoake no Mariko [with Microphone]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.11": {
+    "Name": "Check-i-TV",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.12": {
+    "Name": "Rimoko Koron",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_110.13": {
+    "Name": "Bravo Music",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_110.14": {
+    "Name": "Pipo Saru (Ape Escape) 2001",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_110.15": {
+    "Name": "Check-i-TV",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.16": {
+    "Name": "Seigi no Mikata",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.17": {
+    "Name": "Bravo Music - Christmas Edition",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.18": {
+    "Name": "Yoake no Mariko",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.19": {
+    "Name": "Bravo Music - Chou-Meikyokuban [Limited Edition] [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.20": {
+    "Name": "Bravo Music - Chou-Meikyokuban [Limited Edition] [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.21": {
+    "Name": "Yoake no Mariko 2nd Act",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.22": {
+    "Name": "Yoake no Mariko 2nd Act",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.23": {
+    "Name": "Bravo Music - Chou-Meikyokuban",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.24": {
+    "Name": "Otostaz",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SCPS_110.25": {
+    "Name": "Space Fisherman",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "vuClampMode": 3
+  },
+  "SCPS_110.26": {
+    "Name": "Gacharoku",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.27": {
+    "Name": "Mawaza",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.28": {
+    "Name": "Let's Bravo Music",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.29": {
+    "Name": "Shibai Muchi",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.30": {
+    "Name": "Shibai Muchi [with Microphone]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.31": {
+    "Name": "Kumauta",
+    "Region": "NTSC-J"
+  },
+  "SCPS_110.32": {
+    "Name": "Vib Ripple",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_110.33": {
+    "Name": "Mojib-Ribbon",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_110.34": {
+    "Name": "Gacharoku 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.01": {
+    "Name": "Scandal",
+    "Region": "NTSC-J",
+    "Compat": 2
+  },
+  "SCPS_150.02": {
+    "Name": "TV DJ",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SCPS_150.03": {
+    "Name": "Sky Odyssey",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.04": {
+    "Name": "Dark Cloud",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.05": {
+    "Name": "Phase Paradox",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.06": {
+    "Name": "Popolocrois Story 3 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.07": {
+    "Name": "Blood - The Last Vampire - Vol.1 Joukan",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_150.08": {
+    "Name": "Blood - The Last Vampire - Vol.2 Gekan",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_150.09": {
+    "Name": "Gran Turismo 3 - A-Spec",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.10": {
+    "Name": "Gran Turismo - Concept 2001 Tokyo",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_150.11": {
+    "Name": "Extermination",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.12": {
+    "Name": "Surveillance",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.13": {
+    "Name": "Poinie's Poin",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.14": {
+    "Name": "Genshi no Kotoba",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.15": {
+    "Name": "Toro to Kyuujitsu",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_150.16": {
+    "Name": "Minna no Golf 3",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.17": {
+    "Name": "PaRappa the Rapper 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.18": {
+    "Name": "Train Simulator Real, The - Yamanote Sen",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.19": {
+    "Name": "Formula One 2001",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.20": {
+    "Name": "Legaia 2 - Duel Saga",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.21": {
+    "Name": "Jak & Daxter 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.22": {
+    "Name": "Dual Hearts",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.23": {
+    "Name": "Wild ARMs - Advanced 3rd",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.24": {
+    "Name": "Wild ARMs - Advanced 3rd",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.25": {
+    "Name": "Saru Get You 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_150.26": {
+    "Name": "Boku no Natsuyasumi 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.27": {
+    "Name": "PoPoLoCrois - Hajimari no Bouken [Limited]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.28": {
+    "Name": "PoPoLoCrois - Hajimari no Bouken",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.29": {
+    "Name": "Xi (Sai) Jumbo",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.30": {
+    "Name": "Fantavision",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.31": {
+    "Name": "Train Simulator Real, The",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.32": {
+    "Name": "Formula One 2002",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.33": {
+    "Name": "Dark Chronicle",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.34": {
+    "Name": "This is Football 2003",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.35": {
+    "Name": "Train Simulator Real, The - Keihin Keikyu",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.36": {
+    "Name": "Kaitou Sly Cooper",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.37": {
+    "Name": "Ratchet & Clank",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.38": {
+    "Name": "Operator's Side",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.39": {
+    "Name": "Operator's Side",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.40": {
+    "Name": "Arc the Lad - Twilight of the Spirits [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.41": {
+    "Name": "Arc the Lad - Seirei no Koukon",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.42": {
+    "Name": "Deka Voice [with Microphone]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.43": {
+    "Name": "Deka Voice",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.44": {
+    "Name": "SOCOM - U.S. Navy SEALs",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.45": {
+    "Name": "Ka (Mosquito) - Let's Go Hawaiian",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_150.46": {
+    "Name": "Hungry Ghosts",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_150.47": {
+    "Name": "Dokodemo Issyo - Watashi na Ehon",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.49": {
+    "Name": "Minna no Golf Online",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.50": {
+    "Name": "Flipnic",
+    "Region": "NTSC-J",
+    "Compat": 3
+  },
+  "SCPS_150.51": {
+    "Name": "MLB 2003",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.52": {
+    "Name": "Saints Seinaru Mamono",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.53": {
+    "Name": "Siren",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_150.54": {
+    "Name": "Chain Drive",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.55": {
+    "Name": "Gran Turismo 4 - Prologue",
+    "Region": "NTSC-J",
+    "vuClampMode": 2
+  },
+  "SCPS_150.56": {
+    "Name": "Ratchet & Clank 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.57": {
+    "Name": "Jak & Daxter 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.58": {
+    "Name": "Arc the Lad - Generation",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.59": {
+    "Name": "Minna no Golf 4",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.60": {
+    "Name": "Koufuku Sousakan",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.61": {
+    "Name": "EyeToy - Play [with Camera]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.62": {
+    "Name": "Bakuso! Mountain Bikers",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.63": {
+    "Name": "Popolocrois - The Law of the Moon",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.64": {
+    "Name": "Ghost in the Shell - Stand Alone Complex",
+    "Region": "NTSC-J",
+    "Compat": 3
+  },
+  "SCPS_150.65": {
+    "Name": "SOCOM II - U.S. Navy SEALs",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "EETimingHack": 1,
+    "VIF1StallHack": 1
+  },
+  "SCPS_150.66": {
+    "Name": "Prince of Persia - The Sands of Time",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.67": {
+    "Name": "Dokodemo Issyo - Toro to Nagare Boshi",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.68": {
+    "Name": "MLB 2004",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.69": {
+    "Name": "Fish - Legend of Seven Waters and Gods",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.70": {
+    "Name": "EyeToy - Play [Game Only]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.71": {
+    "Name": "Minna no Golf Online",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.72": {
+    "Name": "Gacha Mecha Stadium - Saru Battle",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.73": {
+    "Name": "EyeToy - Groov [with Camera]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.74": {
+    "Name": "Olympic Summer Games - Athens 2004",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.75": {
+    "Name": "DJ Box [Premium Kit]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.76": {
+    "Name": "EyeToy - HuriHuri Dance",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.77": {
+    "Name": "EyeToy - Uki Uki Panic [with Camera]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.78": {
+    "Name": "EyeToy - Uki Uki Panic [Game Only]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.79": {
+    "Name": "Bakufuu Slash! Kizuna Arashi [with Camera]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.80": {
+    "Name": "Waga Ryuomiyo - Pride of the Dragon Peace",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.81": {
+    "Name": "Dokodemo Issyo - Toro to Ippai",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.82": {
+    "Name": "DJ Box",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.83": {
+    "Name": "Formula One 2004",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.84": {
+    "Name": "Ratchet & Clank 3",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.85": {
+    "Name": "Kenran Butousai",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.86": {
+    "Name": "Bakufuu Slash! Kizuna Arashi [Game Only]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.87": {
+    "Name": "Bleach - Erabareshi Tamashi",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.88": {
+    "Name": "Bokura no Kazoku",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.89": {
+    "Name": "EyeToy - Play 2 [With Camera]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.90": {
+    "Name": "Sly Racoon 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.91": {
+    "Name": "Wild ARMs - The 4th Detonator",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.92": {
+    "Name": "Wild ARMs - The 4th Detonator",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.93": {
+    "Name": "Rule of Rose",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_150.94": {
+    "Name": "EyeToy - Play 2 [Game Only]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.95": {
+    "Name": "Genji - Dawn of the Samurai",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.96": {
+    "Name": "Saru Get You! 3",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.97": {
+    "Name": "Wanda to Kyozou (Shadow of the Colossus)",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_150.98": {
+    "Name": "Formula One 2005",
+    "Region": "NTSC-J"
+  },
+  "SCPS_150.99": {
+    "Name": "Ratchet & Clank - Giga Battle",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.00": {
+    "Name": "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.01": {
+    "Name": "Bleach - Hanatareshi Yabou",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.02": {
+    "Name": "Rogue Galaxy",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.03": {
+    "Name": "Gunparade Orchestra - Shiro no Shou - Aomori Penguin Densetsu [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.04": {
+    "Name": "Gunparade Orchestra - Shiro no Shou - Aomori Penguin Densetsu",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.05": {
+    "Name": "Tourist Trophy - The Real Riding Simulator",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.06": {
+    "Name": "Siren 2",
+    "Region": "NTSC-J",
+    "Compat": 4,
+    "XgKickHack": 1
+  },
+  "SCPS_151.07": {
+    "Name": "Gunparade Orchestra - Midori no Shou [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.08": {
+    "Name": "Gunparade Orchestra - Midori no Shou",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.09": {
+    "Name": "Gunparade Orchestra - Ao no Shou [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.10": {
+    "Name": "Gunparade Orchestra - Ao no Shou",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.11": {
+    "Name": "Brave Story - Wataru no Bouken",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.12": {
+    "Name": "Blood+ Souyoku Battle Rinbukyoku",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_151.13": {
+    "Name": "Minna no Tennis",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.14": {
+    "Name": "Soukou Kihei Armodyne",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.15": {
+    "Name": "Saru Get You - Million Monkeys",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_151.16": {
+    "Name": "Bleach - Blade Battlers",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SCPS_151.17": {
+    "Name": "Formula One 2006",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.18": {
+    "Name": "Wild ARMs - The Vth Vanguard",
+    "Region": "NTSC-J"
+  },
+  "SCPS_151.19": {
+    "Name": "Bleach - Blade Battlers 2nd",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "OPHFLagHack": "1 "
+  },
+  "SCPS_151.20": {
+    "Name": "Ratchet & Clank 5 Gekitotsu! Dodeka Ginga no Mirimiri Gundan",
+    "Region": "NTSC-J"
+  },
+  "SCPS_170.01": {
+    "Name": "Gran Turismo 4",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SCPS_170.02": {
+    "Name": "Wild ARMs - Alter Code F",
+    "Region": "NTSC-J"
+  },
+  "SCPS_170.08": {
+    "Name": "Nike - Gran Turismo [Limited Edition - 8 inch]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_170.09": {
+    "Name": "Nike - Gran Turismo [Limited Edition - 9 inch]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_170.10": {
+    "Name": "Nike - Gran Turismo [Limited Edition - 10 inch]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_170.11": {
+    "Name": "Nike - Gran Turismo [Limited Edition - 11 inch]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_170.13": {
+    "Name": "Rogue Galaxy [Directors Cut]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_191.01": {
+    "Name": "Mosquito [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_191.02": {
+    "Name": "Boku to Maou [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_191.03": {
+    "Name": "Ico [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "eeClampMode": 2,
+    "vuClampMode": 1
+  },
+  "SCPS_191.04": {
+    "Name": "Pipo Saru 2001 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_191.05": {
+    "Name": "Bravo Music [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_191.51": {
+    "Name": "Ico [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "eeClampMode": 2,
+    "vuClampMode": 1
+  },
+  "SCPS_191.52": {
+    "Name": "Saru Get You! 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_191.53": {
+    "Name": "Pipo Saru 2001 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.01": {
+    "Name": "PaRappa the Rapper 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.02": {
+    "Name": "Extermination [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.03": {
+    "Name": "Dark Cloud [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.04": {
+    "Name": "Zegaia - Duel Saga [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.05": {
+    "Name": "Wild ARMs - Advanced 3rd [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.06": {
+    "Name": "Ape Escape 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.07": {
+    "Name": "Popolocrois Story - Hajime no Bouken [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.08": {
+    "Name": "Gran Turismo - Concept 2001 Tokyo [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.09": {
+    "Name": "Boku no Summer Vacation [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.10": {
+    "Name": "Jack & Dexter [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.11": {
+    "Name": "Ratchet & Clank [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.13": {
+    "Name": "Operator's Side [PlayStation 2 The Best] [with Microphone]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.14": {
+    "Name": "Operator's Side [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.15": {
+    "Name": "Dark Chronicle [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.51": {
+    "Name": "Wild ARMs - Alter Code F [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_192.52": {
+    "Name": "Gran Turismo 4 [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "vuClampMode": 2
+  },
+  "SCPS_192.53": {
+    "Name": "Wild ARMs - Alter Code F [PlayStation 2 The Best - Reprint]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.01": {
+    "Name": "Minna no Golf 4 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.02": {
+    "Name": "Ratchet & Clank 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.03": {
+    "Name": "Boku no Natsuyasumi 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.04": {
+    "Name": "Gran Turismo 4 - Prologue [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "vuClampMode": 2
+  },
+  "SCPS_193.05": {
+    "Name": "Siren [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.06": {
+    "Name": "Dark Chronicle [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.07": {
+    "Name": "Popolocrois - The First Adventure [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.08": {
+    "Name": "Saru Get You 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.09": {
+    "Name": "Ratchet & Clank 3 - Up Your Arsenal [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.10": {
+    "Name": "Ratchet & Clank [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.11": {
+    "Name": "Saru Get You 3 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.12": {
+    "Name": "Siren [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.13": {
+    "Name": "Wild ARMs - The 4th Detonator [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.15": {
+    "Name": "EyeToy - Play [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.16": {
+    "Name": "Ratchet & Clank [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.17": {
+    "Name": "Ratchet & Clank 2 - Going Commando [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.18": {
+    "Name": "Genji - Dawn of the Samurai [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.19": {
+    "Name": "Minna no Golf 4 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.20": {
+    "Name": "Wanda to Kyozou (Shadow of the Colossus) [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.21": {
+    "Name": "Ratchet & Clank 4th - GiriGiri Gingano Giga-Battle [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.22": {
+    "Name": "Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.23": {
+    "Name": "Wild ARMs - The 4th Detonator [PlayStation 2 The Best - Reprint]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.24": {
+    "Name": "Tourist Trophy - The Real Riding Simulator [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.25": {
+    "Name": "Ape Escape - Million Monkeys [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.26": {
+    "Name": "Siren 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "XgKickHack": 1
+  },
+  "SCPS_193.27": {
+    "Name": "Ape Escape 3 [PlayStation 2 the Best - Reprint]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.28": {
+    "Name": "Ratchet & Clank 4th Girigiri Gingano Giga-battle [PlayStation 2 the Best - Reprint]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.29": {
+    "Name": "Bleach - Blade Battlers [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.30": {
+    "Name": "Bleach - Hanatareshi Yabou [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.31": {
+    "Name": "Bleach - Selected Soul [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_193.32": {
+    "Name": "Minna no Tennis [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.01": {
+    "Name": "Moto GP 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.04": {
+    "Name": "Bravo Music",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.05": {
+    "Name": "Samurai",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.06": {
+    "Name": "Alpine Racer 3",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.08": {
+    "Name": "Wave Rally",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.09": {
+    "Name": "Underwater Unit",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.10": {
+    "Name": "Shikigami no Shiro",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.11": {
+    "Name": "Ragingbless",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.12": {
+    "Name": "Gigantic Drive",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.13": {
+    "Name": "Torneko's Adventure 3",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.14": {
+    "Name": "Ninja Assault",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.15": {
+    "Name": "Super Puzzle Bobble 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_510.16": {
+    "Name": "Space Fishermen",
+    "Region": "NTSC-J",
+    "vuClampMode": 3
+  },
+  "SCPS_550.01": {
+    "Name": "Ico",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "eeClampMode": 2,
+    "vuClampMode": 1
+  },
+  "SCPS_550.02": {
+    "Name": "Zero",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.03": {
+    "Name": "Vampire Night",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SCPS_550.04": {
+    "Name": "Jack & Dexter - The Precursor Legacy",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.05": {
+    "Name": "Gran Turismo - Concept 2001 Tokyo",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.06": {
+    "Name": "Wild ARMs - Advanced 3rd",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.07": {
+    "Name": "Gran Turismo 3 - A-Spec",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.08": {
+    "Name": "Thunderstrike",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.10": {
+    "Name": "Grandia Extreme",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.11": {
+    "Name": "Dual Hearts",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.12": {
+    "Name": "Grandia 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.13": {
+    "Name": "Soul Reaver 2 - Legacy of Kain",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.14": {
+    "Name": "Armored Core 3",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.15": {
+    "Name": "Zettai Zetsumei Toshi",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.16": {
+    "Name": "Jet de Go! 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.17": {
+    "Name": "Tekken 4",
+    "Region": "NTSC-J",
+    "Compat": 3
+  },
+  "SCPS_550.18": {
+    "Name": "Kingdom of Scribbling",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.19": {
+    "Name": "Star Ocean 3 - Till the End of Time",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SCPS_550.20": {
+    "Name": "Kengo 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.21": {
+    "Name": "Super Robot Wars Impact",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.22": {
+    "Name": "Surveillance",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.23": {
+    "Name": "Otostaz",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.24": {
+    "Name": "Armored Core 2 - Another Age",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.25": {
+    "Name": "Eve of Extinction",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.26": {
+    "Name": "Gundam Giren's Ambition",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.27": {
+    "Name": "Runabout 3 - Neo Age",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.28": {
+    "Name": "Popolocrois Story - Hajime no Bouken",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.29": {
+    "Name": "dot Hack - Vol.1",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.30": {
+    "Name": "First Step Victorious Boxers [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.31": {
+    "Name": "Ghost Vibration",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.32": {
+    "Name": "Fantavision - For You and Me",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.35": {
+    "Name": "Ape Escape 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.40": {
+    "Name": "G-Breaker 2 - Doumei no Hangeki",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.41": {
+    "Name": "Memories Off",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.42": {
+    "Name": "dot Hack - Vol.2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.43": {
+    "Name": "Fatal Frame",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.44": {
+    "Name": "Energy Airforce",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.45": {
+    "Name": "Poinie's Poin 3",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.46": {
+    "Name": "Ultraman Fighting Evolution 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.47": {
+    "Name": "Formula One 2002",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.48": {
+    "Name": "Dark Chronicle",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.49": {
+    "Name": "King of Fighters 2000, The",
+    "Region": "NTSC-J"
+  },
+  "SCPS_550.50": {
+    "Name": "Tales of Destiny 2",
+    "Region": "NTSC-J"
+  },
+  "SCPS_559.01": {
+    "Name": "Xenosaga Episode I - Der Wille zur Macht",
+    "Region": "NTSC-J"
+  },
+  "SCPS_559.02": {
+    "Name": "Gran Turismo - Concept 2002 Tokyo-Geneva",
+    "Region": "NTSC-J"
+  },
+  "SCPS_559.03": {
+    "Name": "Gran Turismo - Concept 2002 Tokyo-Geneva",
+    "Region": "NTSC-J"
+  },
+  "SCPS_560.01": {
+    "Name": "Ico",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "eeClampMode": 2,
+    "vuClampMode": 1
+  },
+  "SCPS_560.02": {
+    "Name": "Tekken Tag Tournament",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCPS_560.05": {
+    "Name": "Gran Turismo Concept 2002 Tokyo-Seoul",
+    "Region": "NTSC-K"
+  },
+  "SCPS_560.06": {
+    "Name": "Tekken 4",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCPS_560.08": {
+    "Name": "Fatal Frame",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCPS_560.11": {
+    "Name": "U - Underwater Unit",
+    "Region": "NTSC-J"
+  },
+  "SCPS_560.12": {
+    "Name": "Raw Danger",
+    "Region": "NTSC-K"
+  },
+  "SCPS_560.14": {
+    "Name": "Gungrave",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SCPS_560.15": {
+    "Name": "Ninja Assault",
+    "Region": "NTSC-J"
+  },
+  "SLAJ_250.02": {
+    "Name": "Shinobi",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.03": {
+    "Name": "Unlimited SaGa",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.04": {
+    "Name": "Kingdom Hearts - Final Mix",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.05": {
+    "Name": "World Soccer Winning Eleven 7",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.06": {
+    "Name": "Virtual Fighter 4 - Evolution",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.07": {
+    "Name": "NBA 2K3",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.08": {
+    "Name": "Initial D - Special Stage",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.11": {
+    "Name": "Shin Sangoku Musou 3",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.12": {
+    "Name": "Final Fantasy X-2",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.14": {
+    "Name": "Virtual On - Marz",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.16": {
+    "Name": "Sangokushi Senki 2",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.18": {
+    "Name": "Shutokou Battle 01",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.23": {
+    "Name": "Shin Sangoku Musou 3 - Mushoden",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.26": {
+    "Name": "Kunoichi Shinobi",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.27": {
+    "Name": "Sonic Heroes",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.31": {
+    "Name": "Kunoichi - Shinobu",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.33": {
+    "Name": "Puyo Puyo Fever",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.34": {
+    "Name": "Sakura Taisen - Mysterious Paris",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.35": {
+    "Name": "Sengoku Musou",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.37": {
+    "Name": "Astro Boy Atom",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.39": {
+    "Name": "Beni no Umi 2",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.40": {
+    "Name": "Shin Sangoku Musou 3 - Empires",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.42": {
+    "Name": "Virtua Fighter - Cyber Generation",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.45": {
+    "Name": "Sakura Taisen V - Episode 0",
+    "Region": "NTSC-Ch-J"
+  },
+  "SLAJ_250.46": {
+    "Name": "NBA Live 2005",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.47": {
+    "Name": "Dororo",
+    "Region": "NTSC-Ch-J"
+  },
+  "SLAJ_250.48": {
+    "Name": "Sengoku Musou Mushoden",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.49": {
+    "Name": "Kengo 3",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.51": {
+    "Name": "Lord of the Rings - The Third Age",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.52": {
+    "Name": "Urbz, The - Sims in the City",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.53": {
+    "Name": "Burnout 3 - Takedown",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.55": {
+    "Name": "Def Jam - Fight for N.Y.",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.56": {
+    "Name": "Shining Tears",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.57": {
+    "Name": "Kessen III",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.58": {
+    "Name": "GoldenEye - Rogue Agent",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.59": {
+    "Name": "NBA Street V3",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.60": {
+    "Name": "Project Altered Beast",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.63": {
+    "Name": "Shin Sangoku Mosou 4",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.64": {
+    "Name": "MVP Baseball 2005",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.66": {
+    "Name": "Burnout Revenge - Battle Racing Ignited",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.68": {
+    "Name": "Shin Sangoku Musou 4 - Moushouden",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.72": {
+    "Name": "Matrix, The - Path of Neo",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.73": {
+    "Name": "Resident Evil 4",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.75": {
+    "Name": "Need for Speed - Most Wanted [Black Edition]",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.76": {
+    "Name": "Harry Potter and the Goblet of Fire",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.77": {
+    "Name": "Sengoku Musou 2",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.78": {
+    "Name": "Black",
+    "Region": "NTSC-Unk",
+    "vuClampMode": "0"
+  },
+  "SLAJ_250.79": {
+    "Name": "Shin Sangoku Musou 4 - Empires",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.80": {
+    "Name": "Godfather, The",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.81": {
+    "Name": "FIFA World Cup - Germany 2006",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.84": {
+    "Name": "Sengoku Musou 2 - Empires",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.87": {
+    "Name": "NBA Live '07",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.88": {
+    "Name": "FIFA Soccer 2007",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.91": {
+    "Name": "Need for Speed - Carbon",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.92": {
+    "Name": "Shin Sangoku Musou 4 [PlayStation 2 The Best]",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.93": {
+    "Name": "Sangoku Musou [PlayStation 2 The Best]",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.94": {
+    "Name": "Burnout Dominator",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.95": {
+    "Name": "Medal of Honor - Vanguard",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.96": {
+    "Name": "Musou Orochi",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_250.99": {
+    "Name": "NBA Live '08",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_251.15": {
+    "Name": "World Soccer Winning Eleven 2011",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_350.01": {
+    "Name": "Sakura Wars",
+    "Region": "NTSC-Unk"
+  },
+  "SLAJ_350.03": {
+    "Name": "Sakura Taisen - Atsuki Chishioni Ni",
+    "Region": "NTSC-Unk"
+  },
+  "SLKA_150.03": {
+    "Name": "Shikigami no Shiro II",
+    "Region": "NTSC-K"
+  },
+  "SLKA_150.04": {
+    "Name": "Gunbird - Premium Package",
+    "Region": "NTSC-J"
+  },
+  "SLKA_150.05": {
+    "Name": "Strikers 1945 III",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLKA_150.07": {
+    "Name": "GrowLanser2",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "OPHFLagHack": 1
+  },
+  "SLKA_150.08": {
+    "Name": "Choro Q HG2",
+    "Region": "NTSC-E-F-G"
+  },
+  "SLKA_150.21": {
+    "Name": "GrowLanser3",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "OPHFLagHack": 1
+  },
+  "SLKA_150.32": {
+    "Name": "Gradius V",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_250.12": {
+    "Name": "Devil May Cry 2 Dante",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_250.13": {
+    "Name": "Devil May Cry 2 Lucia",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_250.15": {
+    "Name": "Evolution Skateboarding",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.21": {
+    "Name": "Shinobi",
+    "Region": "NTSC-M3",
+    "Compat": 5
+  },
+  "SLKA_250.24": {
+    "Name": "Lilo & Stitch Experiment",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.26": {
+    "Name": "Chaos Legion",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.33": {
+    "Name": "Gregory Horror Show",
+    "Region": "NTSC-K",
+    "Compat": 1
+  },
+  "SLKA_250.35": {
+    "Name": "Mobile Suit Gundam - Lost War Chronicles",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.38": {
+    "Name": "Gun Survivor 4 - Biohazard - Heroes Never Die",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.41": {
+    "Name": "Armored Core 3 Silent Line",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.42": {
+    "Name": "Tamamayu Monogatari 2 Horobi no Mushi",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.43": {
+    "Name": "Virtua Fighter 4 - Evolution",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_250.46": {
+    "Name": "Dragonball Z",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.48": {
+    "Name": "Makai Senki Disgaea",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_250.49": {
+    "Name": "Metal Slug 3",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.51": {
+    "Name": "Clock Tower 3",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_250.52": {
+    "Name": "Air Ranger 2 - Rescue Helicopter",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.60": {
+    "Name": "I.Q. Remix+ - Intelligent Qube",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.62": {
+    "Name": "Dragonball Z 2",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_250.63": {
+    "Name": "Kaido Battle",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.64": {
+    "Name": "Tenchu 3 Wrath of Heaven",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_250.66": {
+    "Name": "Zone of The Enders 2nd Runner SE",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_250.67": {
+    "Name": "Unlimited Saga",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.70": {
+    "Name": "Guity Gear XX Reload - The Midnight Carnival",
+    "Region": "NTSC-J-K"
+  },
+  "SLKA_250.71": {
+    "Name": "Tantei Jinguji Saburo 8 Inocent Black",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_250.77": {
+    "Name": "Culdicept II - Expansion",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.81": {
+    "Name": "SD Gundam G Generation Neo",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.82": {
+    "Name": "Castlevania Lament of Innocence",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_250.87": {
+    "Name": "FIFA Soccer 2004",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLKA_250.91": {
+    "Name": "Hanjuku Hero vs. 3D",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.92": {
+    "Name": "Onimusha Buraiden",
+    "Region": "NTSC-K"
+  },
+  "SLKA_250.93": {
+    "Name": "Onimusha 3 Demon Siege",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.00": {
+    "Name": "Dragon Quest V Dragon Quarter",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_251.03": {
+    "Name": "Neon Genesis Evangelion 2",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.12": {
+    "Name": "King of Fighters 2001, The",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.15": {
+    "Name": "Rockman X7",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.25": {
+    "Name": "SNK vs. Capcom - Chaos",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.30": {
+    "Name": "Bloody Roar 4",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.31": {
+    "Name": "Project Altered Beast",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.32": {
+    "Name": "Mobile Suit Gundam Encounters in Space",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.33": {
+    "Name": "AirForce Delta Strike",
+    "Region": "NTSC-K",
+    "Compat": 1
+  },
+  "SLKA_251.34": {
+    "Name": "NBA Street v3",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.35": {
+    "Name": "Kunoichi",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_251.39": {
+    "Name": "Fu-un Shinsengumi",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.44": {
+    "Name": "Final Fantasy X-2",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_251.49": {
+    "Name": "Silent Hill 4 The Room",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_251.50": {
+    "Name": "Bujingai",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.52": {
+    "Name": "Hajime no Ippo All-Stars",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.53": {
+    "Name": "Winning Eleven 10 - Liveware Edition",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.59": {
+    "Name": "Astro Boy",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.60": {
+    "Name": "Shin Megami Tensei III - Nocturne Maniax",
+    "Region": "NTSC-K",
+    "eeRoundMode": "0 "
+  },
+  "SLKA_251.65": {
+    "Name": "Mobile Suit Gundam - Seed Destiny - Rengou vs. Z.A.F.T. II Plus",
+    "Region": "NTSC-K",
+    "eeRoundMode": 1,
+    "FpuNegDivHack": 1
+  },
+  "SLKA_251.66": {
+    "Name": "Sengoku Musou",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.67": {
+    "Name": "King of Fighters XI, The",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.70": {
+    "Name": "SD Gundam G Generation Seed",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.71": {
+    "Name": "Guon",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_251.75": {
+    "Name": "Transformers",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.81": {
+    "Name": "Energy Airforce Aim Strike",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.82": {
+    "Name": "Hajime no Ippo2 Victorious Road",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.83": {
+    "Name": "Street Fighter - Anniversary Collection",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.86": {
+    "Name": "King of Fighters, The - Maximum Impact [Limited Edition]",
+    "Region": "NTSC-K"
+  },
+  "SLKA_251.98": {
+    "Name": "Tenchu Kurenai",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_251.99": {
+    "Name": "Kengo 3",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_252.00": {
+    "Name": "SSX 3 [PlayStation 2 - Big Hit Series]",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.01": {
+    "Name": "Armored Core Nexus Evolution DISC1",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.02": {
+    "Name": "Armored Core Nexus Revolution DISC2",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.04": {
+    "Name": "Showdown - Legends of Wrestling",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.05": {
+    "Name": "DragonBall Z 3",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.07": {
+    "Name": "Sakura Taisen V - Episode 0 - Samurai Girl of Wild",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_252.08": {
+    "Name": "From TV Animation - One Piece - Round the Land!",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.13": {
+    "Name": "Berserk",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_252.14": {
+    "Name": "Final Fantasy X - International [PlayStation 2 - Big Hit Series]",
+    "Region": "NTSC-K",
+    "IPUWaitHack": 1
+  },
+  "SLKA_252.15": {
+    "Name": "Shining Wild",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.16": {
+    "Name": "Gitaroo-Man [PlayStation 2 - Big Hit Series]",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.17": {
+    "Name": "Shinging Tears",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.18": {
+    "Name": "Hitman - Contracts",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.19": {
+    "Name": "Monster Hunter G",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_252.21": {
+    "Name": "Busin Zero",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_252.22": {
+    "Name": "Rockman X8",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.24": {
+    "Name": "Detective Saburou Jinguji 9 - Kind of Blue",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.25": {
+    "Name": "Dororo",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_252.27": {
+    "Name": "Neo Contra",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.32": {
+    "Name": "Naruto Naruthimetto Hero International",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_252.33": {
+    "Name": "Sonic - Mega Collection Plus",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.43": {
+    "Name": "Medal of Honor - European Assault",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.44": {
+    "Name": "WWE SmackDown! vs. Raw",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.46": {
+    "Name": "Bard's Tale",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.49": {
+    "Name": "Ys - The Ark of Napishtim [with Guide Book]",
+    "Region": "NTSC-K",
+    "EETimingHack": 1
+  },
+  "SLKA_252.51": {
+    "Name": "Metal Gear Solid 3 - Snake Eater",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.52": {
+    "Name": "Forgotten Realms - Demon Stone",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.54": {
+    "Name": "Digimon Rumble Arena 2",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "FpuCompareHack": 1
+  },
+  "SLKA_252.55": {
+    "Name": "Mobile Suit Gundam - Seed - Never Ending Tomorrow",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.57": {
+    "Name": "Fu-un Bakumatsu Den",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.58": {
+    "Name": "The Story of the Hero Yoshitsune",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_252.59": {
+    "Name": "Swords of Destiny",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.61": {
+    "Name": "Tsukiyo ni Saraba",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.63": {
+    "Name": "NanoBreaker",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLKA_252.65": {
+    "Name": "Devil May Cry 3",
+    "Region": "NTSC-K",
+    "eeRoundMode": "0"
+  },
+  "SLKA_252.66": {
+    "Name": "Sangokushi IX [PlayStation 2 - Big Hit Series]",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.68": {
+    "Name": "Mobile Suit Gundam - Gundam vs. Z-Gundam",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.70": {
+    "Name": "Armored Core - Formula Front",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.75": {
+    "Name": "King of Fighters 2002-2003, The",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.79": {
+    "Name": "Hello Kitty - Rescue Mission",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.80": {
+    "Name": "Ryu ga Gotoku 2 [Disc1of2]",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.81": {
+    "Name": "Ryu ga Gotoku 2 [Disc2of2]",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.84": {
+    "Name": "Sakura Taisen 3",
+    "Region": "NTSC-K",
+    "Compat": 1
+  },
+  "SLKA_252.87": {
+    "Name": "Metal Slug 4&5",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.89": {
+    "Name": "Shin Sangoku Musou 4",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.90": {
+    "Name": "Super Monkey Ball Deluxe",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.91": {
+    "Name": "Chains of Power",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.96": {
+    "Name": "Inuyasha - Feudal Combat",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.97": {
+    "Name": "Taito Memories - Joukan [Special Package]",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.98": {
+    "Name": "Winning Eleven 9",
+    "Region": "NTSC-K"
+  },
+  "SLKA_252.99": {
+    "Name": "From TV Animation - One Piece - Grand Battle! Combat Rush",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.00": {
+    "Name": "Digital Devil Saga [Special Package]",
+    "Region": "NTSC-J-K",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLKA_253.01": {
+    "Name": "Digital Devil Saga - Avatar Tuner 2",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLKA_253.07": {
+    "Name": "Dragonball Z Sparking",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_253.11": {
+    "Name": "Marvel Nemesis - Rise of the Imperfects",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.13": {
+    "Name": "Naruto - Uzumaki Chronicles",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "OPHFLagHack": 1
+  },
+  "SLKA_253.17": {
+    "Name": "Shin Sangoku Musou 3 [PlayStation 2 - Big Hit Series]",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.20": {
+    "Name": "Ikusa Gami",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_253.21": {
+    "Name": "K.League - Winning Eleven 9 - Asia Championship",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.22": {
+    "Name": "Guilty Gear XX - Slash",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.23": {
+    "Name": "SSX On Tour",
+    "Region": "NTSC-J-K"
+  },
+  "SLKA_253.28": {
+    "Name": "Castlevania - Curse of Dakness",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "vuClampMode": "0"
+  },
+  "SLKA_253.29": {
+    "Name": "Shin Sangoku Musou 4 - Moushouden",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.31": {
+    "Name": "Marc Ecko's Getting Up - Contents Under Pressure",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.33": {
+    "Name": "Metal Slug Complete",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.41": {
+    "Name": "Driver - Parallel Lines",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.42": {
+    "Name": "Ryu ga Gotoku",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.51": {
+    "Name": "One Piece Pirates Carnival",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.52": {
+    "Name": "Full Metal Alchemist - Dream Carnival",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.53": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Limited Edition] [Disc1of2]",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_253.54": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Limited Edition] [Disc2of2]",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_253.59": {
+    "Name": "Winning Eleven 9 - Liveware Edition",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.61": {
+    "Name": "Keroro Gunsou MeroMero Battle Royale Z",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.64": {
+    "Name": "Mobile Suit Gundam - Climax U.C.",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.65": {
+    "Name": "WWE Smack Down Vs RAW 2008",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.66": {
+    "Name": "Naruto - Uzumaki Chronicles 2",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "OPHFLagHack": 1
+  },
+  "SLKA_253.75": {
+    "Name": "Transformers - The Game",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.81": {
+    "Name": "Winning Eleven 10",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.84": {
+    "Name": "Blazing Souls",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.88": {
+    "Name": "One Piece - Grand Adventure",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_253.89": {
+    "Name": "Shinobido Imashime",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "eeClampMode": "3 "
+  },
+  "SLKA_253.90": {
+    "Name": "Shin Sangoku Musou 4 - Empires",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.96": {
+    "Name": "FIFA '07",
+    "Region": "NTSC-K"
+  },
+  "SLKA_253.97": {
+    "Name": "Dragon Ball Z Sparking NEO",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_254.06": {
+    "Name": "King of Fighters, The - Maximum Impact - Regulation A",
+    "Region": "NTSC-K"
+  },
+  "SLKA_254.07": {
+    "Name": "DragonBall Z - Sparkling! Meteor",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_254.13": {
+    "Name": "SD Gundam G - Generation Spirits",
+    "Region": "NTSC-K"
+  },
+  "SLKA_254.22": {
+    "Name": "Silent Hill - Origins",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_254.24": {
+    "Name": "SNK Arcade Classics Vol.1",
+    "Region": "NTSC-K"
+  },
+  "SLKA_254.43": {
+    "Name": "Musou Orochi Maou Sairin",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_254.77": {
+    "Name": "World Soccer Winning Eleven 2011",
+    "Region": "NTSC-K"
+  },
+  "SLKA_254.80": {
+    "Name": "World Soccer Winning Eleven 2012",
+    "Region": "NTSC-K"
+  },
+  "SLKA_350.01": {
+    "Name": "Metal Gear Solid 2 Substance",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_350.03": {
+    "Name": "Sakura Taisen - Atsuki Chishioni",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_350.04": {
+    "Name": "Sakura Wars 5 So Long My Love",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLKA_350.05": {
+    "Name": "Shin Sangoku Musou 5 Special",
+    "Region": "NTSC-K"
+  },
+  "SLPM_550.05": {
+    "Name": "Mana Khemia 2: Ochita Gakuen to Renkinjutsushi Tachi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_550.08": {
+    "Name": "Sengoku Basara X",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_550.33": {
+    "Name": "J. League Winning Eleven 2008 - Club Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPM_550.96": {
+    "Name": "ThunderForce VI",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_551.08": {
+    "Name": "Fate - Unlimited Codes",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "eeRoundMode": "0"
+  },
+  "SLPM_551.10": {
+    "Name": "Mercenaries 2 - World in Flames",
+    "Region": "NTSC-J"
+  },
+  "SLPM_551.14": {
+    "Name": "Mana Khemia 2: Ochita Gakuen to Renkinjutsushi Tachi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_551.20": {
+    "Name": "Fukakutei Sekai no Tantei Shinshi - Agyou Souma no Jiken File",
+    "Region": "NTSC-J"
+  },
+  "SLPM_551.22": {
+    "Name": "Sengoku Musou 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_551.27": {
+    "Name": "Need for Speed - Undercover",
+    "Region": "NTSC-J"
+  },
+  "SLPM_551.31": {
+    "Name": "World Soccer Winning Eleven 2009",
+    "Region": "NTSC-J"
+  },
+  "SLPM_551.48": {
+    "Name": "007: Nagusame no Houshuu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_551.82": {
+    "Name": "J. League Winning Eleven 2009 - Club Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPM_551.84": {
+    "Name": "Melty Blood - Actress Again",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_552.26": {
+    "Name": "FIFA 10: World Class Soccer",
+    "Region": "NTSC-J"
+  },
+  "SLPM_552.44": {
+    "Name": "Need for Speed - Undercover [EA:SY! 1980]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_552.51": {
+    "Name": "WWE SmackDown vs. Raw 2009",
+    "Region": "NTSC-J"
+  },
+  "SLPM_552.58": {
+    "Name": "World Soccer Winning Eleven 2010 - Aoki Samurai no Chousen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_552.62": {
+    "Name": "J.League Winning Eleven 2010 - Club Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPM_552.71": {
+    "Name": "FIFA 10: World Class Soccer (EA:SY! 1980)",
+    "Region": "NTSC-J"
+  },
+  "SLPM_552.76": {
+    "Name": "World Soccer Winning Eleven 2011",
+    "Region": "NTSC-J"
+  },
+  "SLPM_552.80": {
+    "Name": "The King of Fighters '98 Ultimate Match",
+    "Region": "NTSC-J"
+  },
+  "SLPM_601.01": {
+    "Name": "0 Story",
+    "Region": "NTSC-J"
+  },
+  "SLPM_601.02": {
+    "Name": "From Software First Previews",
+    "Region": "NTSC-J"
+  },
+  "SLPM_601.04": {
+    "Name": "Konami PlayStation 2 Taikeban",
+    "Region": "NTSC-J"
+  },
+  "SLPM_601.06": {
+    "Name": "Koei PlayStation 2 Line-Up",
+    "Region": "NTSC-J"
+  },
+  "SLPM_601.07": {
+    "Name": "Golf Paradise",
+    "Region": "NTSC-J"
+  },
+  "SLPM_601.72": {
+    "Name": "Itadaki Street 3 - Okuman Chouja ni Shiteageru",
+    "Region": "NTSC-J"
+  },
+  "SLPM_602.07": {
+    "Name": "Rockman X7",
+    "Region": "NTSC-J"
+  },
+  "SLPM_602.51": {
+    "Name": "Devil May Cry 3 [Trial Version]",
+    "Region": "NTSC-J",
+    "eeRoundMode": "0"
+  },
+  "SLPM_602.62": {
+    "Name": "10th Anniversary Memorial Save Data [Disc 2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_602.65": {
+    "Name": "10th Anniversary PlayStation & PlayStation 2 All-Soft Catalogue Special SaveData Collection [PS2 Disc]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_611.47": {
+    "Name": "Xenosaga Episode III - Also Sprach Zarathustra [Demo]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.01": {
+    "Name": "Drum Mania",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.02": {
+    "Name": "Live World Soccer 2000",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.04": {
+    "Name": "Mahjong Yarouze 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.05": {
+    "Name": "Shin Sangokumusou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.06": {
+    "Name": "Eisei Meijin 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.07": {
+    "Name": "Gradius III & IV",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_620.08": {
+    "Name": "Powerful Pro Baseball 7",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.09": {
+    "Name": "Ganbare Nippon Olympics 2000",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.10": {
+    "Name": "Romance of the Three Kingdoms VII",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.11": {
+    "Name": "Jikkyou GI Stable",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.12": {
+    "Name": "Keyboard Mania",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.13": {
+    "Name": "Ring of Red",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.15": {
+    "Name": "Silpheed - The Lost Planet",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_620.16": {
+    "Name": "Super Bust-A-Move",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_620.21": {
+    "Name": "Angelique Trois [Premium Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.22": {
+    "Name": "Angelique Trois",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.23": {
+    "Name": "Winback",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.27": {
+    "Name": "Snowboard Heaven",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.28": {
+    "Name": "Greatest Striker",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.29": {
+    "Name": "Dance Summit 2001",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_620.31": {
+    "Name": "Primal Image for Printer",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.32": {
+    "Name": "ESPN NBA 2Night",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.35": {
+    "Name": "Got to Do! Hot Spring Table Tennis",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.36": {
+    "Name": "Choukousoku Reversi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.40": {
+    "Name": "J League Winning Eleven 8 - Asia Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.41": {
+    "Name": "ESPN National Hockey Night",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.44": {
+    "Name": "RC Revenge Pro",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.45": {
+    "Name": "Jikkou J. League Perfect Striker 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.46": {
+    "Name": "WTA Tennis Tour USA",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_620.47": {
+    "Name": "Endnesia",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.48": {
+    "Name": "Battle Gear 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.49": {
+    "Name": "Densha de Go! 3 - Takkyuu!!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.51": {
+    "Name": "Yanya Caballista - featuring Gawoo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.52": {
+    "Name": "Beatmania Da! Da! Da!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.53": {
+    "Name": "World Soccer Winning Eleven 5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.54": {
+    "Name": "Eternity Master V",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.55": {
+    "Name": "Bloody Roar 3",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_620.56": {
+    "Name": "DNA - Dark Native Apostle",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.60": {
+    "Name": "Winning Post 4 Maximum 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.62": {
+    "Name": "Gitaroo Man One",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.63": {
+    "Name": "Gradius III & IV [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.67": {
+    "Name": "Hunter X Hunter - Ryumyaku no Saidan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.68": {
+    "Name": "Egbrowser",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.69": {
+    "Name": "All-Star Baseball 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.70": {
+    "Name": "Uchu-Jintte Naani",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.72": {
+    "Name": "Horse Breaker",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.73": {
+    "Name": "Tam Tam Paradise",
+    "Region": "NTSC-J",
+    "Compat": 1
+  },
+  "SLPM_620.75": {
+    "Name": "Live World Soccer 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.76": {
+    "Name": "Age of Empires II - The Age of Kings",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.77": {
+    "Name": "Maestro Music 2, The",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.78": {
+    "Name": "Maestro Music 2, The",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.81": {
+    "Name": "Ever Blue",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_620.82": {
+    "Name": "Professional Baseball Japan 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.84": {
+    "Name": "ESPN X-Games Skateboarding",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.87": {
+    "Name": "Touge 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.88": {
+    "Name": "J-League Winning Eleven 5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.91": {
+    "Name": "Ring of Red",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.92": {
+    "Name": "XG3 Extreme G Racing",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.94": {
+    "Name": "Simple 2000 Series Vol. 2 - The Party Game",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.95": {
+    "Name": "Flying Circus [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.96": {
+    "Name": "Flying Circus",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.97": {
+    "Name": "Keisusaikan, The - Shinjuku 24 Hours",
+    "Region": "NTSC-J"
+  },
+  "SLPM_620.98": {
+    "Name": "Busin - Wizardry Alternative",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.00": {
+    "Name": "Rez [Special Package]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.01": {
+    "Name": "Rez",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_621.02": {
+    "Name": "Crazy Taxi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.04": {
+    "Name": "Choro-Q HG2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.07": {
+    "Name": "Growlanser 3 - The Duel Darkness",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_621.08": {
+    "Name": "Growlanser 3 - The Duel Darkness",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_621.09": {
+    "Name": "Hippa Linda",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.12": {
+    "Name": "Itadaki Street 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.13": {
+    "Name": "World Soccer Winning Eleven 5 - Final Evolution",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.17": {
+    "Name": "Momotaro Train X",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.18": {
+    "Name": "Bomberman Kart",
+    "Region": "NTSC-J",
+    "Compat": 1
+  },
+  "SLPM_621.20": {
+    "Name": "Jikkyou World Soccer 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.21": {
+    "Name": "ESPN NBA 2Night 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.22": {
+    "Name": "Hermina to Culus - Lilie no Atelier Mou Hitotsu no Monogatari",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.23": {
+    "Name": "Winning Post 5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.24": {
+    "Name": "Ready 2 Rumble Boxing - Round 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.25": {
+    "Name": "Gauntlet - Dark Legacy",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.27": {
+    "Name": "Maximo",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_621.28": {
+    "Name": "Le Mans 24 Hours",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.29": {
+    "Name": "Climax Tennis - WTA Tour Edition",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.30": {
+    "Name": "Virtua Fighter 4",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_621.31": {
+    "Name": "Romance of the Three Kingdoms VIII",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.32": {
+    "Name": "24 - The Game",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.33": {
+    "Name": "Bloody Roar 3 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.34": {
+    "Name": "Final Fantasy XI [Beta Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.37": {
+    "Name": "Psyvariar Complete Edition [Special Sound Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.38": {
+    "Name": "Psyvariar Complete Edition [Special Capture Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.39": {
+    "Name": "Psyvariar Complete Edition",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_621.42": {
+    "Name": "World Grand Prix",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.43": {
+    "Name": "Hakoniwa Tetsudou - Blue Train Express",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.44": {
+    "Name": "Super Bust-A-Move",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.47": {
+    "Name": "Bass Strike",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.51": {
+    "Name": "Live GI Stable 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.53": {
+    "Name": "Racing Construction - Mareru Tsukeru Hahiiru Ore - Dead Heat",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.54": {
+    "Name": "DDR Max - Dance Dance Revolution - 6th Mix",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_621.55": {
+    "Name": "Baseball 2002, The",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.57": {
+    "Name": "Building Baku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.58": {
+    "Name": "Virtua Fighter 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.59": {
+    "Name": "World Soccer Winning Eleven 6",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.61": {
+    "Name": "Generation of Chaos - Next [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.64": {
+    "Name": "Generation of Chaos - Next",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.65": {
+    "Name": "Shikigami no Shiro [Limited Edition]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_621.68": {
+    "Name": "Disney Golf Classics",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.69": {
+    "Name": "Live World Soccer 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.71": {
+    "Name": "Simple 2000 Series Vol.05 - The Blockbuster Hyper",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.75": {
+    "Name": "Beatmania Utsu Utsu Utsu! [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.76": {
+    "Name": "Egbrowser BB",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.77": {
+    "Name": "Kuusen [Kadokawa The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.80": {
+    "Name": "Simple 2000 Series Vol.01 - The Shougi",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_621.82": {
+    "Name": "Top Gun - Ace of the Sky",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.85": {
+    "Name": "San Goku Shi VII",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.86": {
+    "Name": "Get Backers - The Stolen City of Infinite",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.90": {
+    "Name": "High Heat - Major League Baseball 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.93": {
+    "Name": "J League Perfect Striker 5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.97": {
+    "Name": "Simple 2000 Series Vol.07 - The Real Fist Fighter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.98": {
+    "Name": "Simple 2000 Series Vol.04 - The Mahjong",
+    "Region": "NTSC-J"
+  },
+  "SLPM_621.99": {
+    "Name": "Dragon Quest Characters - Toruneko no Daibouken 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.00": {
+    "Name": "Horse Breaker",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.01": {
+    "Name": "Winback",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.02": {
+    "Name": "Winning Post 4 Maximum 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.03": {
+    "Name": "Dog of Bay",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.04": {
+    "Name": "LEGO Racers 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.05": {
+    "Name": "Virtua Cop Re-Birth",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_622.06": {
+    "Name": "Growlanser 2 [Atlus The Best]",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_622.07": {
+    "Name": "Simple 2000 Series Vol.09 - Bittersweet Fools",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.09": {
+    "Name": "Gigantic Drive",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.11": {
+    "Name": "18 Wheeler",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.12": {
+    "Name": "Critical Bullet - Seventh Target",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.13": {
+    "Name": "Ultimate Fighting Championship 2 - Tap-Out",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.14": {
+    "Name": "Ever Blue 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.15": {
+    "Name": "Virtua Cop Re-Birth",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.16": {
+    "Name": "Ever Blue [CapKore The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.17": {
+    "Name": "J League Winning Eleven 6",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.18": {
+    "Name": "Simple 2000 Series Vol.10 - The Table Game Sekai-Hen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.19": {
+    "Name": "Simple 2000 Series Vol.08 - The Tennis",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.21": {
+    "Name": "Winning Post 5 - Max 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.23": {
+    "Name": "Simple 2000 Series Vol.11 - The Off-Road Buggy",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.24": {
+    "Name": "Simple 2000 Series Ultimate Vol.3 - Saisoku! Zokusha King - Buchigiri Densetsu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.25": {
+    "Name": "Nobunaga no Yabou Arashi Seiki [with Power-Up Kit]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.27": {
+    "Name": "Marvel vs. Capcom 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_622.28": {
+    "Name": "Slipheed - The Lost Planet",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.29": {
+    "Name": "Super Puzzle Bobble 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.30": {
+    "Name": "Silent Scope 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.32": {
+    "Name": "Simple 2000 Series Vol.15 - The Rugby",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.33": {
+    "Name": "Simple 2000 Series Ultimate Vol.4 - Urawaza Ikasa Majangai-Niisan Tsukanjimattayodane",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.34": {
+    "Name": "Simple2000 Vol.13 The Renai Adv Garasu No Mori",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.35": {
+    "Name": "GetBass Battle",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.36": {
+    "Name": "Power Smash 2",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_622.37": {
+    "Name": "Gakuen Toshi Vara Noir [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.38": {
+    "Name": "Gakuen Toshi Vara Noir",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.39": {
+    "Name": "Supercar Street Challenge",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.44": {
+    "Name": "Choro Q - High Grade 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.45": {
+    "Name": "Yuusei Kara no Buttai - Episode 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.47": {
+    "Name": "Shin Contra",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.48": {
+    "Name": "Simple 2000 Series Vol.05 - The Love Mahjong",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.49": {
+    "Name": "Hello Kitty Star Light - Inogasi Cube",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.50": {
+    "Name": "Hello Kitty Star Light - Fusiginasekai",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.51": {
+    "Name": "Simple 2000 Series Vol.14 - The Billiard",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.52": {
+    "Name": "Simple 2000 Series Vol.17 - The Suiri-Aratanaru 20 no Jikenbo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.53": {
+    "Name": "Simple 2000 Series Vol.16 - The Sniper",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.54": {
+    "Name": "Kaerazu no Mori",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.55": {
+    "Name": "NBA Starting Five",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.56": {
+    "Name": "Super Trucks",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.57": {
+    "Name": "Rally Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.58": {
+    "Name": "GTC Africa",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.60": {
+    "Name": "DogStation",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.61": {
+    "Name": "DogStation",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.62": {
+    "Name": "GI Jockey 2 [Koei the best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.63": {
+    "Name": "Snowboard Heaven",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.64": {
+    "Name": "Shin Contra",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.65": {
+    "Name": "Power Smash 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.66": {
+    "Name": "Momotaro Densetsu XI",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.68": {
+    "Name": "Winning Eleven 6 - Final Evolution",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_622.69": {
+    "Name": "Akagi - Yami ni Oritattatensai",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.70": {
+    "Name": "Simple 2000 Series Vol.19 - The Love Simulation - The Coffee Shop",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.71": {
+    "Name": "Simple 2000 Series Vol.20 - The Dungeon RPG",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.72": {
+    "Name": "Simple 2000 Series Vol.18 - The Party Sugoroku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.73": {
+    "Name": "Mai-Shin 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.74": {
+    "Name": "Powerful Pro Baseball 9 Ketteiban",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.75": {
+    "Name": "Space Raiders",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.76": {
+    "Name": "Get Backers - All Members Gather",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.77": {
+    "Name": "GI Jockey 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.78": {
+    "Name": "Hunter x Hunter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.79": {
+    "Name": "Winning Post 5 - Maximum 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.82": {
+    "Name": "Silent Scope 2 - Innocent Sweeper",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.84": {
+    "Name": "Europe Games Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.85": {
+    "Name": "Waku Waku Volley 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_622.87": {
+    "Name": "Fire Pro Wrestling Z [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.88": {
+    "Name": "Pop'n Music - Best Hits",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.91": {
+    "Name": "Bomberman Land 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.92": {
+    "Name": "Warrior Blade - Rasten vs. Barbarian",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.94": {
+    "Name": "Simple 2000 Series Vol.21 - The Moonlight Tale RPG",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.95": {
+    "Name": "Simple 2000 Series Vol.22 - The Densha de Go! Commuter Train Version",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.96": {
+    "Name": "Simple 2000 Series Vol.05 - Love Upper Boxing",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.97": {
+    "Name": "Got To Do! Hot Spring Table Tennis",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.98": {
+    "Name": "PuchiCopter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_622.99": {
+    "Name": "Winback [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.00": {
+    "Name": "Horse Breaker [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.01": {
+    "Name": "Aerobics Revolution",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.05": {
+    "Name": "Othello [SuperLite 2000]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.07": {
+    "Name": "Simple 2000 Series Vol.26 - The Paintball X 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.08": {
+    "Name": "Simple 2000 Series Vol.24 - The Bowling",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.10": {
+    "Name": "Souten Ryuu - The Arcade",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.14": {
+    "Name": "Simple 2000 Series Vol.07 - Saikyou! Shiro Biking Security Police",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.15": {
+    "Name": "Pepit Copter [with Controller]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.16": {
+    "Name": "Table Mahjong [Superlite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.18": {
+    "Name": "XII Stag",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.19": {
+    "Name": "Romance of the Three Kingdoms VIII",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.21": {
+    "Name": "Robocop",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.22": {
+    "Name": "Conveti 3, The",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.24": {
+    "Name": "Simple 2000 Series Vol.08 - Gekido! Merio King",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.25": {
+    "Name": "High Heat Major League Baseball 2003 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.26": {
+    "Name": "G-Taste Mahjong [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.27": {
+    "Name": "G-Taste Mahjong",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.28": {
+    "Name": "Simple 2000 Series Vol.27 - The Pro Yakyuu 2003 Pennent Race",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.34": {
+    "Name": "Simple 2000 Series Vol.29 - The Nenai Board Game",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.35": {
+    "Name": "Simple 2000 Series Vol.28 - The Bushido - Tsujigiri Ichidai",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.36": {
+    "Name": "Simple 2000 Series Vol.44 - The First Step RPG",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.37": {
+    "Name": "Simple 2000 Series Vol.30 - The Basketball - 3-on-3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.38": {
+    "Name": "Ishikura Noboru no Igo Kouza",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.39": {
+    "Name": "Kikou Heidai - J-Pheonix 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.40": {
+    "Name": "Apprentice Magician",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.41": {
+    "Name": "Alice's Adventures in Wonderland",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.42": {
+    "Name": "Fire Pro Wrestling Z",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_623.43": {
+    "Name": "Simple 2000 Series Vol.34 - Love Horror Adventure",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.44": {
+    "Name": "Simple 2000 Series Vol.31 - The Chikyuu Boueigun",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.45": {
+    "Name": "Simple 2000 Series Vol.32 - The Tank",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.48": {
+    "Name": "Run-Dim Mechsmith",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.49": {
+    "Name": "Welcome to Universal Studios Japan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.50": {
+    "Name": "Hudson Selection Vol.2 - Star Soldier",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.53": {
+    "Name": "Simple 2000 Series Vol.33 - The Jet Coaster - Yuuenchi Otsukkurou!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.54": {
+    "Name": "Space Invaders 25th Anniversary",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.55": {
+    "Name": "Choro Q - High Grade 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.56": {
+    "Name": "World Soccer Winning Eleven 7",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_623.62": {
+    "Name": "Sega Ages 2500 Series Vol.01 - Phantasy Star",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_623.64": {
+    "Name": "Sega Ages 2500 Series Vol.02 - Monaco GP",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.65": {
+    "Name": "Cardinal Arc - Konton no Fuusatsu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.66": {
+    "Name": "Sega Ages 2500 Series Vol.03 - Fantasy Zone",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_623.67": {
+    "Name": "Sega Ages 2500 Series Vol.01 - Phantasy Star [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.69": {
+    "Name": "Karaoke Revolution - J-Pop Vol.1",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.70": {
+    "Name": "Psyvariar Medium Unit [Superlite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.71": {
+    "Name": "Psyvariar Revision [Superlite 2000 Series]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_623.73": {
+    "Name": "Simple 2000 Series Vol.35 - The Helicopter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.74": {
+    "Name": "Simple 2000 Series Ultimate Vol.12 - Street Golfer",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.75": {
+    "Name": "Simple 2000 Series Vol.36 - The Musume Ikusei Simulation",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.76": {
+    "Name": "Get Backers - All Members Gather [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.77": {
+    "Name": "Get Backers Dakkanoku - Ubawareta Mugenshiro [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.78": {
+    "Name": "Bakusou Convoy Densetsu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.79": {
+    "Name": "Karaoke Revolution - J-Pop Vol.2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.80": {
+    "Name": "Karaoke Revolution - J-Pop Vol.3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.81": {
+    "Name": "Karaoke Revolution - J-Pop Vol.4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.82": {
+    "Name": "Karaoke Revolution - Love & Ballad",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_623.83": {
+    "Name": "Karaoke Revolution - Night Selection 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.84": {
+    "Name": "Sega Ages 2500 Series Vol.04 - Space Harrier",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.85": {
+    "Name": "Sega Ages 2500 Series Vol.05 - Golden Axe",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_623.89": {
+    "Name": "Big Bass - Bass Tsuri Kanzen Kouryaku [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.90": {
+    "Name": "Ichigeki Sacchuu! HoiHoi-san [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.91": {
+    "Name": "Ichigeki Sacchuu! HoiHoi-san",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.92": {
+    "Name": "G1 Jockey 3 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.94": {
+    "Name": "Power Smash 2 [Sega The Best - 2800 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.95": {
+    "Name": "Simple 2000 Series Vol.37 - The Shooting - Double Shienryu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_623.97": {
+    "Name": "Simple 2000 Honkaku Shikou Vol.5 - Kiryoku Kentei",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.00": {
+    "Name": "Sega Ages 2500 Series Vol.12 - Puyo Puyo Tsu Perfect Set",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.01": {
+    "Name": "Death Crimson OX+",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.03": {
+    "Name": "Chou Aniki - Seinaru Protein Densetsu",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.04": {
+    "Name": "Hudson Selection Vol.1 - Cubic Lode Runner",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.06": {
+    "Name": "Kurogane no Houkou - Warship Commander [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.07": {
+    "Name": "Hisako Takahashi's Let's Marathon!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.08": {
+    "Name": "Harry Potter - Quidditch World Cup",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.09": {
+    "Name": "Wizardry Empire III - Ancestry of the Emperor",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.10": {
+    "Name": "Silent Scope 3 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.12": {
+    "Name": "Simple 2000 Series Vol.41 - The Volleyball",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.13": {
+    "Name": "Kuusen 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.14": {
+    "Name": "Karaoke Revolution - Dreams & Memories",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.15": {
+    "Name": "G1 Jockey 2 [Koei Teiban Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.16": {
+    "Name": "Momotaro Densetsu XII - West Japan Hen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.17": {
+    "Name": "Hudson Selection Vol.2 - Sakigake!! Kuromati Koukou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.18": {
+    "Name": "Hudson Selection Vol.3 - PC Genjin",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.22": {
+    "Name": "Hudson Selection Vol.4 - Adventure Island (Takahashi Meijin no Bouken Jima)",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.23": {
+    "Name": "Tetris Kiwamemichi [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.24": {
+    "Name": "Suku Suku Inufuku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.25": {
+    "Name": "Sega Ages 2500 Series Vol.07 - Columns",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.26": {
+    "Name": "Simple 2000 Series Vol.42 - The Ultimate Fight",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.27": {
+    "Name": "Dance Dance Revolution - Party Collection",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.28": {
+    "Name": "Kiwame Mahjong DXII - The 4th Mondo 21 Cup Competition",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.29": {
+    "Name": "Simple 2000 Series Vol.15 - The Love Ping Pong",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.30": {
+    "Name": "Simple 2000 Series Vol.43 - The Saiban",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.32": {
+    "Name": "Sega Ages 2500 Series Vol.11 - Hokuto no Ken",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.33": {
+    "Name": "Sega Ages 2500 Series Vol.06 - Bonanza Brothers",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.37": {
+    "Name": "Suisui Sweet - Amai Ai no Mitsukekata",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.38": {
+    "Name": "Growlanser Collection",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_624.40": {
+    "Name": "Growlanser III [Atlus The Best]",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_624.42": {
+    "Name": "Youkoso Hitsuji-Mura",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.43": {
+    "Name": "Sega Ages 2500 Series Vol.08 - Virtua Racing",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.44": {
+    "Name": "Sega Ages 2500 Series Vol.15 - Decathlete Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.45": {
+    "Name": "Sega Ages 2500 Series Vol.09 - Gain Ground",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.46": {
+    "Name": "Sega Ages 2500 Series Vol.10 - Afterburner II",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.47": {
+    "Name": "Sega Ages 2500 Series Vol.13 - Outrun",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.48": {
+    "Name": "Crossword [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.49": {
+    "Name": "Tom & Jerry - War of the Whiskers",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.50": {
+    "Name": "Karaoke Revolution - Anime Song Selection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.51": {
+    "Name": "Karaoke Revolution - J-Pop Vol.5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.53": {
+    "Name": "G-Taste Mahjong",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.54": {
+    "Name": "Karaoke Revolution - J-Pop Vol.6",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.55": {
+    "Name": "Karaoke Revolution - J-Pop Vol.7",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.56": {
+    "Name": "Karaoke Revolution - J-Pop Vol.8",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.57": {
+    "Name": "Karaoke Revolution - Snow & Party",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.58": {
+    "Name": "Daisan Teikoku Koubouki - Aufstieg und Fall des dritten Reiches",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.59": {
+    "Name": "Simple 2000 Series Vol.16 - Sengoku vs. Gendai",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.60": {
+    "Name": "Kakoniwa Tetsudou - Blue Train Tokkyuuhen [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.61": {
+    "Name": "Shikigami no Shiro II",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_624.62": {
+    "Name": "Gradius V",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.63": {
+    "Name": "Loop Sequencer - Music Generator",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.64": {
+    "Name": "Pop'n Taisen Pazurudame Online",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.65": {
+    "Name": "LeMans 24 Hours [Sega The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.66": {
+    "Name": "Zooo [Superlite 2000 Series]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.67": {
+    "Name": "Simple 2000 Series Vol.18 - Love Aerobics",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.68": {
+    "Name": "Simple 2000 Series Vol.17 - Taisen! Bakudan Poy Poy",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.69": {
+    "Name": "Gunbird 1&2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.71": {
+    "Name": "Uno [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.72": {
+    "Name": "Diet Channel",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.73": {
+    "Name": "Nobunaga no Yabou - Ranseiki [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.74": {
+    "Name": "Simple 2000 Series Vol.46 - The Kanji Quiz - Challenge! Kanji Kentei",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.75": {
+    "Name": "Momotaro Densetsu XI [Hudson The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.76": {
+    "Name": "Get Backers Dakkanoku - Ura Shinjuku Saikyou Battle",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.77": {
+    "Name": "Simple 2000 Series Vol.47 - The Gassen Sekigahara",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.78": {
+    "Name": "Bomberman Kart DX",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.79": {
+    "Name": "Karaoke Revolution - J-Pop Vol.9",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.80": {
+    "Name": "Hot Gimmick Cosplay Mahjong [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.81": {
+    "Name": "Waku Waku Volleyball 2 [Superlite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.82": {
+    "Name": "Pachinko Slot Tokodensho - Inoki Festival",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.83": {
+    "Name": "Simple 2000 Series Vol.48 - The Taxi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.84": {
+    "Name": "Simple 2000 Series Vol.50 - The Daibijin",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.85": {
+    "Name": "Simple 2000 Series Vol.49 - The World Champ Dodgeballer",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.86": {
+    "Name": "Chou Saisoku! Zokusha King B.U. [Simple Series DX]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.88": {
+    "Name": "Hot Gimmick Cosplay Mahjong",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.89": {
+    "Name": "Yoshinoya",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.90": {
+    "Name": "Dragon Quest VIII [Premium Disc]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.91": {
+    "Name": "RockMan Power Battle Fighters",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.92": {
+    "Name": "Karaoke Revolution - Kids Song Selection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.93": {
+    "Name": "Simple 2000 Series Vol.54 - The Daikiju",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.94": {
+    "Name": "Simple 2000 Series Vol.55 - The Cat Fight",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_624.95": {
+    "Name": "Simple 2000 Series Vol.53 - The Camera Kozo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.96": {
+    "Name": "Simple 2000 Series Vol.52 - The Space Raiders",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.97": {
+    "Name": "Simple 2000 Series Vol.51 - The Battleship",
+    "Region": "NTSC-J"
+  },
+  "SLPM_624.99": {
+    "Name": "Tetuya Digest",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.00": {
+    "Name": "Sega Ages 2500 Series Vol.14 - Alien Syndrome",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.01": {
+    "Name": "Assault Suits Valken Zero",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.02": {
+    "Name": "Nobunaga Senki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.03": {
+    "Name": "Bomberman Battles",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.04": {
+    "Name": "Simple 2000 Series Vol.56 - The Survival Game",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.05": {
+    "Name": "Fukuhara Love Ping Pong",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.06": {
+    "Name": "Vampire Panic",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.08": {
+    "Name": "Simple 2000 Series Vol.57 - The Baseball 2004",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.09": {
+    "Name": "Simple 2000 Series Vol.58 - The Surgeon",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.10": {
+    "Name": "Simple 2000 Series Vol.60 - The Tokusatsu Henshin Hero",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_625.11": {
+    "Name": "Victory Wings - Zero Pilot Series",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.12": {
+    "Name": "Keiei Simulation - Jurassic Park [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.13": {
+    "Name": "Harry Potter and the Chamber of Secrets [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.14": {
+    "Name": "Sim People [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.15": {
+    "Name": "Psikyo Shooting Collection Vol.1 - Strikers 1945 1&2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_625.16": {
+    "Name": "EyeToy Sports - Let's Play Sports!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.17": {
+    "Name": "Winning Post 5 [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.18": {
+    "Name": "Teitoku no Ketsudan 4 [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.19": {
+    "Name": "Sangokushi VIII [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.21": {
+    "Name": "Kiwame Mahjong DXII - The 4th Mondo 21 Cup Competition [Athena Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.23": {
+    "Name": "Shikigami no Shiro [Taito The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.24": {
+    "Name": "Simple 2000 Series Vol.59 - The Uchyujin to Hanashi Sou!",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_625.25": {
+    "Name": "Simple 2000 Series Vol.61 - The O-Ane-Chan Bara",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_625.26": {
+    "Name": "Giant Robo - The Animation",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.28": {
+    "Name": "Karaoke Revolution - Kazoku Idol Sengen [with Microphone]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.29": {
+    "Name": "Karaoke Revolution - Kazoku Idol Sengen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.30": {
+    "Name": "Gradius III & IV [Konami Dendou Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.31": {
+    "Name": "Mahjong Yarouze! 2 [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.32": {
+    "Name": "Ys III - Wanderers from Ys [Limited Edition]",
+    "Region": "NTSC-J",
+    "Compat": 2
+  },
+  "SLPM_625.34": {
+    "Name": "Simple 2000 Series Vol.63 - Women's Swim Meet",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_625.36": {
+    "Name": "G1 Jockey 3 [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.37": {
+    "Name": "Star Wars - Starfighter [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.38": {
+    "Name": "Kyoushuu Kidou Butai - Kougeki Helicopter Senki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.39": {
+    "Name": "Chess Champion [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.40": {
+    "Name": "Super Husaru [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.41": {
+    "Name": "Super Bowling [Superlite 2000 Series Sports]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.42": {
+    "Name": "Simple 2000 Series Vol.20 - The Love Mahjong 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.43": {
+    "Name": "Simple 2000 Series Vol.65 - The Kyonshi Panic",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.44": {
+    "Name": "Simple 2000 Series Vol.19 - Akagi Yama ni Oritattatensai",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.45": {
+    "Name": "Simple 2000 Series Vol.64 - Splatter Action",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_625.46": {
+    "Name": "Sangokushi VII [Koei Collection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.47": {
+    "Name": "Sega Ages 2500 Series Vol.16 - Virtua Fighter 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_625.48": {
+    "Name": "Heisei Bakutoden [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.49": {
+    "Name": "Otona no Gal - Kimi ni Hane Man [Jaleco The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.50": {
+    "Name": "Wizardry Empire III - Ancestry of the Emperor [Good Price - Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.51": {
+    "Name": "Wizardry Empire III - Ancestry of the Emperor [Good Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.52": {
+    "Name": "Super Shanghai 2005",
+    "Region": "NTSC-J",
+    "Compat": 2
+  },
+  "SLPM_625.53": {
+    "Name": "Sega Ages 2500 Series Vol.17 - Phantasy Star Generation 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_625.54": {
+    "Name": "EyeToy - Sega Superstars [with Camera]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.55": {
+    "Name": "Momotaro Densetsu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.56": {
+    "Name": "Simple 2000 Series Vol.66 - Brain Power Puzzles",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.57": {
+    "Name": "Simple 2000 Series Vol.67 - The Suiri",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.58": {
+    "Name": "Simple 2000 Series Vol.21 - Kenka Joutou! Yankee Banchou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.59": {
+    "Name": "Sega Superstars",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.60": {
+    "Name": "Growlanser IV - Return",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.62": {
+    "Name": "Psyvariar 2 - Ultimate Final",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.63": {
+    "Name": "Psikyo Shooting Collection Vol.2 - Sengoku Ace & Sengoku Blade",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.64": {
+    "Name": "Simple 2000 Series Vol.68 - The Runaway - Toumei Highway",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.65": {
+    "Name": "Boboboubo Boubobo - Shuumare! Taikan Boubobo [with Camera]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.66": {
+    "Name": "Typing of the Dead - Zombie Panic",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.67": {
+    "Name": "Winback [Koei Best Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.68": {
+    "Name": "Shin Sangoku Musou [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.69": {
+    "Name": "PC Genjin [Hudson The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.70": {
+    "Name": "Takahashi Meijin no Adventure Island [Hudson The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.71": {
+    "Name": "Simple 2000 Series Ultimate Vol.22 - Stylish Mahjong",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_625.72": {
+    "Name": "Boboboubo Boubobo - Shuumare! Taikan Boubobo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.74": {
+    "Name": "Shoubushi Densetsu - Tetsuya Digest [Athena Best Collection Vol.3]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.76": {
+    "Name": "Jissen Paci-Slot Hisho Kata - Fist of North Star Plus",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.77": {
+    "Name": "Jissen Pachi-Slot Hisshoho! Hokuto no Ken Plus",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.78": {
+    "Name": "Buzz Rod Fishing Fantasy",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.79": {
+    "Name": "Simple 2000 Series Vol.74 - The Girl for Prince Romance",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.80": {
+    "Name": "Simple 2000 Series Vol.69 - The Board Game Collection",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_625.81": {
+    "Name": "K-1 Premium 2004 - Fighting Dynamite!!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.82": {
+    "Name": "Slotter-Up Core 6",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.83": {
+    "Name": "Hudson Selection Vol.1 - Cubic Lode Runner [Hudson The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.84": {
+    "Name": "Hudson Selection Vol.2 - Star Soldier [Hudson The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.85": {
+    "Name": "Sakigake! Cromartie High School [Hudson The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.86": {
+    "Name": "Simple 2000 Series Vol.70 - Kanshikikan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.88": {
+    "Name": "Simple 2000 Series Vol.73 - The Saiyuki Saruden",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.89": {
+    "Name": "Simple 2000 Series Vol.72 - Ninhaza",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.91": {
+    "Name": "GI Jockey 3 2005",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.93": {
+    "Name": "Psikyo Shooting Collection Vol.3 - Sol Divide & Dragon Blaze",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.94": {
+    "Name": "Hot Gimmick Cosplay Mahjong - Pure",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.95": {
+    "Name": "Choro Q - HG 3 [Takara The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.96": {
+    "Name": "EX Okuman Chouja Game [Takara The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.97": {
+    "Name": "Gakuen Heaven - Okawari!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_625.99": {
+    "Name": "Bomberman Kart DX",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.00": {
+    "Name": "Simple 2000 Series Vol.75 - The Tokudane",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.01": {
+    "Name": "Conveti 3, The [Hamster The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.02": {
+    "Name": "Yokushin - Giga Wing Generations",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.03": {
+    "Name": "Wizardry Summoner",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.04": {
+    "Name": "Simple 2000 Series Vol.76 - The Journey to the World of English Language",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.05": {
+    "Name": "Simple 2000 Series Vol.77 - The Hanashi Sou Kankokugo no Tabi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.06": {
+    "Name": "Sega Ages 2500 Series Vol.19 - Fighting Vipers",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.07": {
+    "Name": "Shikigami no Shiro III [Taito The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.08": {
+    "Name": "Yoshinoya [Superlite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.09": {
+    "Name": "Majhong Haoh - Shinken Battle [Mycom The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.10": {
+    "Name": "Saikyou Toudai Shogi Supesharu II",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.11": {
+    "Name": "Taisen Hot Gimmick Axes Jong [Limited Edition]",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_626.12": {
+    "Name": "Taisen Hot Gimmick Axes Jong",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.13": {
+    "Name": "Tough Dark Fight",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.14": {
+    "Name": "Horse Breaker [Koei Teiban Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.15": {
+    "Name": "Slotter Up Mania 6",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.16": {
+    "Name": "Simple 2000 Series Ultimate Vol.25 - Chou-Saisoku! Zokusha King BU no BU 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.17": {
+    "Name": "Simple 2000 Series Vol.79 - Akko ni Omakase! The Party Quiz",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.18": {
+    "Name": "Simple 2000 Series Vol.78 - The Uchuu Daisensou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.20": {
+    "Name": "Pachi-Slot Winning Post",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.21": {
+    "Name": "Gradius V [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.22": {
+    "Name": "Slotter Up Core 7",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.23": {
+    "Name": "Elemental Gerad",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "XgKickHack": "1 "
+  },
+  "SLPM_626.24": {
+    "Name": "Indoor Helicopter Adventure 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.25": {
+    "Name": "Onihama Bakusou Gurentai Gekitou Hen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.26": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.01 - Scramble",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.27": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.02 - Crazy Climber",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.28": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.03 - Karate Michi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.29": {
+    "Name": "Mahjong Haoh - Battle Royal",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.30": {
+    "Name": "Sukusuku Inufuku [Hamster The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.31": {
+    "Name": "Simple 2000 Series 2-in-1 Vol.3 - The Puzzle Collection 2000 Toi & The Touyou Sandai Senjitsu Fusui, Seimeidanhan, Ekisen [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.32": {
+    "Name": "Simple 2000 Series 2-in-1 Vol.3 - The Puzzle Collection 2000 Toi & The Touyou Sandai Senjitsu Fusui, Seimeidanhan, Ekisen [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.33": {
+    "Name": "Simple 2000 Series 2-in-1 Vol.2 - The Bass Fishing & The Bowling Hyper [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.34": {
+    "Name": "Simple 2000 Series 2-in-1 Vol.2 - The Bass Fishing & The Bowling Hyper [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.35": {
+    "Name": "Simple 2000 Series Vol.26 - The Love Smash! 5.1",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.36": {
+    "Name": "Simple 2000 Series 2-in-1 Vol.1 - The Tennis & The Snowboard [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.37": {
+    "Name": "Simple 2000 Series 2-in-1 Vol.1 - The Tennis & The Snowboard [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.38": {
+    "Name": "Simple 2000 Series Vol.80 - The O-Ane-Chan Puruu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.39": {
+    "Name": "Mahjong Taikai III - Millennium League [Koei Selection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.40": {
+    "Name": "Taikou Risshiden IV [Koei Selection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.41": {
+    "Name": "Sangokushi VIII [with Power-Up Kit] [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.42": {
+    "Name": "Nobunaga no Yabou - Ranseiki [with Power-Up Kit] [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.43": {
+    "Name": "Bomberman Land 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.44": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.04 - Time Pilot",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.45": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.05 - Moon Cresta",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.46": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.06 - Sonic Wings",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.48": {
+    "Name": "K-1 World Max 2005",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.49": {
+    "Name": "Simple 2000 Series Vol.88 - The Sekai Meisaku Gekijou Quiz",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.50": {
+    "Name": "Simple 2000 Series Vol.82 - The Kung-fu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.51": {
+    "Name": "Simple 2000 Series Vol.83 - The Konchu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.52": {
+    "Name": "Simple 2000 Series Vol.81 - The Chikyuu Boueigun 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_626.53": {
+    "Name": "Psikyo Shooting Collection Vol.1 - Strikers 1945 1&2 [Taito The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.55": {
+    "Name": "Sega Ages 2500 Series Vol.11 - Hokuto no Ken",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.56": {
+    "Name": "Sega Ages 2500 Series Vol.12 - Puyo Puyo Perfect Set",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.58": {
+    "Name": "Kyoushuu Kidou Butai - Kougeki Helicopter Senki [Taito The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.60": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.09 - Super Volleyball",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.61": {
+    "Name": "Oretachi Geasen Zoku Sono - Terra Cresta",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.62": {
+    "Name": "Simple 2000 Series 2-in-1 Vol.5 - The Shooting & The Helicopter [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.63": {
+    "Name": "Simple 2000 Series 2-in-1 Vol.5 - The Shooting & The Helicopter [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.64": {
+    "Name": "Simple 2000 Series 2-in-1 Vol.4 - The Bushidou & The Sniper 2 [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.65": {
+    "Name": "Simple 2000 Series 2-in-1 Vol.4 - The Bushidou & The Sniper 2 [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.66": {
+    "Name": "Sega Ages 2500 Series Vol.01 - Phantasy Star Generation 1",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.68": {
+    "Name": "Sega Ages 2500 Series Vol.03 - Fantasy Zone",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.70": {
+    "Name": "Sega Ages 2500 Series Vol.05 - Golden Axe",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.71": {
+    "Name": "Sega Ages 2500 Series Vol.06 - Bonanza Bros. & Tant-R",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.75": {
+    "Name": "Sega Ages 2500 Series Vol.13 - Outrun",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.77": {
+    "Name": "Sega Ages 2500 Series Vol.15 - Decathlete Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.78": {
+    "Name": "Kurogane no Houkou - Warship Commander [Koei Selection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.79": {
+    "Name": "Relakuma - Ojama Shitemasu 2 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.80": {
+    "Name": "Relakuma - Ojama Shitemasu 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.81": {
+    "Name": "Nobunaga no Yabou - Ranseiki [Koei Selection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.82": {
+    "Name": "Slotter Up Core 8 - Giant's Star III",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.83": {
+    "Name": "Mahjong Taikai Battle [Mycom The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.84": {
+    "Name": "Toudai Shogi - Jouseki Dojo Kanketsuhen [Mycom The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.85": {
+    "Name": "Homura",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_626.86": {
+    "Name": "Psikyo Shooting Collection Vol.2 - Sengoku Ace & Sengoku Blade [Taito The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.87": {
+    "Name": "Sega Ages 2500 Series Vol.24 - Last Bronx",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.89": {
+    "Name": "Langrisser III",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.90": {
+    "Name": "Raiden III",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.91": {
+    "Name": "Sega Ages 2500 Series Vol.20 - Space Harrier Collection",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_626.92": {
+    "Name": "Sega Ages 2500 Series Vol.21 - SDI & Quartet",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.93": {
+    "Name": "Slotter Up Mania 7 - Saishin Saikyou Pioneer MAX",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.94": {
+    "Name": "Slotter Up Mania 8",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.95": {
+    "Name": "Oretachi Geasen Zoku Sono - Burger Time",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.96": {
+    "Name": "Oretachi Geasen Zoku Sono - Yie Ar Kung-fu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.97": {
+    "Name": "Generation of Chaos Next [Idea Factory Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.98": {
+    "Name": "Ultimate Pro Pinball",
+    "Region": "NTSC-J"
+  },
+  "SLPM_626.99": {
+    "Name": "Neverland Card War Cardinal Arc - Konton no Fuusatsu [Idea Factory Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.00": {
+    "Name": "Princess Maker [Best Hit Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.01": {
+    "Name": "Princess Maker 2 [Best Hit Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.02": {
+    "Name": "Momotaro Densetsu 15",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.03": {
+    "Name": "Sega Rally Championship '95",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_627.04": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.10 - Quarth",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.05": {
+    "Name": "Oretachi Geasen Zoku Sono - Nekketsu Koukou Dodgeball-bu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.06": {
+    "Name": "Oretachi Geasen Zoku Sono - Nekketsu Kouha Kunio-kun",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.07": {
+    "Name": "Oretachi Geasen Zoku Sono - Rabio Lepus",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.08": {
+    "Name": "Sega Ages 2500 Series Vol.22 - Advanced Daisenryaku - Doitsu Dengeki Sakusen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.09": {
+    "Name": "Sega Ages 2500 Series Vol.23 - Sega Memorial Selection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.10": {
+    "Name": "San Goku Shi VIII",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.11": {
+    "Name": "Welcome to Sheep Village [Superlite 2000]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.12": {
+    "Name": "Sega Ages 2500 Series Vol.25 - Gunstar Heroes - Treasure Box",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.13": {
+    "Name": "Yokushin - Giga Wing Generations [Taito The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.14": {
+    "Name": "Shin Sangoku Musou Series Collection Joukan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.17": {
+    "Name": "Sega Ages 2500 Series Vol.26 - Dynamite Deka",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_627.18": {
+    "Name": "Sega Ages 2500 Series Vol.27 - Panzer Dragoon",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.19": {
+    "Name": "Nobunaga no Yabou - Tenka Souyo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.20": {
+    "Name": "Wizardry Summoner [Taito The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.21": {
+    "Name": "Ichigeki Sacchuu! HoiHoi-san [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.22": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! Ore no Sora",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.24": {
+    "Name": "Conveti 4, The",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.25": {
+    "Name": "Mahjong Hoah - Shinken Battle II",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.26": {
+    "Name": "Shooting Love - Trizeal",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.27": {
+    "Name": "Spectral vs. Generation",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_627.29": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.15 - Akumajou Dracula",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_627.30": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.16 - Contra",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.31": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.17 - Pooyan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.33": {
+    "Name": "Garfield - Saving Arlene",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.36": {
+    "Name": "Slotter Up Mania [Dorart Value Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.37": {
+    "Name": "Rally Shox & Freestyle Motorcross [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.39": {
+    "Name": "Suro Genjin",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.40": {
+    "Name": "Saikyo Shogi Gekisashi Special",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.43": {
+    "Name": "School Heaven Okawari [The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.44": {
+    "Name": "Oretachi Geasen Zoku Sono - Thunder Cross",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.45": {
+    "Name": "Oretachi Geasen Zoku Sono Vol.19 - Trio the Punch",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.46": {
+    "Name": "Sega Ages 2500 Series Vol.28 - Tetris Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.47": {
+    "Name": "G1 Jockey 3 [Koei Selection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.48": {
+    "Name": "Nobunaga no Yabou - Renseiki [with Power-Up Kit] [Koei Selection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.49": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! Mister Magic Neo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.50": {
+    "Name": "Momotaro Densetsu 16",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.52": {
+    "Name": "Slotter Up Core 9",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.53": {
+    "Name": "Homura [Taito The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.54": {
+    "Name": "Puyo Puyo! 15th Anniversary",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.55": {
+    "Name": "Mahjong Haoh - Shinken Battle [Mycom The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.56": {
+    "Name": "Saikyou Toudai Shogi 6 [Mycom The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.57": {
+    "Name": "EX Okuman Chouja Game [Atlus Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.58": {
+    "Name": "River Ride Adventure featuring Salomon",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.59": {
+    "Name": "Nobunaga no Yabou - Soutensoku [Koei Selection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.60": {
+    "Name": "Sega Ages 2500 Vol.29 - Monster World Complete Collection",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_627.61": {
+    "Name": "Choro Q - HG 2 [Atlus Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.62": {
+    "Name": "Sangokushi VIII [with Poer-Up Kit] [Koei Selection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.63": {
+    "Name": "Bomberman Land 3 [Hudson Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.64": {
+    "Name": "Ojama Shitemasu 2 Shuukan [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.66": {
+    "Name": "Sega Ages 2500 Vol.30 - Galaxy Force II",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.67": {
+    "Name": "Sega Ages 2500 Vol.31 - Dennou Senki Virtual On",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.70": {
+    "Name": "Volleyball World Cup - Venus Evolution",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_627.71": {
+    "Name": "Choro Q HG 3 [Atlus Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.72": {
+    "Name": "Mahjong Haoh - Battle Royal [Mycom Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.73": {
+    "Name": "Slotter Up Mania 9",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.74": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! Selection - Salaryman Kintarou - Slotter Kintarou - Ore no Sora",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.75": {
+    "Name": "Sega Ages 2500 Vol.32 - Phantasy Star Complete Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.78": {
+    "Name": "Slotter Up Mania 10 - Pioneer Special 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.79": {
+    "Name": "Puyo Puyo! [Special Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_627.80": {
+    "Name": "Fantasy Zone Complete Collection",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_645.04": {
+    "Name": "Maximo",
+    "Region": "NTSC-K"
+  },
+  "SLPM_645.22": {
+    "Name": "La Pucelle",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLPM_645.23": {
+    "Name": "Marvel Vs Capcom 2",
+    "Region": "NTSC-K"
+  },
+  "SLPM_645.25": {
+    "Name": "Guilty Gear X Plus \"By Your Side\"",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLPM_650.01": {
+    "Name": "Kessen",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.02": {
+    "Name": "Love/0 Story",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.04": {
+    "Name": "Reiselied - Ephemeral Fantasia",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.05": {
+    "Name": "I am the Coach",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.06": {
+    "Name": "Beatmania IIDX - 3rd Style",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.07": {
+    "Name": "Roadsters Trophy 2000",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.08": {
+    "Name": "7 Blades",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.09": {
+    "Name": "ESPN X-Games Snowboarding",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.10": {
+    "Name": "Onimusha",
+    "Region": "NTSC-J",
+    "Compat": 1
+  },
+  "SLPM_650.11": {
+    "Name": "Guitar Freaks 3rd Mix and DrumMania 2nd Mix",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.12": {
+    "Name": "Gitaroo Man",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "eeRoundMode": 1,
+    "vuRoundMode": 3
+  },
+  "SLPM_650.13": {
+    "Name": "Shadow of Memories",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.14": {
+    "Name": "Bouken Jidai Katsugeki - Goemon",
+    "Region": "NTSC-J",
+    "Compat": 3
+  },
+  "SLPM_650.15": {
+    "Name": "Kessen 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.16": {
+    "Name": "Love Songs [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.17": {
+    "Name": "Love Songs - Idol is my Classmate",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.18": {
+    "Name": "Zone of Enders [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.19": {
+    "Name": "Zone of Enders",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.20": {
+    "Name": "ParaPara Paradise",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.21": {
+    "Name": "Super Galdelic Hour",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.22": {
+    "Name": "BioHazard - Code Veronica - Perfect Version",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.23": {
+    "Name": "Devil May Cry [Demo] [BioHazard - Code Veronica - Perfect Version - Bonus Disc]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.24": {
+    "Name": "BioHazard - 5th Anniversary Package - Nightmare Returns [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.25": {
+    "Name": "BioHazard - 5th Anniversary Package - Nightmare Returns [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.26": {
+    "Name": "Beatmania IIDX - 4th Style",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.32": {
+    "Name": "Tokyo Bus Guide - Annai",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.33": {
+    "Name": "Kikou Heiden - J-Pheonix",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.34": {
+    "Name": "Sangokushi North Winds",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.38": {
+    "Name": "Devil May Cry",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.39": {
+    "Name": "Densha de Go! Shinkansen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.40": {
+    "Name": "Fear, The [Disc1of4]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.41": {
+    "Name": "Fear, The [Disc2of4]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.42": {
+    "Name": "Fear, The [Disc3of4]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.43": {
+    "Name": "Fear, The [Disc4of4]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.44": {
+    "Name": "Aizouban Angelique Trois [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.47": {
+    "Name": "Capcom vs. SNK 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.49": {
+    "Name": "Beatmania IIDX - 5th Style - New Songs Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.50": {
+    "Name": "Yu-Gi-Oh! Shin Duel Monsters 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.51": {
+    "Name": "Silent Hill 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.52": {
+    "Name": "Guitar Freaks 4th Mix & Drummania 3rd Mix",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.53": {
+    "Name": "Shin Sangoku Musou 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.54": {
+    "Name": "Princess Abarenbou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.56": {
+    "Name": "Orega Kantoku da Vol.2 - Getitou Pennent Race",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.57": {
+    "Name": "7 Blades",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.59": {
+    "Name": "Biohazard Gun Survivor 2 - CODE - Veronica [with Guncon]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.60": {
+    "Name": "Biohazard Gun Survivor 2 - CODE - Veronica",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.61": {
+    "Name": "Adventure of Tokyo Disney Sea",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.65": {
+    "Name": "Sorcerous Stabber Orphen [Kadokawa The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.66": {
+    "Name": "Bouken Jidai Katsugeki Goemon",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.70": {
+    "Name": "Shadow of Memories",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.71": {
+    "Name": "Drift Champ",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.72": {
+    "Name": "ESPN Winter X-Games Snowboarding 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.73": {
+    "Name": "Genso Suikoden III",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.74": {
+    "Name": "Genso Suikoden III",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.75": {
+    "Name": "K-1 World Grand Prix 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.76": {
+    "Name": "Gundam - Federation vs. Zeon DX",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.77": {
+    "Name": "Metal Gear Solid 2 - Sons of Liberty [Premium Package]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.78": {
+    "Name": "Metal Gear Solid 2 - Sons of Liberty",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.80": {
+    "Name": "Tokimeki Memorial 3",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.82": {
+    "Name": "Grandia Extreme [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.83": {
+    "Name": "Houshin Engi 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.85": {
+    "Name": "Alone in the Dark",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.86": {
+    "Name": "Ayumi Hamasaki Dome Tour 2001 - A Visual Mix [Disc1of2]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.87": {
+    "Name": "Ayumi Hamasaki Dome Tour 2001 - A Visual Mix [Disc2of2]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.89": {
+    "Name": "Grandia Extreme",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.90": {
+    "Name": "Spy Hunter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.91": {
+    "Name": "Harukanaru Toki no Naka de 2 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.92": {
+    "Name": "Harukanaru Toki no Naka de 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.93": {
+    "Name": "Sangokushi Senki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.94": {
+    "Name": "Keyboardmania 2nd & 3rd Mix",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.95": {
+    "Name": "Space Channel 5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_650.96": {
+    "Name": "Space Channel 5 - Part 2",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_650.97": {
+    "Name": "Galacta Meisaku Gekijou - Rakugaki Oukouku",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_650.98": {
+    "Name": "Silent Hill 2 - Saigo no Uta",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_651.00": {
+    "Name": "Onimusha 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.01": {
+    "Name": "Onimusha 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.05": {
+    "Name": "Shin Combat Choro Q",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.07": {
+    "Name": "Simple 2000 Series Ultimate Vol.02 - Edit Racing",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.08": {
+    "Name": "Jet de Go! 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.09": {
+    "Name": "J-League Sakatsuku 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.10": {
+    "Name": "Roommania #203",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.11": {
+    "Name": "NFL 2K2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.13": {
+    "Name": "Splashdown",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.15": {
+    "Name": "Final Fantasy X International",
+    "Region": "NTSC-J",
+    "IPUWaitHack": 1
+  },
+  "SLPM_651.16": {
+    "Name": "Lilie no Atelier Plus - Salburg no Renkinjutsushi 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.17": {
+    "Name": "Kikou Heiden J-Pheonix [Takara The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.18": {
+    "Name": "Tokimeki Memorial 2 - Video Clips",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.19": {
+    "Name": "Shine - Spinning World",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.20": {
+    "Name": "Shine - Spinning World",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.21": {
+    "Name": "Switch",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_651.22": {
+    "Name": "J-Pheonix Burst Tactics [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.23": {
+    "Name": "J-Pheonix Burst Tactics",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.24": {
+    "Name": "Auto Modellista",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.25": {
+    "Name": "NBA 2K3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.26": {
+    "Name": "Tokimeki Mamorial - Girl's Side",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.30": {
+    "Name": "Dramatic Soccer Game - Becoming a National Team Member",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.31": {
+    "Name": "Atelier Judie: Gramnad no Renkinjutsushi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.32": {
+    "Name": "Warriors of Might and Magic",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.33": {
+    "Name": "Konohana 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.34": {
+    "Name": "Red Card",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.35": {
+    "Name": "NBA 2K2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.37": {
+    "Name": "All-Star Baseball 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.39": {
+    "Name": "Gun Survivor 3 - Dino Crisis",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_651.40": {
+    "Name": "Jojo's Bizarre Adventure 5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.41": {
+    "Name": "Tsuzuse Gareijiri",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.42": {
+    "Name": "Anime Super Remix, The - Kyojin no Hoshi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.43": {
+    "Name": "Anime Super Remix, The - Ashita no Joe 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.48": {
+    "Name": "Densha de Go! Ryojouhen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.50": {
+    "Name": "Aero Dancing 4 - New Generation",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.52": {
+    "Name": "GunGrave [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.53": {
+    "Name": "GunGrave",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.54": {
+    "Name": "Rumbling Hearts",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.55": {
+    "Name": "Rumbling Hearts",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.56": {
+    "Name": "Beatmania IIDX - 6th Style",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.58": {
+    "Name": "Riding Spirits",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.60": {
+    "Name": "Gitaroo Man [The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.61": {
+    "Name": "Aero Dancing 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.64": {
+    "Name": "Project Minerva [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.65": {
+    "Name": "Project Minerva",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.66": {
+    "Name": "Ultimate Fighting Championship 2 - Tap-Out",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.67": {
+    "Name": "Pride",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.69": {
+    "Name": "Combat Queen",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_651.70": {
+    "Name": "Shin Sangoku Musou 2 - Mushouden",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.73": {
+    "Name": "Innocent Black",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.74": {
+    "Name": "Britney's Dance Beat",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.76": {
+    "Name": "King of Colosseum - Red",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.77": {
+    "Name": "Energy Airforce",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_651.78": {
+    "Name": "Ferrari F355 Challenge",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.79": {
+    "Name": "Culdcept 2 - Expansion",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.80": {
+    "Name": "Baseball 2003, The",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.83": {
+    "Name": "Auto Modellista",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.84": {
+    "Name": "Document of Metal Gear Solid 2, The",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.85": {
+    "Name": "Ferrari F355 Challenge",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.86": {
+    "Name": "Thread Colors [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.87": {
+    "Name": "Thread Colors",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.91": {
+    "Name": "V-Rally 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.92": {
+    "Name": "NBA Live 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.93": {
+    "Name": "FIFA Soccer 2003",
+    "Region": "NTSC-J",
+    "vuClampMode": 2
+  },
+  "SLPM_651.96": {
+    "Name": "Breath of Fire V - Dragon Quarter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.97": {
+    "Name": "Nobunaga's Ambition Online",
+    "Region": "NTSC-J"
+  },
+  "SLPM_651.99": {
+    "Name": "J-Pheonix - Cobalt Shoutaihen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.00": {
+    "Name": "Shinobi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.02": {
+    "Name": "K-1 World Grand Prix 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.03": {
+    "Name": "Phantom of Inferno [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.04": {
+    "Name": "Phantom of Inferno",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.05": {
+    "Name": "Spider-Man",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.06": {
+    "Name": "King of Colosseum - Green",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.07": {
+    "Name": "Chou Battle Houshin",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.08": {
+    "Name": "Pop'n Music 7",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.09": {
+    "Name": "Star Ocean 3 [Limited Edition]",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLPM_652.10": {
+    "Name": "Chou Battle Houshin - Bundle #1",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.13": {
+    "Name": "Evolution Skateboarding",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.15": {
+    "Name": "Chou Battle Houshin - Bundle #2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.18": {
+    "Name": "Bomberman Jetters",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.19": {
+    "Name": "Cheerful Party",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.20": {
+    "Name": "Cheerful Party",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.21": {
+    "Name": "Clock Tower 3",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_652.22": {
+    "Name": "Yu-Gi-Oh! 2 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.23": {
+    "Name": "Triange Again",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.24": {
+    "Name": "NFL 2K3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.26": {
+    "Name": "Savage Skies",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.27": {
+    "Name": "J-League Pro Soccer Club - Tsukuku! 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.28": {
+    "Name": "Taisho Mononoke Ibunroku",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_652.29": {
+    "Name": "Arms Men - Air Attack 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.30": {
+    "Name": "Tokimeki Memorial 3 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.31": {
+    "Name": "Evolution Snowboarding",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.32": {
+    "Name": "Devil May Cry 2 [Dante Disc]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_652.33": {
+    "Name": "Devil May Cry 2 [Lucia Disc]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_652.34": {
+    "Name": "Gregory Horror Show - Soul Collector",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.35": {
+    "Name": "New Roommania - Porori Seishun",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.36": {
+    "Name": "Anubis Zone of Enders",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.37": {
+    "Name": "Zone of the Enders [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.38": {
+    "Name": "Angelic Concert [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.39": {
+    "Name": "Angelic Concert",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.41": {
+    "Name": "Shin Megami Tensei 3 - Nocturne [Limited Edition]",
+    "Region": "NTSC-J",
+    "eeRoundMode": "0 "
+  },
+  "SLPM_652.42": {
+    "Name": "Shin Megami Tensei 3 - Nocturne",
+    "Region": "NTSC-J",
+    "eeRoundMode": "0 "
+  },
+  "SLPM_652.43": {
+    "Name": "Densha de Go! Professional 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.44": {
+    "Name": "Tom Clancy's Ghost Recon",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.45": {
+    "Name": "Biohazard Gun Survivor 4 - Heroes Never Die",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.46": {
+    "Name": "Kaidou Battle",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.47": {
+    "Name": "Sangokushi Senki 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.48": {
+    "Name": "Shin Sangoku Musou 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.49": {
+    "Name": "Chaos Legion",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_652.54": {
+    "Name": "Galaxy Angel",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.55": {
+    "Name": "Chobits",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.56": {
+    "Name": "First Kiss Story 1&2 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.57": {
+    "Name": "Silent Hill 3",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_652.60": {
+    "Name": "Air Land Force",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.62": {
+    "Name": "Boboboubo Boubobo Hajike Matsuri",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.63": {
+    "Name": "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Mushouden [Koei Mega Pack] [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.64": {
+    "Name": "Shin Sangoku Musou 2 & Shin Sangoku Musou 2 Mushouden [Koei Mega Pack] [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.66": {
+    "Name": "Drag-on Dragoon",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.67": {
+    "Name": "Kurogane no Houkou 2 - Warship Gunner",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.68": {
+    "Name": "Initial D - Special Stage",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.69": {
+    "Name": "NBA 2K3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.70": {
+    "Name": "Virtua Fighter 4 - Evolution",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.71": {
+    "Name": "Over the Monochrome Rainbow featuring Shogo Hamada",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.73": {
+    "Name": "Triange Again 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.74": {
+    "Name": "Saishuu Heiki Kanojo [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.75": {
+    "Name": "Saishuu Heiki Kanojo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.76": {
+    "Name": "Grand Prix Challenge",
+    "Region": "NTSC-J",
+    "VIFFIFOHack": 1
+  },
+  "SLPM_652.77": {
+    "Name": "DDR Max 2 - Dance Dance Revolution - 7th Mix",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_652.78": {
+    "Name": "Generation of Chaos 3 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.79": {
+    "Name": "Generation of Chaos 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.80": {
+    "Name": "Green Green - Sound of the Ring Dynamic [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.81": {
+    "Name": "Green Green - Sound of the Ring Dynamic",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.82": {
+    "Name": "Green Green - Sound of the Ring Romantic [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.83": {
+    "Name": "Green Green - Sound of the Ring Romantic",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.84": {
+    "Name": "World Rallt Championship II Extreme",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.85": {
+    "Name": "Love Hina Gorgeous [First Limited Edition]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_652.86": {
+    "Name": "Auto Modellista - US Tuned",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.87": {
+    "Name": "Final Fantasy XI - Girade no Genei",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.88": {
+    "Name": "Final Fantasy XI - Girade no Genei [All-in-One Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.89": {
+    "Name": "Final Fantasy XI [Entry Disc]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.90": {
+    "Name": "Merge Marginal [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.91": {
+    "Name": "Merge Marginal",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.94": {
+    "Name": "Cafe Little Wish - Mahou no Recipe [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.95": {
+    "Name": "Cafe Little Wish - Mahou no Recipe",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.96": {
+    "Name": "F Fanatic [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.97": {
+    "Name": "F Fanatic",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.98": {
+    "Name": "Winning Post 5 - Maximum 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_652.99": {
+    "Name": "Konohana 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.00": {
+    "Name": "All-Star Pro Wrestling 3",
+    "Region": "NTSC-J",
+    "Compat": 2
+  },
+  "SLPM_653.01": {
+    "Name": "Torakapuu! Dash [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.02": {
+    "Name": "Torakapuu! Dash",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.03": {
+    "Name": "Virtual On - Marz",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.05": {
+    "Name": "Genso Suikoden 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.06": {
+    "Name": "Sakura Yuki Gekka [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.07": {
+    "Name": "Sakura Yuki Gekka",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.08": {
+    "Name": "Shutokou Battle 01",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.09": {
+    "Name": "Splashdown [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.10": {
+    "Name": "Viorate no Atelier - The Alchemist of Gramnad [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.11": {
+    "Name": "Viorate no Atelier - The Alchemist of Gramnad",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.13": {
+    "Name": "First Kiss Story 1&2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.14": {
+    "Name": "Hanjuku Hero VS 3-D [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.15": {
+    "Name": "Hanjuku Hero VS 3-D",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_653.16": {
+    "Name": "Pop'n Music 8",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.17": {
+    "Name": "Jikkyou Powerful Pro Baseball 10",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.18": {
+    "Name": "Shoubushi Tetsuya 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.19": {
+    "Name": "Eve Burst Error Plus [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.20": {
+    "Name": "Eve Burst Error Plus",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.21": {
+    "Name": "Prince of Tennis - Smash Hit!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.22": {
+    "Name": "Prince of Tennis - Smash Hit! - B-Type",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.23": {
+    "Name": "Prince of Tennis - Smash Hit! - C-Type",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.24": {
+    "Name": "Gregory Horror Show - Soul Collector",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.25": {
+    "Name": "Air Ranger 2 - Rescue Helicopter [Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.26": {
+    "Name": "Choro Q HG 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.27": {
+    "Name": "Prince of Tennis - Smash Hit! [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.28": {
+    "Name": "Shirachuu Tankenbu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.29": {
+    "Name": "Makai Tensei",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.30": {
+    "Name": "Akudaikan 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.31": {
+    "Name": "RockMan X7",
+    "Region": "NTSC-J",
+    "eeClampMode": 3
+  },
+  "SLPM_653.32": {
+    "Name": "Mahoromatic Automatic Maiden [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.33": {
+    "Name": "Mahoromatic Automatic Maiden",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.34": {
+    "Name": "Shinseiki Evangelion - Ayanami Ikusei Keikaku with Asuka Hokan Keikaku",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_653.35": {
+    "Name": "Gekitou Professional Baseball",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.36": {
+    "Name": "K-1 World Grand Prix - The Beast Attack!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.37": {
+    "Name": "Gegege no Kitaro - Ibun Youkaitan",
+    "Region": "NTSC-J",
+    "Compat": 3
+  },
+  "SLPM_653.38": {
+    "Name": "Junni Kuniki - Guren no Hyou Koujin no Mitsu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.39": {
+    "Name": "Akudaikan [Global The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.40": {
+    "Name": "Shinseiki Evangelion - Ayanami Ikusai Keikaku with Asuka Hokan Keikaku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.41": {
+    "Name": "Silent Hill 2 - Saigo No Uta [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.42": {
+    "Name": "Kyoufu Shinbun (Heisei) Kaiki! Shinrei File",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.43": {
+    "Name": "Kikou Heidai - J-Pheonix 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.44": {
+    "Name": "Project Minerva - Professional",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.45": {
+    "Name": "Simple 2000 Series Ultimate Vol.09 - Runabout 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.46": {
+    "Name": "Winning Post 6",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.47": {
+    "Name": "Bistro Cupid 2 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.48": {
+    "Name": "Bistro Cupid 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.49": {
+    "Name": "Tokyo Bus Guide [Superlite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.50": {
+    "Name": "Simple 2000 Series Ultimate Vol.11 - Wonder Bass",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.52": {
+    "Name": "Simple 2000 Series Ultimate Vol.10 - Love Songs",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.53": {
+    "Name": "SuperLite 2000 Series Vol. 6 - Konohana 2 - Todokanai Requiem",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.56": {
+    "Name": "Natsuiro Komachi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.57": {
+    "Name": "BioHazard - Code Veronica - Perfect Version",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.58": {
+    "Name": "Dance Dance Revolution Extreme",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_653.61": {
+    "Name": "Anubis Zone of Enders [Special Edition LE]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_653.62": {
+    "Name": "NHK Tensai Bit-Kun - Guramon Battle",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.64": {
+    "Name": "School Heaven - Boy's Love Scramble!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.65": {
+    "Name": "Tokimeki Memorial - Girl's Side [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.66": {
+    "Name": "Dear Boys - Fast Break!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.67": {
+    "Name": "Makai Eiyuuki Maximo - Machine Monster no Yabou",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_653.68": {
+    "Name": "D.N. Angel - TV Animation Series",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.70": {
+    "Name": "Prince of Tennis - Sweat & Tears 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.72": {
+    "Name": "Soccer Kantoku Saihai Simulation - Formation Final",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.73": {
+    "Name": "Glass Rose",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_653.74": {
+    "Name": "Energy Airforce - Aim Strike!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.75": {
+    "Name": "Shin Sangoku Musou 3 - Mushouden [Premium Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.77": {
+    "Name": "Shin Sangoku Musou 3 - Mushouden",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.78": {
+    "Name": "Busin 0 - Wizardry Alternative Zero",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.79": {
+    "Name": "Baseball 2003 - Akikigou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.80": {
+    "Name": "Samurai Michi 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.81": {
+    "Name": "Kimagure Strawberry Cafe",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.82": {
+    "Name": "Grand Theft Auto III",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.83": {
+    "Name": "Growlanser IV - Wayfarer of the Time [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.84": {
+    "Name": "Dream Mix TV World Fighters",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_653.86": {
+    "Name": "Train Simulator - Midosuji Line",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.87": {
+    "Name": "Aero Dancing 4 - New Generation [Sega The Best 2800]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.88": {
+    "Name": "Lost Passage [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.89": {
+    "Name": "Lost Passage",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.90": {
+    "Name": "Shinki Genso - Spectral Souls [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.91": {
+    "Name": "Shinki Genso - Spectral Souls",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.92": {
+    "Name": "Kanojo no Densetsu - Boku no Sekiban",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.93": {
+    "Name": "Simple 2000 Series Vol.38 - The Friendship Adventure",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.94": {
+    "Name": "Love Smash! 5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.95": {
+    "Name": "Digi-Charat Fantasy",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.97": {
+    "Name": "Prince of Tennis - Kiss of Prince - Ice Version",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.98": {
+    "Name": "Prince of Tennis - Kiss of Prince - Flame Version",
+    "Region": "NTSC-J"
+  },
+  "SLPM_653.99": {
+    "Name": "D.C.P.S. [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.00": {
+    "Name": "D.C.P.S.",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.01": {
+    "Name": "Tengai Makyou II - Manji Maru",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.04": {
+    "Name": "Kita He - Diamond Dust",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.05": {
+    "Name": "Hyper Dimension Fortress Macross",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_654.06": {
+    "Name": "Castlevania - Lament of Innocence [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.07": {
+    "Name": "Transformers Tatakai",
+    "Region": "NTSC-J",
+    "Compat": 3
+  },
+  "SLPM_654.08": {
+    "Name": "Growlanser IV - Wayfarer of the Time",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.09": {
+    "Name": "Air Ranger 2 - Rescue Helicopter - Plus",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.10": {
+    "Name": "Getaway, The",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.11": {
+    "Name": "Onimusha Buraiden",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_654.12": {
+    "Name": "War of the Monsters",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.13": {
+    "Name": "Onimusha 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.14": {
+    "Name": "Simple 2000 Series Vol.45 - The Love and Tears and Memory",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.16": {
+    "Name": "Pride Grand Prix 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.17": {
+    "Name": "Mat Hoffman's Pro BMX 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.18": {
+    "Name": "Kelly Slater's Pro Surfer 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.19": {
+    "Name": "Tony Hawk's Pro Skater 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.20": {
+    "Name": "Dabitsuku 3 - Let's Become a Derby Owner",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.21": {
+    "Name": "Ever 17 - Out of Infinity [Premium Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.22": {
+    "Name": "Tom Clancy's Splinter Cell",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.23": {
+    "Name": "Sangokushi IX",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.24": {
+    "Name": "Moekko Company [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.25": {
+    "Name": "Moekko Company",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.26": {
+    "Name": "Pro Baseball Team Tsukuro! 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.27": {
+    "Name": "Riding Spirits 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.28": {
+    "Name": "BioHazard Outbreak",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_654.29": {
+    "Name": "Galaxy Angel - Moonlit Lovers",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.31": {
+    "Name": "Sonic Heroes",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_654.32": {
+    "Name": "J-League Winning Eleven Tactics",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.33": {
+    "Name": "K-1 World Grand Prix 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.34": {
+    "Name": "Battle Gear 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.35": {
+    "Name": "Diamond Dust",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.38": {
+    "Name": "Star Ocean 3 [Director's Cut] [Disc1of2]",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLPM_654.39": {
+    "Name": "Star Ocean 3 [Director's Cut] [Disc2of2]",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLPM_654.41": {
+    "Name": "Ashita no Joe - Masshiro ni Moetsukuru",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.42": {
+    "Name": "Terminator 3, The - Rise of the Machines",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.43": {
+    "Name": "Front Mission 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.44": {
+    "Name": "Castlevania - Lament of Innocence",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_654.45": {
+    "Name": "Powerful Pro Baseball 10 - Decision",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.46": {
+    "Name": "James Bond 007 - Everything or Nothing",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.47": {
+    "Name": "Kunoichi",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_654.48": {
+    "Name": "Cambrian QTS - Kaseki Ninattemo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.49": {
+    "Name": "SSX 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.50": {
+    "Name": "Detective Gakuen Q",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.51": {
+    "Name": "Prince of Tennis - Smash Hit! 2 [First Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.54": {
+    "Name": "Prince of Tennis - Smash Hit! 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.56": {
+    "Name": "Magical Nurse Witch Komugi-chan [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.57": {
+    "Name": "Magical Nurse Witch Komugi-chan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.58": {
+    "Name": "Kurogane no Houkou 2 - Warship Commander",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.59": {
+    "Name": "Bujingai",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.60": {
+    "Name": "Conflict Delta - Wangan War 1991",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.61": {
+    "Name": "Shin Megami Tensei 3 - Nocturne - Maniacs",
+    "Region": "NTSC-J",
+    "eeRoundMode": "0 "
+  },
+  "SLPM_654.62": {
+    "Name": "Shin Megami Tensei 3 - Nocturne - Maniacs",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "eeRoundMode": "0 "
+  },
+  "SLPM_654.63": {
+    "Name": "Rocky",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.64": {
+    "Name": "Wind - A Breath of Heart",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.65": {
+    "Name": "Harry Potter to Kenja no Ishi",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPM_654.66": {
+    "Name": "Kousen Gaeri - Refrain",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.68": {
+    "Name": "Roommate Asami - D-Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.70": {
+    "Name": "Firefighter F.D. 18",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.71": {
+    "Name": "Firefighter F.D. 18",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.72": {
+    "Name": "Train Simulator & Densha de Go! Tokyo Kyuukouhen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.73": {
+    "Name": "Hagane no Renkinjutsushi - Tobenai Tenshi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.74": {
+    "Name": "Kurogane no Houkou 2 - Warship Commander [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.77": {
+    "Name": "Crimson Sea 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.78": {
+    "Name": "Final Fantasy X-2 International",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_654.79": {
+    "Name": "Sims, The - Bustin' Out",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.80": {
+    "Name": "Michigan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.81": {
+    "Name": "After... [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.82": {
+    "Name": "After...",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.83": {
+    "Name": "Secret Weapons Over Normandy",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.84": {
+    "Name": "WISP - Word Image Sound Play",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_654.86": {
+    "Name": "Airforce Delta - Blue Wing Knights",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.88": {
+    "Name": "Grand Theft Auto - Vice City",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.89": {
+    "Name": "Tantei Jingiji Saburo - Innocent Black [WorkJam Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.90": {
+    "Name": "Sanma Nisai Deus Mechanica - Demon Bane [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.91": {
+    "Name": "Sanma Nisai Deus Mechanica - Demon Bane",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.92": {
+    "Name": "GunGrave O.D.",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.93": {
+    "Name": "Hurrah! Sailor",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.94": {
+    "Name": "Fuun Shinsengumi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.95": {
+    "Name": "Monster Hunter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.96": {
+    "Name": "Hyper Street Fighter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.97": {
+    "Name": "World Soccer Winning Eleven 7 - International [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.98": {
+    "Name": "World Soccer Winning Eleven 7 - International",
+    "Region": "NTSC-J"
+  },
+  "SLPM_654.99": {
+    "Name": "Bloody Roar 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.00": {
+    "Name": "Anubis ZOE - Special Edition",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.01": {
+    "Name": "Frogger - The Great Quest",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.02": {
+    "Name": "GunGrave [Red Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.03": {
+    "Name": "Lord of the Rings, The - The Return of the King",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_655.04": {
+    "Name": "Cool Girl [Limited Edition] [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.05": {
+    "Name": "Cool Girl [Limited Edition] [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.06": {
+    "Name": "Cool Girl",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.08": {
+    "Name": "Pop'n Music 9",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.09": {
+    "Name": "Prince of Tennis - Love of Prince - Sweet",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.10": {
+    "Name": "Prince of Tennis - Love of Prince - Bitter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.12": {
+    "Name": "Angel's Feather [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.13": {
+    "Name": "Angel's Feather",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.14": {
+    "Name": "Kaido Battle 2 - Chain Reaction",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.15": {
+    "Name": "Sakura Taisen - Mysterious Paris",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.17": {
+    "Name": "Sengoku Musou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.18": {
+    "Name": "Raimuiro Senkitan Jun [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.19": {
+    "Name": "Raimuiro Senkitan Jun",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.20": {
+    "Name": "Tentama 2 Wins [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.21": {
+    "Name": "Tentama 2 Wins",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.23": {
+    "Name": "Hurrah! Sailor",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.24": {
+    "Name": "Orange Pocket - Root [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.25": {
+    "Name": "Orange Pocket - Root",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.26": {
+    "Name": "Dororo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.27": {
+    "Name": "FIFA Total Football",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.29": {
+    "Name": "Mission Impossible - Operation Surma",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.30": {
+    "Name": "J-League Pro Soccer Club - Tsukuku 2004",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.31": {
+    "Name": "Sakura Taisen V - Episode 0",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.32": {
+    "Name": "Puyo Puyo Fever",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.33": {
+    "Name": "Pyu to Fuku! Jaguar Ashita no Japan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.34": {
+    "Name": "Rogue Ops",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.35": {
+    "Name": "Oshiete! Popotan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.37": {
+    "Name": "Chou Battle Houshin [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.38": {
+    "Name": "James Bond 007 - Nightfire [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.39": {
+    "Name": "V-Rally 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.40": {
+    "Name": "Galaxy Angel - Moonlit Lovers [First Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.41": {
+    "Name": "Angelique Trois - Aizouhen [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.42": {
+    "Name": "Zero Shikikan Josentoki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.43": {
+    "Name": "Pro Yakyu Spirits 2004",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.45": {
+    "Name": "Izayoi Renke Kamifurusato",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.46": {
+    "Name": "Cross Channel - To All People [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.47": {
+    "Name": "Cross Channel - To All People",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.48": {
+    "Name": "Freedom Fighters",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.49": {
+    "Name": "Remember 11 - The Age of Infinity [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.50": {
+    "Name": "Remember 11 - The Age of Infinity",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.51": {
+    "Name": "Astro Boy Atom",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.52": {
+    "Name": "Metal Wolf Rev [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.53": {
+    "Name": "Metal Wolf Rev",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.54": {
+    "Name": "Croket Ban - King no Kiki wo Sukuu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.55": {
+    "Name": "Dragon Quest V - Bride of the Sky",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_655.56": {
+    "Name": "Nobunaga no Yabou - Tenka Sousei",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.57": {
+    "Name": "Steady X Study [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.58": {
+    "Name": "Steady X Study",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.59": {
+    "Name": "Tenohira Taiyouni [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.60": {
+    "Name": "Tenohira Taiyouni",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.61": {
+    "Name": "Shin Sangoku Musou 3 [Super Premium Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.64": {
+    "Name": "Shin Sangoku Musou 3 - Empires",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.65": {
+    "Name": "Shin Sangoku Musou 3 - Empires",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.66": {
+    "Name": "La Corda d'Oro [Premium Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.67": {
+    "Name": "Corda D'Oro, La",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.69": {
+    "Name": "Kita He - Diamond Dust + Kiss is Beginning",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.70": {
+    "Name": "Frogger [Konami Palace Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.71": {
+    "Name": "Generation of Chaos 4 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.72": {
+    "Name": "Generation of Chaos 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.73": {
+    "Name": "World Rallt Championship II Extreme [Spike The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.74": {
+    "Name": "Silent Hill 4 - The Room",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_655.75": {
+    "Name": "Crimson Tears",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_655.76": {
+    "Name": "Tantei Jingiji Saburo - Kind of Blue",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.79": {
+    "Name": "After School Love Beat",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.80": {
+    "Name": "Crash Bandicoot - Bakuso! Nitro Kart",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.81": {
+    "Name": "Haunted Mansion",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.82": {
+    "Name": "Winning Post 6 Maximum 2004",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.83": {
+    "Name": "World Rally Championship 3",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_655.85": {
+    "Name": "Princess Holiday",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.86": {
+    "Name": "Online Pro Wrestling",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.87": {
+    "Name": "Fight Night 2004",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.88": {
+    "Name": "Colorful Box - To Love [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.89": {
+    "Name": "Colorful Box - To Love",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.90": {
+    "Name": "Densha de Go! Final",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.91": {
+    "Name": "Lost Aya Sophia [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.92": {
+    "Name": "Lost Aya Sophia",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.93": {
+    "Name": "Beatmania IIDX - 7th Style",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.94": {
+    "Name": "Atelier no Iris - Eternal Mana",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.95": {
+    "Name": "Shoubushi Gambler Densetsu - Tetsuya 2 [Athena Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.96": {
+    "Name": "Juuni Kuniki - Kakukaku Taru Ou Michi Beni Midori no Uka",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.97": {
+    "Name": "Digital Devil Saga - Avatar Tuner",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPM_655.98": {
+    "Name": "Tenshou Gakuen Kensousoku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_655.99": {
+    "Name": "Genso Suikoden 4 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.00": {
+    "Name": "Genso Suikoden 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.01": {
+    "Name": "Omoide ni Kawaru-Kimi - Memories Off [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.02": {
+    "Name": "King of Colosseum 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_656.03": {
+    "Name": "Run Like Hell",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.04": {
+    "Name": "Animation Battle - Recca no Honou",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_656.07": {
+    "Name": "3LDK - Shiawase ni Narouyo [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.08": {
+    "Name": "3LDK - Shiawase ni Narouyo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.09": {
+    "Name": "Memories Off... - Sorekara [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.10": {
+    "Name": "Memories Off... - Sorekara",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.11": {
+    "Name": "Pizzicato Polka",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.12": {
+    "Name": "Harry Potter and The Prisoner of Azkaban",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.13": {
+    "Name": "Yu-Gi-Oh! Capsule Monster Coliseum",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.14": {
+    "Name": "Need for Speed Underground [EA Best Hits]",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPM_656.15": {
+    "Name": "Dokapon DX",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.16": {
+    "Name": "Juuni Kuniki - Guren no Hyou Koujin noJi [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.17": {
+    "Name": "Bouken Jidai Katsugeki Goemon [Konami Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.18": {
+    "Name": "Vampire Panic",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.19": {
+    "Name": "Tom Clancy's Ghost Recon - Jungle Storm",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.20": {
+    "Name": "Akudaikan 2 [Global The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.21": {
+    "Name": "Street Fighter III - 3rd Strike",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_656.22": {
+    "Name": "Silent Hill 3 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.23": {
+    "Name": "Tantei Gakuen Q [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.24": {
+    "Name": "Dear Boys Fast Break! [Konami Palace Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.25": {
+    "Name": "Ashita no Joe Masshiro ni Moetsukuru [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.26": {
+    "Name": "Kyoufu Shinbun (Heisei-Han) Kaiki! Shinrei File [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.27": {
+    "Name": "Gegege no Kitarou [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.28": {
+    "Name": "Konhana Pack - 3tsu no Jikenbou [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.29": {
+    "Name": "Kappa no Kai-Kata - How to Breed Kappas",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.30": {
+    "Name": "Jikkyo Powerful Pro Baseball XI",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.31": {
+    "Name": "Silent Hill 2 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.32": {
+    "Name": "Virtua Fighter Cyber Generation - Ambition of the Judgement Six",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.33": {
+    "Name": "I Love Baseball - Pro Yakyu wo Koyonaku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.34": {
+    "Name": "Summer Girl - Promised Summer",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.35": {
+    "Name": "Bakuen Kakeshi Neverland Senki Zero",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.36": {
+    "Name": "Sangokushi Senki 2 [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.37": {
+    "Name": "Rakugaki Oukoku 2 - Majo no Tataki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.38": {
+    "Name": "Full House Kiss",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.39": {
+    "Name": "Party Shana Nanco [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.40": {
+    "Name": "Party Shana Nanco",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.41": {
+    "Name": "Utau - Tumbling Dice",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.42": {
+    "Name": "Meiwaku Seijin Panic Maker",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_656.43": {
+    "Name": "RockMan X - Command Mission",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.44": {
+    "Name": "Guilty Gear Isuka",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.48": {
+    "Name": "Medal of Honor - Frontline [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.49": {
+    "Name": "NBA Street 2 [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.50": {
+    "Name": "Harry Potter and The Sorcerer's Stone [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.51": {
+    "Name": "Kowloon Youma Gakuenki [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.52": {
+    "Name": "Kowloon Youma Gakuenki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.53": {
+    "Name": "Darling Special Backlash - Koi no Exhaust Heat",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.54": {
+    "Name": "Kaiketsu! Osabakiina",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.55": {
+    "Name": "Finding Nemo [Yuke's The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.57": {
+    "Name": "World Soccer Winning Eleven 8",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.61": {
+    "Name": "Densha de Go! Professional 2 [Taito Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.63": {
+    "Name": "Zwei!!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.64": {
+    "Name": "Memories Off... Duet [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.65": {
+    "Name": "BloodRayne",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.66": {
+    "Name": "NBA Live 2004 [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.68": {
+    "Name": "Spectral Force - Radical Elements [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.69": {
+    "Name": "Spectral Force - Radical Elements",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.70": {
+    "Name": "Aqua Kids",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.71": {
+    "Name": "W - Wish [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.72": {
+    "Name": "W - Wish",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.74": {
+    "Name": "Taikou Risshiden V",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.75": {
+    "Name": "Final Approach [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.76": {
+    "Name": "Final Approach",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.77": {
+    "Name": "Prince of Tennis - Smash Hit! [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.78": {
+    "Name": "Prince of Tennis - Smash Hit! 2 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.79": {
+    "Name": "Prince of Tennis - Sweat 2 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.80": {
+    "Name": "Prince of Tennis - Make the Strongest Team",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.81": {
+    "Name": "Monochrome [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.82": {
+    "Name": "Monochrome",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.83": {
+    "Name": "Violet no Atelier [Gust Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.84": {
+    "Name": "Meine Liebe - Yuubinaru Kioku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.85": {
+    "Name": "Stella Deus",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.86": {
+    "Name": "Berserk [Branded Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.87": {
+    "Name": "Star Wars - Battlefront",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.88": {
+    "Name": "Berserk",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_656.89": {
+    "Name": "Never 7 - The End of Infinity [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.90": {
+    "Name": "Konohana 4 - Yami wo Harau Inori",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_656.91": {
+    "Name": "Ever 17 - Out of Infinity [SuperLite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.92": {
+    "Name": "BioHazard Outbreak - File 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_656.93": {
+    "Name": "Tokimeki Memorial 3 [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.94": {
+    "Name": "Genso Suikoden 3 [Konami Dendou Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.95": {
+    "Name": "Hard Luck - Return of the Heroes",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.96": {
+    "Name": "Simple 2000 Series Vol.62 - The Super Puzzle Bubble DX",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.97": {
+    "Name": "Shrek 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.98": {
+    "Name": "Love Songs - ADV Futaba Riho 14-sai Natsu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_656.99": {
+    "Name": "Viewtiful Joe - Aratanaru Kibo",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_657.00": {
+    "Name": "Kengo 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.01": {
+    "Name": "Ghost Hunter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.02": {
+    "Name": "Sangokushi Senki [Koei Collection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.03": {
+    "Name": "Double Reaction Plus",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.04": {
+    "Name": "Standard Daisenryaku Dengekisen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.05": {
+    "Name": "Final Fantasy XI - Chains of Promathia [Expansion Disc]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.06": {
+    "Name": "Final Fantasy XI - Chains of Promathia [All-in-One Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.08": {
+    "Name": "Hagane no Renkinjutsushi - Akaki Elixir no Akuma",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.10": {
+    "Name": "Apocripha Zero",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.14": {
+    "Name": "Angelique Etoile [Premium Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.15": {
+    "Name": "Angelique Etoile",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.16": {
+    "Name": "Gaika no Gouhou - Air Land Force [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.17": {
+    "Name": "Tsuki wa Higashi ni Ha wa Nishi na - Operation Sanctuary",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.18": {
+    "Name": "Sengoku Musou Moushouden",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.19": {
+    "Name": "Burnout 3 - Takedown",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.20": {
+    "Name": "Shin Sangoku Musou 2 Mushouden [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.21": {
+    "Name": "Pro Yakyuu Spirits 2004 Climax",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.22": {
+    "Name": "Airforce Delta - Blue Wing Knights [Konami the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.23": {
+    "Name": "Van Helsing",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.24": {
+    "Name": "Choro Q Works",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.25": {
+    "Name": "James Bond 007 - Everything or Nothing [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.26": {
+    "Name": "Star Wars - Jango Fett [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.27": {
+    "Name": "Lord of the Rings, The - The Return of the King [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.28": {
+    "Name": "Hobbit, The",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.29": {
+    "Name": "True Crime - Streets of L.A.",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.30": {
+    "Name": "RockMan X8",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.31": {
+    "Name": "Tom Clancy's Rainbow Six 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.32": {
+    "Name": "Akaiito",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_657.34": {
+    "Name": "Kita He - Diamond Dust [Hudson The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.35": {
+    "Name": "Ao no Mamade [Treasure Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.36": {
+    "Name": "Ao no Mamade",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.37": {
+    "Name": "Meshimase Roman Sabou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.38": {
+    "Name": "Love Songs Adv - Futaba Riho 19 Sai",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.39": {
+    "Name": "Nightmare Before Christmas",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_657.40": {
+    "Name": "J-League Winning Eleven 8 - Asia Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.41": {
+    "Name": "Driver 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.42": {
+    "Name": "Cool Girl [Konami the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.44": {
+    "Name": "Firefighter F.D. 18 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.45": {
+    "Name": "Tokimeki Memorial - Girl's Side [Konami Dendou Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.46": {
+    "Name": "FIFA Total Football 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.48": {
+    "Name": "Zoids Struggle",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.49": {
+    "Name": "Zoids Infinity",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.50": {
+    "Name": "Dokapon the World",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.51": {
+    "Name": "Suigetsu Mayoi-Gokoro",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.52": {
+    "Name": "Neo Contra",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.53": {
+    "Name": "Kessen [Koei Collection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.54": {
+    "Name": "Metal Gear Solid 2 [Konami Dendou Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.55": {
+    "Name": "Samurai Western - Katsugeki Samurai-dou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.56": {
+    "Name": "Tennis no Oji-Sama - Rush & Dream",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.57": {
+    "Name": "Medal of Honor - Rising Sun [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.58": {
+    "Name": "Sonic Mega Collection Plus",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.59": {
+    "Name": "Mr. Incredible",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.60": {
+    "Name": "Grand Theft Auto III [Capcom The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.61": {
+    "Name": "World Super Police",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.62": {
+    "Name": "Katakamuna",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.63": {
+    "Name": "007 Goldeneye - Rogue Agent",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.64": {
+    "Name": "Men at Work! 3 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.65": {
+    "Name": "Men at Work! 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.66": {
+    "Name": "Need for Speed Underground 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.67": {
+    "Name": "NBA Starting Five 2005",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.68": {
+    "Name": "Beatmania IIDX - 8th Style",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.69": {
+    "Name": "Pop'n Music 10 [with Pop'n Controller 2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.70": {
+    "Name": "Pop'n Music 10",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.71": {
+    "Name": "Natural 2 Duo - Sakurairo no Kisetsu [Deluxe Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.72": {
+    "Name": "Natural 2 Duo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.73": {
+    "Name": "Shining Tears",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.75": {
+    "Name": "Dance Dance Revolution - Festival",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_657.76": {
+    "Name": "Tenkuu Danzai - Skelter Heaven [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.77": {
+    "Name": "Tenkuu Danzai - Skelter Heaven",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.78": {
+    "Name": "Sega Ages 2500 Series Vol.18 - Dragon Force",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.79": {
+    "Name": "Exciting Pro Wrestling 5 [Yuke's the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.80": {
+    "Name": "Kessen III [Treasure Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.81": {
+    "Name": "Kessen III",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.83": {
+    "Name": "Nobunaga no Yabou Online - Tappi no Shou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.85": {
+    "Name": "Natsuiro - Hoshikuzu no Memory [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.86": {
+    "Name": "Natsuiro - Hoshikuzu no Memory",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.87": {
+    "Name": "NBA Live 2005",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.88": {
+    "Name": "Winning Eleven 8 - Liveware Evolution",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.89": {
+    "Name": "Metal Gear Solid 3 - Snake Eater [Premium Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.90": {
+    "Name": "Metal Gear Solid 3 - Snake Eater",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.91": {
+    "Name": "S.L.A.I. - Steel Lancer Arena International",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.93": {
+    "Name": "SSX 3 [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.94": {
+    "Name": "Capcom Fighting Jam",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_657.95": {
+    "Name": "Digital Devil Saga - Avatar Tuner 2",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPM_657.96": {
+    "Name": "Project Altered Beast",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.97": {
+    "Name": "Dragon Quest & Final Fantasy in Itadaki Street",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_657.98": {
+    "Name": "Madden NFL Superbowl 2005",
+    "Region": "NTSC-J"
+  },
+  "SLPM_657.99": {
+    "Name": "New Jinsei Game",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.00": {
+    "Name": "Radiata Stories",
+    "Region": "NTSC-J",
+    "VuAddSubHack": 1
+  },
+  "SLPM_658.01": {
+    "Name": "Crash Bandicoot 5",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_658.02": {
+    "Name": "Def Jam - Vendetta [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.03": {
+    "Name": "Freedom Fighters [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.04": {
+    "Name": "European Club Soccer - Winning Eleven Tactics",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.05": {
+    "Name": "Gojira Monster Fighter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.06": {
+    "Name": "VM Japan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.07": {
+    "Name": "Urbz, The - Sims in the City",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.08": {
+    "Name": "Derby Tsuku 4 - Derby Uma o Tsukurou!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.09": {
+    "Name": "NanoBreaker",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.10": {
+    "Name": "Densha de Go! Ryojouhen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.11": {
+    "Name": "Zero Shikikan Josentoki [Taito Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.12": {
+    "Name": "Bakushou! Jinsei Kaimichi [Taito Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.13": {
+    "Name": "Fu-un Bakumatsu Den",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_658.15": {
+    "Name": "Tom Clancy's Splinter Cell - Pandora Tomorrow",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.16": {
+    "Name": "Shin Bakusou Dekotora Densetsu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.17": {
+    "Name": "Tennis no Oji-Sama - Love of Prince Sweet [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.18": {
+    "Name": "Tennis no Oji-Sama - Love of Prince Bitter [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.19": {
+    "Name": "Tennis no Oji-Sama - Kiss of Prince - Ice Version [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.20": {
+    "Name": "Tennis no Oji-Sama - Kiss of Prince - Flame Version [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.21": {
+    "Name": "Shinseiki Yuusha Taisen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.22": {
+    "Name": "Ichigo 100% Strawberry Diary",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.23": {
+    "Name": "Shinsengumi Gunrou-den",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.24": {
+    "Name": "Viewtiful Joe 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_658.25": {
+    "Name": "Jikkyou Powerful Pro Yakyuu 11 Chou Ketteiban",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.26": {
+    "Name": "Tsukiyo ni Saraba",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_658.28": {
+    "Name": "Angel Wish",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.29": {
+    "Name": "Ys - The Ark of Napishtim [Limited Edition]",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPM_658.30": {
+    "Name": "Ys - The Ark of Napishtim",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPM_658.31": {
+    "Name": "Hello Kitty no PikoPiko Daisakusen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.32": {
+    "Name": "Izumo Complete",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.33": {
+    "Name": "Harukanaru Jikuu no Naka De 2 [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.34": {
+    "Name": "Harukanaru Jikuu no Naka De 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.35": {
+    "Name": "Bakumatsu Koihana - Shinsengumi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.36": {
+    "Name": "Ys - The Ark of Napishtim",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPM_658.37": {
+    "Name": "Terminator 3 - Redemption",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.38": {
+    "Name": "Hanjuku Hero 4 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.39": {
+    "Name": "Hanjuku Hero 4",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_658.40": {
+    "Name": "Wizardry X - Zensen no Gakufu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.41": {
+    "Name": "Mizuiro [Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.42": {
+    "Name": "Kanon [Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.43": {
+    "Name": "120-en no Haru - 120yen Stories",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.44": {
+    "Name": "Air [Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.46": {
+    "Name": "Lord of the Rings, The - Uchitsu Kuni Daisanki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.47": {
+    "Name": "Soriaro no Fuukin Remix [First Print - Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.48": {
+    "Name": "Soriaro no Fuukin Remix",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.53": {
+    "Name": "Let's Make a Baseball Team 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.54": {
+    "Name": "Red Dead Revolver",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.55": {
+    "Name": "Girls Bravo - Romance 15's [Deluxe Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.56": {
+    "Name": "Girls Bravo - Romance 15's",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.57": {
+    "Name": "Memories Off - After Rain Vol.1 [Special Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.58": {
+    "Name": "Memories Off - After Rain Vol.1",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.59": {
+    "Name": "Junrui Sosa - Kan Pony - Eirian vs. Seirian",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.60": {
+    "Name": "Shinki Genso Spectral Souls II [Premium Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.61": {
+    "Name": "Shinki Genso Spectral Souls II",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.62": {
+    "Name": "Pyua Pyua Mimi Toshippono Monogatari",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.63": {
+    "Name": "D1 Grand Prix Series - Professional Drift",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.64": {
+    "Name": "Nobunaga no Yabou - Tenka Sousei [with Power-Up Kit]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.66": {
+    "Name": "Izuku e Iku no, Anohi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.67": {
+    "Name": "Shinseiki Evangelion - Koutetsu no Girlfriend 2nd",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_658.68": {
+    "Name": "Metal Saga - Chain of Cloud",
+    "Region": "NTSC-J",
+    "DMABusyHack": "1 "
+  },
+  "SLPM_658.69": {
+    "Name": "Monster Hunter G",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_658.70": {
+    "Name": "Magic Teacher Negima - Honor Version",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.71": {
+    "Name": "Magic Teacher Negima - Scholarship Version",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_658.72": {
+    "Name": "Simple 2000 Series Ultimate Vol.24 - Makai Tensei",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.73": {
+    "Name": "Simple 2000 Series Ultimate Vol.23 - Project Minerva Professional",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.74": {
+    "Name": "Simple 2000 Series Vol.71 - The Fantasy Renai Adventure - Kanojo no Densetsu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.75": {
+    "Name": "Growlanser IV - Wayfarer of the Time [Atlus The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.76": {
+    "Name": "Busin 0 - Wizardry Alternative Neo [Atlus Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.78": {
+    "Name": "Galaxy Angel - Eternal Lovers",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.79": {
+    "Name": "C1 Grand Prix Racing Battle",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.80": {
+    "Name": "Devil May Cry 3",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "eeRoundMode": "0"
+  },
+  "SLPM_658.81": {
+    "Name": "SmackDown vs. Raw - Exciting Professional Wrestling 6",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.82": {
+    "Name": "Duel Masters",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.83": {
+    "Name": "Shadow of Rome",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.84": {
+    "Name": "Remote Control Dandy SF",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.85": {
+    "Name": "Rumble Roses",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.86": {
+    "Name": "Guisard Revolution",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.87": {
+    "Name": "Like Life an Hour",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.88": {
+    "Name": "Dragon Quest VIII",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_658.89": {
+    "Name": "Kazoku Keikaku - Kokoro no Kizuna",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.90": {
+    "Name": "Shin Sangoku Musou 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.91": {
+    "Name": "Sangokushi X",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.92": {
+    "Name": "Zill O'll Infinite",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.94": {
+    "Name": "Winning Post 6 - 2005 Version",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.96": {
+    "Name": "Tsuki wa Kirisaku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.97": {
+    "Name": "C1 Grand Prix Racing Battle",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.98": {
+    "Name": "Castle Fantasia [Deluxe Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_658.99": {
+    "Name": "Castle Fantasia",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.00": {
+    "Name": "Sakura Taisen 3 - Remake",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.01": {
+    "Name": "Shark Tale",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.02": {
+    "Name": "Memories Off - After Rain Vol.2 Souen [Special Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.03": {
+    "Name": "Memories Off - After Rain Vol.2 Souen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.04": {
+    "Name": "Baldr Force EXE",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.06": {
+    "Name": "Sakura Taisen 3 - Remake",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.07": {
+    "Name": "Def Jam Fight for NY",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.08": {
+    "Name": "Shining Force Neo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.09": {
+    "Name": "Super Monkey Ball Deluxe",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.10": {
+    "Name": "Cafe Lindbergh - Summer Season [Sweet Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.11": {
+    "Name": "Cafe Lindbergh - Summer Season",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.12": {
+    "Name": "Boboboubo Boubobo [Hudson the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.13": {
+    "Name": "Demento",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_659.14": {
+    "Name": "Nana",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_659.15": {
+    "Name": "Fallout - Brotherhood of Steel",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.16": {
+    "Name": "Harukanaru Jikuu no Kade - Hachiha Katsunori",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.17": {
+    "Name": "Transformers Tatakai [The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.18": {
+    "Name": "Dear My Love - Love Like Powdery Snow",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.19": {
+    "Name": "Rumble Fish, The",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_659.20": {
+    "Name": "Romancing SaGa - Minstrel Song",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_659.21": {
+    "Name": "Pia Carrot e Youkoso!! 3 [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.22": {
+    "Name": "Aikagi [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.23": {
+    "Name": "Canvas [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.24": {
+    "Name": "Kono Haretasora no Shita de [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.25": {
+    "Name": "Kono Haretasora no Shita de",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.26": {
+    "Name": "Y's IV - Mask of the Sun - A New Theory",
+    "Region": "NTSC-J",
+    "eeClampMode": 3
+  },
+  "SLPM_659.27": {
+    "Name": "Forgotten Realms - Demon Stone",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.28": {
+    "Name": "SuperLite 2000 Series - Memories Off Mix",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.29": {
+    "Name": "Pro Baseball Spirits 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.30": {
+    "Name": "EVE - Burst Error Plus [GameBridge The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.31": {
+    "Name": "Shinseiki Genso - Spectral Souls [IF Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.32": {
+    "Name": "Sento Country Kai - New Operation [with Bonus DVD]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.34": {
+    "Name": "Maple Colors",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.35": {
+    "Name": "Princess Maker 4 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.36": {
+    "Name": "Princess Maker 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.37": {
+    "Name": "Siekai no Senki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.38": {
+    "Name": "Memories Off - After Rain Vol.3 [Special Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.39": {
+    "Name": "Memories Off - After Rain Vol.3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.41": {
+    "Name": "Mabino Style",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.42": {
+    "Name": "Mercenaries",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.43": {
+    "Name": "Angel's Feather",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.44": {
+    "Name": "Detective Saburou Jinguiji 9 - Kind of Blue [Workjam Best Collection - Vol.2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.45": {
+    "Name": "Red Ninja - End of Honor",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.46": {
+    "Name": "Beatmania IIDX - 9th Style",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_659.47": {
+    "Name": "Killer 7",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.48": {
+    "Name": "Enthusia Professional Racing",
+    "Region": "NTSC-J",
+    "eeClampMode": 3
+  },
+  "SLPM_659.49": {
+    "Name": "Get Ride! AM Driver - The Truth of Xiangke",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.50": {
+    "Name": "Gantz - The Game",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_659.51": {
+    "Name": "Tom Clancy's Ghost Recon 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.52": {
+    "Name": "Tengai Makyou III - Namida",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.53": {
+    "Name": "Final Fantasy XI [Entry Disc 2005]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.54": {
+    "Name": "Tom Clancy's Ghost Recon [Ubisoft Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.55": {
+    "Name": "Tom Clancy's Splinter Cell [Ubisoft Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.57": {
+    "Name": "Harukanaru Jikuu no Kade Hachiha Katsunori",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.58": {
+    "Name": "Burnout 3 - Takedown [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.59": {
+    "Name": "Standard Daisenryoku - Shiwareta Shouri",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.60": {
+    "Name": "North Wind Promise Forever [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.61": {
+    "Name": "North Wind Promise Forever",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.62": {
+    "Name": "Home Maid - Owari no Tachi [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.63": {
+    "Name": "Home Maid - Owari no Tachi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.64": {
+    "Name": "Magical Tale - Chitchana Mahoutsukai [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.65": {
+    "Name": "Magical Tale - Chitchana Mahoutsukai",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.66": {
+    "Name": "Spectral Force Chronicle [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.67": {
+    "Name": "Spectral Force Chronicle",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.68": {
+    "Name": "Lovely Doll - Lovely Idol [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.69": {
+    "Name": "Lovely Doll - Lovely Idol",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.70": {
+    "Name": "Kappa no Kai-Kata - How to Breed Kappas [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.71": {
+    "Name": "Soshite Bokura wa... and He Said",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.72": {
+    "Name": "Constantine",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.73": {
+    "Name": "Mirai Shounen Conan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.74": {
+    "Name": "Kenka Banchou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.75": {
+    "Name": "World Rally Championship 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.76": {
+    "Name": "Grandia III",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_659.78": {
+    "Name": "Kurogane no Houkou 2 - Warship Gunner [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.80": {
+    "Name": "Dream Mix TV World Fighters [Hudson the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.81": {
+    "Name": "Front Mission Online",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.82": {
+    "Name": "Tokyo Bus Guide 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_659.84": {
+    "Name": "Grand Theft Auto - San Andreas",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.85": {
+    "Name": "Atelier Iris 2 - Eternal Mana",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.86": {
+    "Name": "Quartett! The Stage of Love [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.87": {
+    "Name": "Quartett! The Stage of Love",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.88": {
+    "Name": "Shoujo Yoshitsune Den 2 [Premium Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.89": {
+    "Name": "Shoujo Yoshitsune Den 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.90": {
+    "Name": "Neo Contra [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.91": {
+    "Name": "Anubis ZOE - Special Edition [Konami Dendou Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.94": {
+    "Name": "Remember 11 - The Age of Infinity [Superlite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.95": {
+    "Name": "Dog's Life",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.96": {
+    "Name": "Mars of Destruction [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.97": {
+    "Name": "Mars of Destruction",
+    "Region": "NTSC-J"
+  },
+  "SLPM_659.98": {
+    "Name": "Vampire Darkstalkers Collection",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_659.99": {
+    "Name": "Drag-on Dragoon 2 - Fuuin no Kurenai",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.00": {
+    "Name": "Conflict Delta II - Gulf War 1991",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.01": {
+    "Name": "Chocolat - Maid Cafe Curio",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.02": {
+    "Name": "Prince of Persia - Warrior Within",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.06": {
+    "Name": "Angelique Trois - Aizouhen [Koei Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.07": {
+    "Name": "Zoids Tactics",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.08": {
+    "Name": "Musashiden II - Blademaster",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.09": {
+    "Name": "World Soccer Winning Eleven 9 - Bonus Pack",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_660.10": {
+    "Name": "Tennis no Oji-Sama - Smash-Hit! [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.11": {
+    "Name": "Tennis no Oji-Sama - Smash-Hit! 2 [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.12": {
+    "Name": "Tennis no Oji-Sama - Sweat & Tears 2 [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.13": {
+    "Name": "Tennis no Oji-Sama - Form the Strongest Team [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.14": {
+    "Name": "Tennis no Oji-Sama - Rush & Dream [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.15": {
+    "Name": "SuperLite 2000 Series - Ever 17 - The Out of Infinity [Premium Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.16": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! Onimusha 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.18": {
+    "Name": "Silent Hill 3 [Konami Dendou Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.19": {
+    "Name": "Stuntman",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.20": {
+    "Name": "Psi-Ops - The Mindgate Conspiracy",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.21": {
+    "Name": "NBA Street v3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.22": {
+    "Name": "Kaido Touge no Densetsu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.23": {
+    "Name": "Fushigi Yuugi - Shigiyuugi Kurotake Kaiden Gaiden - Kagami no Fujo [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.24": {
+    "Name": "Fushigi Yuugi - Shigiyuugi Kurotake Kaiden Gaiden - Kagami no Fujo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.25": {
+    "Name": "Generation of Chaos IV [Idea Factory Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.26": {
+    "Name": "Honotomi - First Kiss [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.27": {
+    "Name": "Honotomi - First Kiss",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.28": {
+    "Name": "Ururun Quest",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_660.29": {
+    "Name": "Realize - Panorama Luminary",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.30": {
+    "Name": "Heavy Metal Thunder",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_660.31": {
+    "Name": "Phantasy Star Universe",
+    "Region": "NTSC-J",
+    "eeRoundMode": "0"
+  },
+  "SLPM_660.32": {
+    "Name": "Silent Hill 4 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.33": {
+    "Name": "Oz",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.34": {
+    "Name": "Grand Theft Auto - Vice City",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.35": {
+    "Name": "Kenka Banchou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.38": {
+    "Name": "Georama Sensen Ijou Nashi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.39": {
+    "Name": "SuperLite 2000 Series - Memories Off... Sorekara",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.40": {
+    "Name": "Edo Mono",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.41": {
+    "Name": "Shoujo Yoshitsune Den [WellMADE The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.42": {
+    "Name": "Brother in Arms - Road to Hill 30",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.43": {
+    "Name": "Racing Game - Chuui!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.44": {
+    "Name": "MVP Baseball 2005",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.45": {
+    "Name": "My Merry May with be",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.46": {
+    "Name": "Star Wars - Episode III - Revenge of the Sith",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.47": {
+    "Name": "FIFA Street",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.49": {
+    "Name": "D.C.P.S. - Da Capo Plus Situation [Kadokawa the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.50": {
+    "Name": "Daisan Teikoku Koubouki II - Aufstieg und Fall des Dritten Reich",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.51": {
+    "Name": "Need for Speed Underground 2 [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.52": {
+    "Name": "Miko Mai - Eien no Omoi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.53": {
+    "Name": "Dokapon DX [Asmik Ace Best Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.54": {
+    "Name": "Generation of Chaos 5 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.55": {
+    "Name": "Generation of Chaos 5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.56": {
+    "Name": "Mushihime Sama",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_660.57": {
+    "Name": "Taito Memories Vol.1",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.58": {
+    "Name": "Sengoku Basara",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.59": {
+    "Name": "Robots",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.60": {
+    "Name": "Boukoku no Aegis 2035 - Warship Gunner",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.61": {
+    "Name": "Jikkyou Powerful Pro Baseball 12",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.62": {
+    "Name": "Mahou Sensei Negima! Gold Medal",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.63": {
+    "Name": "Mahou Sensei Negima! Silver Medal",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.64": {
+    "Name": "Tough - Dark Fight",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.65": {
+    "Name": "Pop'n Music 11",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.68": {
+    "Name": "Richard Burns Rally",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.69": {
+    "Name": "Shikigami no Shiro - Nanayozuki Gensoukyoku",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_660.70": {
+    "Name": "Shadow Hearts - From the New World [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.71": {
+    "Name": "Shadow Hearts - From the New World",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_660.72": {
+    "Name": "Fight Night Round 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.73": {
+    "Name": "Hagane no Renkinjutsushi 3 - Kami o Tsugu Shoujo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.74": {
+    "Name": "Sonic Gems Collection",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_660.76": {
+    "Name": "Meine Liebe - Yuubinaru kioku [Konami the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.77": {
+    "Name": "K-1 World Max 2005",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.78": {
+    "Name": "White Princess the Second",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.80": {
+    "Name": "Generation of Chaos 3 [IF Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.81": {
+    "Name": "Atelier no Iris - Eternal Mana [Gust Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.82": {
+    "Name": "Fire Pro Wrestling Returns",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.84": {
+    "Name": "Ramune - Garasu-Bin ni Uturu Umi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.85": {
+    "Name": "Rumble Roses [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.86": {
+    "Name": "Gokujou Seitokai",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.87": {
+    "Name": "Winning Post 7",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.89": {
+    "Name": "3-Nen B-Gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate! [Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.90": {
+    "Name": "Crash Tag Team Wrestling",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.91": {
+    "Name": "Shinobido Imashime",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.92": {
+    "Name": "Taito Memories Gekan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.93": {
+    "Name": "Kessen II [Koei Selection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.94": {
+    "Name": "Shin Sangoku Musou 2 [Koei Selection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.96": {
+    "Name": "Shin Sangoku Musou 2 - Mushouden [Koei Selection Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.97": {
+    "Name": "Shinseiki Evangelion - Ayanami Ikusai Keikaku with Asuka Hokan Keikaku [Broccoli Best Quality]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_660.98": {
+    "Name": "True Crime - Streets of L.A. [CapKore]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.00": {
+    "Name": "Harukanaru Jikuu no Kade 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.01": {
+    "Name": "Shin Sangoku Musou 4 - Moushouden",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.02": {
+    "Name": "Zwei!! [Taito the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.03": {
+    "Name": "WRC 3 [Spike the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.04": {
+    "Name": "Puyo Puyo Fever 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.05": {
+    "Name": "Rhapsodia",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.06": {
+    "Name": "Hoshi no Furu Koku [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.07": {
+    "Name": "Hoshi no Furu Koku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.08": {
+    "Name": "Burnout Revenge",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.09": {
+    "Name": "Code Age Commanders",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.10": {
+    "Name": "Fushigi no Umi no Nadia - Inherit the Blue Water [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.12": {
+    "Name": "Fushigi no Umi no Nadia - Inherit the Blue Water",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.13": {
+    "Name": "Hissatsu Ura-Kagyou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.14": {
+    "Name": "Nizu no Senritsu [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.15": {
+    "Name": "Nizu no Senritsu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.16": {
+    "Name": "NBA Live 2005 [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.17": {
+    "Name": "Metal Gear Solid 3 - Subsistence [with Headset]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.22": {
+    "Name": "Kingdom Hearts [Ultimate Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.23": {
+    "Name": "Kingdom Hearts - Final Mix [Ultimate Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.24": {
+    "Name": "Final Fantasy X [Ultimate Hits]",
+    "Region": "NTSC-J",
+    "IPUWaitHack": 1
+  },
+  "SLPM_661.25": {
+    "Name": "Final Fantasy X-2 [Ultimate Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.29": {
+    "Name": "Guilty Gear XX #Reload",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.30": {
+    "Name": "Tom Clancy's Splinter Cell - Chaos Theory",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.31": {
+    "Name": "Tim Burton's The Nightmare Before Christmas [Premium Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.32": {
+    "Name": "Gladiator - Road to Freedom - Remix",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.34": {
+    "Name": "Shuffle! On the Stage",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.35": {
+    "Name": "World Tank Museum For Game - Toubu Sensen Success",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.36": {
+    "Name": "SuperLite 2000 Series - Akaiito",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.37": {
+    "Name": "Clover Heart's Looking for Happiness [The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.38": {
+    "Name": "Desire [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.39": {
+    "Name": "Duel Savior Destiny",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.40": {
+    "Name": "Atelier Marie + Elie - Atelier of Salburg 1&2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.41": {
+    "Name": "Matantei Loki Ragnarok Mayoukaku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.42": {
+    "Name": "Rebirth Moon [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.43": {
+    "Name": "Rebirth Moon",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.44": {
+    "Name": "D1 Grand Prix 2005",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.45": {
+    "Name": "GoldenEye - Rogue Agent [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.46": {
+    "Name": "Memories Off #5 - Togireta Film [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.47": {
+    "Name": "Memories Off #5 - Togireta Film",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.48": {
+    "Name": "Star Wars - Battlefront [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.49": {
+    "Name": "Shirogane no Torikago [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.50": {
+    "Name": "Shirogane no Torikago",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.51": {
+    "Name": "Killzone",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.52": {
+    "Name": "Konneko - Keep a Memory Green [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.53": {
+    "Name": "Konneko - Keep a Memory Green",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.55": {
+    "Name": "Flame of Recca - Final Burning [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.56": {
+    "Name": "Marheaven Arm Fight Dream",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.57": {
+    "Name": "Rune Princess [First Print - Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.58": {
+    "Name": "Rune Princess",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.59": {
+    "Name": "Call of Duty - Final Hour",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.60": {
+    "Name": "Devil May Cry 3 [Special Edition]",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "eeRoundMode": "0"
+  },
+  "SLPM_661.63": {
+    "Name": "Fuuraiki 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.64": {
+    "Name": "Mahou Tsukai Kurohime",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_661.65": {
+    "Name": "Otome Hao Anesama ni Koi Shiteru",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.66": {
+    "Name": "Shadow the Hedgehog",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.67": {
+    "Name": "God of War",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.68": {
+    "Name": "Ryu Ga Gotoku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.69": {
+    "Name": "J-League Winning Eleven 9 - Asia Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.70": {
+    "Name": "Genso Suikoden V [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.71": {
+    "Name": "NBA Live '06",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.75": {
+    "Name": "Akumajo Dracula - Yami no Juin",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "vuClampMode": "0"
+  },
+  "SLPM_661.76": {
+    "Name": "Chaos Field - New Order",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.77": {
+    "Name": "Matrix,The - Path of Neo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.78": {
+    "Name": "Pop'n Music 7 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.79": {
+    "Name": "Pop'n Music 8 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.80": {
+    "Name": "Beatmania IIDX - 10th Style",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.81": {
+    "Name": "Beat Down - Fists of Vengeance",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.82": {
+    "Name": "Kono Haretasora no Shita de [Good Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.83": {
+    "Name": "Getaway, The - Black Monday",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.84": {
+    "Name": "Ikusa Gami",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.85": {
+    "Name": "Game ni Nattayo! Dokura-chan [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.86": {
+    "Name": "Game ni Nattayo! Dokura-chan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.87": {
+    "Name": "Exciting Pro Wrestling 6 - SmackDown vs. RAW [Yuke's the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.89": {
+    "Name": "SSX On Tour",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.90": {
+    "Name": "Star Wars Battlefront II",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.91": {
+    "Name": "Tiger Woods PGA Tour '06",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.92": {
+    "Name": "Izumo 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.93": {
+    "Name": "Fahrenheit",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.94": {
+    "Name": "Otona no Gal Jan 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.95": {
+    "Name": "SuperLite 2000 Series - Love Adventure Monochrome",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_661.96": {
+    "Name": "Sentimental Prelude [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_661.97": {
+    "Name": "Godzilla Kaijuu Dairansen - Chikyuu Saishuu Kessen [Atari Hot Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.01": {
+    "Name": "Seishun no Kagayaki [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.02": {
+    "Name": "Fragments Blue [Special Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.03": {
+    "Name": "Fragments Blue",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.04": {
+    "Name": "Madden NFL '06",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.05": {
+    "Name": "Front Mission 5 - Scars of the War",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.06": {
+    "Name": "Battlefield 2 - Modern Combat",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.07": {
+    "Name": "Dororo [Sega the Best 2800]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.08": {
+    "Name": "Sakura Taisen V - Episode 0 - Samurai Girl of Wild [Sega the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.09": {
+    "Name": "Pop'n Music 9 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.10": {
+    "Name": "Pop'n Music 10 [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.11": {
+    "Name": "King Kong, Peter Jackson's - The Official Game of the Movie",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.12": {
+    "Name": "Sega Rally 2006",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_662.13": {
+    "Name": "BioHazard 4",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_662.14": {
+    "Name": "White Clarity - And, the Tears Became You [First Print Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.15": {
+    "Name": "White Clarity - And, the Tears Became You",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.17": {
+    "Name": "Jikkyou Powerful Pro Yakyuu 12 Ketteiban",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.18": {
+    "Name": "Eyeshield 21 Amefoot Yarouze! Ya-!Ha-!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.19": {
+    "Name": "Tennis no Oji-Sama - Gakuensai no Oji-Sama",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.20": {
+    "Name": "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc1of3]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.21": {
+    "Name": "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc2of3]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.22": {
+    "Name": "Metal Gear Solid 3 - Subsistence [First Print Limited Edition] [Disc3of3]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.23": {
+    "Name": "Metal Gear Solid 3 - Subsistence [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.24": {
+    "Name": "Metal Gear Solid 3 - Subsistence [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.25": {
+    "Name": "Da Capo Four Seasons [Deluxe Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.26": {
+    "Name": "Da Capo Four Seasons",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.27": {
+    "Name": "GI Jockey 4 + Winning Post 7 [Twin Pack] [GI Jockey 4 Disc]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.28": {
+    "Name": "GI Jockey 4 + Winning Post 7 [Twin Pack] [Winning Post 7 Disc]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.29": {
+    "Name": "GI Jockey 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.31": {
+    "Name": "Karutagura - Tamashii no Kunou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.32": {
+    "Name": "Need for Speed - Most Wanted",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.33": {
+    "Name": "Kingdom Hearts II",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_662.34": {
+    "Name": "Wizardry X - Zensen no Gakufu [Wonder Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.35": {
+    "Name": "Psychic Force Complete",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.37": {
+    "Name": "Otometeki Koi Kakumei Rabu Rebo!! [Love Revo Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.38": {
+    "Name": "Otometeki Koi Kakumei Rabu Rebo!!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.39": {
+    "Name": "Wrestle Angels - Survivor",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.40": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! Aladdin 2 Evolution",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.41": {
+    "Name": "Jissen Pachinko Hisshouhou! CR Hokuto no Ken",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.42": {
+    "Name": "Dance Dance Revolution - Strike",
+    "Region": "NTSC-J",
+    "Compat": 2
+  },
+  "SLPM_662.43": {
+    "Name": "Galaxy Angel II",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.44": {
+    "Name": "Derby Tsuku 5 - Derby Uma o Tsukurou!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.45": {
+    "Name": "Jewels Ocean - Star of Sierra Leone",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.46": {
+    "Name": "Shin Megami Tensei - Devil Summoner - Kuzunoha Raidou",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_662.47": {
+    "Name": "Meine Liebe II - Hokori to Seigi to Ai",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.48": {
+    "Name": "Mr. Incredible - Kyouteki Underminer Toujou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.49": {
+    "Name": "Growlanser V - Generations [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.50": {
+    "Name": "Choro Q - HG 4 [Takara Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.51": {
+    "Name": "EX Jinsei Game II [Takara Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.53": {
+    "Name": "Finalist [Limited First Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.54": {
+    "Name": "Finalist",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.55": {
+    "Name": "World Soccer Winning Eleven 9 [Bonus Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.57": {
+    "Name": "Enthusia - Professional Racing",
+    "Region": "NTSC-J",
+    "eeClampMode": 3
+  },
+  "SLPM_662.58": {
+    "Name": "Magic Teacher Negima - Honor Version [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.59": {
+    "Name": "Mahou Sensei Negima! Silver Medal [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.60": {
+    "Name": "Remote Control Dandy SF [Konami the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.61": {
+    "Name": "Oz [Konami The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.62": {
+    "Name": "Tom Clancy's Rainbow Six 3 [Ubisoft The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.63": {
+    "Name": "Full Spectrum Warrior",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPM_662.64": {
+    "Name": "Canvas 2 - Niji-iro no Sketch [Deluxe Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.65": {
+    "Name": "Canvas 2 - Niji-iro no Sketch",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.66": {
+    "Name": "Kurogane no Houkou 2 - Warship Commander [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.67": {
+    "Name": "Taiko Risshiden V",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.68": {
+    "Name": "Smackdown! vs. Raw 2006 - Exciting Pro Wrestling 7",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.69": {
+    "Name": "Blazing Souls [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.70": {
+    "Name": "Blazing Souls",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.71": {
+    "Name": "Dirge of Cerberus - Final Fantasy VII",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_662.72": {
+    "Name": "I-O",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.73": {
+    "Name": "Memories Off After Rain Vol.1 - Ensou [Superlite 2000]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.74": {
+    "Name": "Ninkyouden Toseinin Ichidaiki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.75": {
+    "Name": "Shin Onimusha - Dawn of Dreams [Disc1of2]",
+    "Region": "NTSC-J",
+    "Compat": 2
+  },
+  "SLPM_662.76": {
+    "Name": "Shin Onimusha - Dawn of Dreams [Disc2of2]",
+    "Region": "NTSC-J",
+    "Compat": 2
+  },
+  "SLPM_662.77": {
+    "Name": "Juiced",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.78": {
+    "Name": "Shin Gouketuji Ichizoku - Bonnou Kaihou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.79": {
+    "Name": "Nobunaga no Yabou - Kakushin",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.80": {
+    "Name": "Monster Hunter 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_662.81": {
+    "Name": "Sonic Riders",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.82": {
+    "Name": "Memories Off After Rain Vol.2 - Souen [Superlite 2000]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.83": {
+    "Name": "SuperLite 2000 Series - Memories Off After Rain Vol.3 - Graduation",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.84": {
+    "Name": "Dessert Love - Sweet Plus",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.85": {
+    "Name": "Princess Concerto",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.86": {
+    "Name": "Genso Suikoden V",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.87": {
+    "Name": "Sengoku Basara",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.88": {
+    "Name": "Full House Kiss 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.89": {
+    "Name": "Black Cat",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.90": {
+    "Name": "Galaxy Angel [The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.91": {
+    "Name": "Tenkabito",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.92": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! Ultraman Club ST",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.93": {
+    "Name": "Gakuen Alice - KiraKira Memory Kiss",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.94": {
+    "Name": "Sotsugyou 2nd Generation",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.95": {
+    "Name": "Yamiyo ni Sasayaku - Tantei Sagara Kyouichirou [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.96": {
+    "Name": "Yamiyo ni Sasayaku - Tantei Sagara Kyouichirou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.97": {
+    "Name": "Separate Hearts [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.98": {
+    "Name": "Separate Hearts",
+    "Region": "NTSC-J"
+  },
+  "SLPM_662.99": {
+    "Name": "Reishiki Kanjou Sentouki 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.00": {
+    "Name": "Wizardry Xth - Mugen no Gakuto",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.01": {
+    "Name": "Ibara",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.02": {
+    "Name": "Clannad",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.07": {
+    "Name": "Sengoku Musou 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.08": {
+    "Name": "Harukanaru Toki no Naka Premium Boxset",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.13": {
+    "Name": "Guitar Freaks V & DrumMania V",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.14": {
+    "Name": "Pop'n Music 12 - Iroha",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_663.15": {
+    "Name": "Shinseiki Evangelion - Koutetsu no Girlfriend 2nd [Broccoli Best Quality]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.16": {
+    "Name": "Pro Soccer Club o Tsukurou! Europe Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.17": {
+    "Name": "Capcom Classics Collection Vol.1",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.18": {
+    "Name": "Haru no Ashioto - Step of Spring",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.19": {
+    "Name": "New Choro Q [Atlus Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.20": {
+    "Name": "Final Fantasy XII",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_663.21": {
+    "Name": "Kurogane no Houkou - Warship Gunner 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.22": {
+    "Name": "James Bond 007 - From Russia With Love",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.23": {
+    "Name": "Princess Software Collection, The",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.24": {
+    "Name": "World Football Climax",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.25": {
+    "Name": "Castlevania - Lament of Innocence [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.27": {
+    "Name": "Wallace and Gromit - The Curse of the Were-Rabbit",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.28": {
+    "Name": "Call of Duty 2 - Big Red One",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.29": {
+    "Name": "Mahou Sensei Negima! Kagai Jugyou",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_663.30": {
+    "Name": "Tokimeki Memorial - Girl's Side - 2nd Kiss",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.31": {
+    "Name": "Kouenji Onago Soccer [1st Stage Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.32": {
+    "Name": "Kouenji Onago Soccer",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.33": {
+    "Name": "Guilty Gear XX Slash",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_663.34": {
+    "Name": "WRC - World Rally Championship 4 [Spike the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.36": {
+    "Name": "Shinseiki Evangelion - Koutetsu no Girlfriend [Special Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.37": {
+    "Name": "EVE New Generation [Deluxe Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.38": {
+    "Name": "EVE New Generation",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.39": {
+    "Name": "Neo Angelique [Premium Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.40": {
+    "Name": "Neo Angelique",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.41": {
+    "Name": "Jan Sangoku Musou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.42": {
+    "Name": "Winning Post 7 Maximum 2006",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.43": {
+    "Name": "Shin Sangoku Musou 4 - Empires",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.48": {
+    "Name": "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.49": {
+    "Name": "Spectral Force Chronicle",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.50": {
+    "Name": "Spectral vs. Generation",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.51": {
+    "Name": "Soshite Kono Uchuu ni Kirameku Kimi no Shi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.52": {
+    "Name": "Memories Off - Sorekara Again [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.53": {
+    "Name": "Memories Off - Sorekara Again",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.54": {
+    "Name": "Black",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "vuClampMode": "0"
+  },
+  "SLPM_663.56": {
+    "Name": "Baldr Force EXE [Alchemist Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.58": {
+    "Name": "Shinobido Takumi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.59": {
+    "Name": "Mutsuzaki Hoshi Kikari",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.60": {
+    "Name": "Ys V - Lost Kefin - Kingdom of Sand",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.61": {
+    "Name": "Konohana 4 - Yami wo Harau Inori [Superlite 2000]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.63": {
+    "Name": "Dragon Quest - Shounen Yangus no Fushigi na Daibouken",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.64": {
+    "Name": "Pro Yakyuu Spirits 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.71": {
+    "Name": "Train Simulator & Densha de Go! Tokyo Kyuukouhen [Ongakukan Pocket Books]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.72": {
+    "Name": "Digital Devil Saga - Avatar Tuner [Atlus Best Collection]",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPM_663.73": {
+    "Name": "Digital Devil Saga - Avatar Tuner 2 (Atlus Best Collection]",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPM_663.74": {
+    "Name": "World Soccer Winning Eleven 10",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_663.75": {
+    "Name": "Ookami",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_663.76": {
+    "Name": "KimiStar - Kimi to Study [BGM Collection Package]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.77": {
+    "Name": "KimiStar - Kimi to Study",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.78": {
+    "Name": "Garfield - Saving Arleene",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.79": {
+    "Name": "Kishin Houkou Demon Bane [Kadokawa The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.80": {
+    "Name": "Mitsu x Mitsu Drops - Love x Love Honey Life [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.81": {
+    "Name": "Mitsu x Mitsu Drops - Love x Love Honey Life",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.82": {
+    "Name": "Tenshou Gakuen Kensousoku [Tokudame Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.83": {
+    "Name": "Natsuyume Yobanashi [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.84": {
+    "Name": "Iris [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.85": {
+    "Name": "Omoi no Kakera - Close to [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.86": {
+    "Name": "FIFA World Cup - Germany 2006",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.87": {
+    "Name": "Shin Bakusou Dekotora Densetsu [Spike the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.88": {
+    "Name": "Fire Pro Wrestling Returns [Spike The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.90": {
+    "Name": "Shoubi no Ki ni Shoubi no Hanasaku - Das Versprechen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.91": {
+    "Name": "Prince of Persia - The Two Thrones",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.93": {
+    "Name": "Final Fantasy XI - Aht Urghan no Hihou [All-in-One Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.94": {
+    "Name": "Final Fantasy XI - Aht Urghan no Hihou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.95": {
+    "Name": "Honoo no Takkyubin",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.96": {
+    "Name": "Tensei Hakken Fuumoroku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.98": {
+    "Name": "Parufu - Chocolat Second Brew",
+    "Region": "NTSC-J"
+  },
+  "SLPM_663.99": {
+    "Name": "Samurai 7 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.00": {
+    "Name": "Samurai 7",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.01": {
+    "Name": "Wrestle Kingdom",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_664.02": {
+    "Name": "Taito Memories Vol.1 [Taito The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.05": {
+    "Name": "Rajirugi - Precious",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_664.06": {
+    "Name": "Sakura Hana",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.07": {
+    "Name": "Mighty Heart",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.08": {
+    "Name": "Tsuyo Kiss - Mighty Heart",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.09": {
+    "Name": "Street Fighter Zero - Fighters Generation",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_664.10": {
+    "Name": "Brothers In Arms - Earned In Blood",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.12": {
+    "Name": "Pizzicato Polka - Suisei Genya [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.13": {
+    "Name": "Cross+Channel - To All People [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.15": {
+    "Name": "Mystereet [First Print - Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.16": {
+    "Name": "Mystereet",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.17": {
+    "Name": "Jikkyou Powerful Pro Major League",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.18": {
+    "Name": "Growlanser V - Generations",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.19": {
+    "Name": "Valkyrie Profile 2 - Silmeria",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLPM_664.20": {
+    "Name": "Front Mission 4 [Ultimate Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.21": {
+    "Name": "Front Mission 5 - Scars of the War [Ultimate Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.22": {
+    "Name": "Romancing Saga - Minstrel Song [Ultimate Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.24": {
+    "Name": "La Corda D'oro [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.26": {
+    "Name": "Beatmania IIDX 11 - Red",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.27": {
+    "Name": "Full Spectrum Warrior - Ten Hammers",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPM_664.29": {
+    "Name": "Special Forces - Fire for Effect",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.30": {
+    "Name": "Destroy All Humans!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.31": {
+    "Name": "WinBack 2 - Project Poseidon",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.32": {
+    "Name": "Tamashii Kyou [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.33": {
+    "Name": "Tamashii Kyou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.34": {
+    "Name": "Festa!! Hyper Girls Party [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.35": {
+    "Name": "Festa!! Hyper Girls Party",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.36": {
+    "Name": "Atelier Iris - Grand Fantasm",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_664.37": {
+    "Name": "Soul Link Extension",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.38": {
+    "Name": "Melty Blood - Act Cadenza",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_664.39": {
+    "Name": "Hokenshitsu e Youkoso [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.40": {
+    "Name": "Hokenshitsu e Youkoso",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.41": {
+    "Name": "Oookuki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.43": {
+    "Name": "FIFA Street 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.44": {
+    "Name": "Spartan - Total Warrior",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.45": {
+    "Name": "Persona 3",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "VuClipFlagHack": 1
+  },
+  "SLPM_664.46": {
+    "Name": "Beat Down - Fists of Vengeance [CapKore]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.47": {
+    "Name": "Sengoku Basara 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_664.48": {
+    "Name": "We Are [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.49": {
+    "Name": "We Are",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.50": {
+    "Name": "Jikkyou Powerful Pro Baseball 13",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_664.51": {
+    "Name": "Major League Baseball 2K6",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.52": {
+    "Name": "Kamaitachi no Yoru 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.53": {
+    "Name": "Hiiro no Kakera [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.54": {
+    "Name": "Hiiro no Kakera",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.55": {
+    "Name": "Spectral Force - Radical Elements [IF Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.56": {
+    "Name": "Asobi ni Iku Yo! [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.57": {
+    "Name": "Asobi ni Iku Yo!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.58": {
+    "Name": "Acheter Fuuraiki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.59": {
+    "Name": "Zero Pilot - Zero",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.60": {
+    "Name": "Summer ##",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.61": {
+    "Name": "Tom Clancy's Ghost Recon - Advanced Warfighter",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.62": {
+    "Name": "Disney-Pixer's Cars",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.63": {
+    "Name": "Def Jam - Fight for NY [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.64": {
+    "Name": "MVP Baseball 2005 [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.65": {
+    "Name": "Mercenaries [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.67": {
+    "Name": "Midway Arcade Treasures - The Game Center of USA",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.68": {
+    "Name": "Area 51",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.69": {
+    "Name": "Love-Com - Punch de Court [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.70": {
+    "Name": "Love-Com - Punch de Court",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_664.71": {
+    "Name": "Hanaki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.72": {
+    "Name": "Planetarian - The Reverie of a Little Planet",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.73": {
+    "Name": "True Crime - New York City",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.74": {
+    "Name": "Odin Sphere",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_664.75": {
+    "Name": "Pachislot Hokuto no Ken [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.76": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! Salaryman Kintarou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.77": {
+    "Name": "Kamiwaza",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.78": {
+    "Name": "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc1of2]",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLPM_664.79": {
+    "Name": "Star Ocean 3 - Till the End of Time [Ultimate Hits] [Disc2of2]",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLPM_664.80": {
+    "Name": "Dragon Quest V - Bride of the Sky [Ultimate Hits]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_664.81": {
+    "Name": "Dragon Quest VIII [Ultimate Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.82": {
+    "Name": "Tokimeki Memorial - Girl's Side 2nd Kiss",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.83": {
+    "Name": "Mushihimesama [Taito Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.84": {
+    "Name": "Guitar Freaks & Drummania - Masterpiece Silver",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_664.85": {
+    "Name": "State of Emergency - Revenge",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.86": {
+    "Name": "Tentama - 1st Sunny Side [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.87": {
+    "Name": "Tentama 2 - Wins [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.88": {
+    "Name": "My Merry May With Be [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.89": {
+    "Name": "Mabino Style [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.91": {
+    "Name": "Ayaka Shibito",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.92": {
+    "Name": "Commandos Strike Force",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.93": {
+    "Name": "Shinten Makai - Generation of Chaos V [IF Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.94": {
+    "Name": "Joshikousei Game's High! [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.95": {
+    "Name": "Joshikousei Game's High!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.96": {
+    "Name": "Tom Clancy's Splinter Cell - Chaos Theory",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.97": {
+    "Name": "Ice Age 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.98": {
+    "Name": "TOCA Race Driver 2 - Ultimate Racing Simulator",
+    "Region": "NTSC-J"
+  },
+  "SLPM_664.99": {
+    "Name": "Kamisama Kazoku - Ouen Ganbou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.00": {
+    "Name": "Like Life an Hour [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.01": {
+    "Name": "Onimusha [Mega Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.02": {
+    "Name": "Devil May Cry [Mega Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.03": {
+    "Name": "Metal Gear Solid 2 [Mega Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.04": {
+    "Name": "Onimusha 2 [Mega Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.05": {
+    "Name": "Shin Sangoku Musou 2 [Mega Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.06": {
+    "Name": "Gundam - Federation vs. Zeon DX [Mega Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.07": {
+    "Name": "Otome no Jijou [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.08": {
+    "Name": "Otome no Jijou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.09": {
+    "Name": "Rugby '06",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.10": {
+    "Name": "NHL '06",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.11": {
+    "Name": "Kyuuryuu Youma Gakuenki Re-charge",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_665.12": {
+    "Name": "Fate-stay Night - Realta Nua [Extra Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.13": {
+    "Name": "Fate-stay Night - Realta Nua",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.14": {
+    "Name": "Medal of Honor - European Assault [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.15": {
+    "Name": "Star Wars - Episode III - Sith no Fukushuu [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.16": {
+    "Name": "Sims, The & The Urbz - Sims in the City [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.18": {
+    "Name": "Teikoku Sensenki [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.19": {
+    "Name": "Gakuen Heaven - Boy's Love Scramble! [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.20": {
+    "Name": "BioHazard - Code Veronica [Premium Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.21": {
+    "Name": "Taito Memories Vol.2 [Taito The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.22": {
+    "Name": "Shin Sangoku Musou 3 [KOEI Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.23": {
+    "Name": "Sangokushi IX [with Power-Up Kit]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.24": {
+    "Name": "Angelique Etoile [Koei Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.25": {
+    "Name": "Zill O'll Infinite [Koei The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.26": {
+    "Name": "Gaika no Gouhou - Air Land Force [KOEI Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.27": {
+    "Name": "Sangokushi Senki 2 [KOEI Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.28": {
+    "Name": "Nobunaga no Yabou - Tenka Sousei [with Power Up Kit] [KOEI the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.29": {
+    "Name": "Boukoku no Aegis 2035 - Warship Gunner [KOEI the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.30": {
+    "Name": "Gift Prism",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.31": {
+    "Name": "Nizu no Senritsu 2 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.32": {
+    "Name": "Nizu no Senritsu 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.33": {
+    "Name": "Pop'n Music 13 - Carnival",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.34": {
+    "Name": "Ryu Koku [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.35": {
+    "Name": "Ryu Koku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.36": {
+    "Name": "Aria the Natural",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.37": {
+    "Name": "Atelier Iris - Eternal Mana 2 [Gust Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.38": {
+    "Name": "GI Jockey 4 2006",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.39": {
+    "Name": "Nobunaga no Yabou Online - Haten no Shou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.42": {
+    "Name": "Sengoku Musou 2 Empires",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.43": {
+    "Name": "Youjinbou - Unmei no Freud",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.44": {
+    "Name": "Sekai no Zente - Two of Us",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.48": {
+    "Name": "Harukanaru Jikuu no Uchi de Mai Ichi Yoru",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.49": {
+    "Name": "Sangokushi XI",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.50": {
+    "Name": "God Hand",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_665.51": {
+    "Name": "Appleseed EX",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.52": {
+    "Name": "Neverland Reportage",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.53": {
+    "Name": "Chaos Wars",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.54": {
+    "Name": "Interlude [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.55": {
+    "Name": "SuperLite 2000 Series - Tokyo Bus Guide 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.56": {
+    "Name": "Shinobido Imashime [Spike The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.57": {
+    "Name": "FIFA Street [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.58": {
+    "Name": "Tomb Raider - Legend",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.59": {
+    "Name": "Winning Post 6 [KOEI Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.60": {
+    "Name": "Sangokushi X [KOEI The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.61": {
+    "Name": "NBA Live '06 [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.62": {
+    "Name": "Need for Speed - Most Wanted [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.63": {
+    "Name": "Nizu no Senritsu [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.64": {
+    "Name": "REC - DokiDoki Seiyuu Paradise [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.65": {
+    "Name": "REC - DokiDoki Seiyuu Paradise",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.66": {
+    "Name": "Tenshou Gakuen Gekkou Hasumi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.67": {
+    "Name": "Driver - Parallel Lines",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.68": {
+    "Name": "Brothers in Arms - Road to Hill 30 [Ubisoft Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.69": {
+    "Name": "Secret of Evangelion",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.70": {
+    "Name": "I's Pure",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.71": {
+    "Name": "Memories Off #5 - Togireta [Superlite 2000 Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.72": {
+    "Name": "LEGO Star Wars II - The Original Trilogy",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.73": {
+    "Name": "Kurogane no Houkou 2 - Warship Gunner [KOEI Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.74": {
+    "Name": "Meitantei Evangelion",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.75": {
+    "Name": "Guitar Freaks V-2 & Drummania V-2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.76": {
+    "Name": "Seiken Densetsu 4",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_665.77": {
+    "Name": "Gladiator - Road to Freedom [Special Remix] [Ertain the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.82": {
+    "Name": "Kohitsuji Hokaku Keakaku! Sweet Boys Life [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.83": {
+    "Name": "Kohitsuji Hokaku Keakaku! Sweet Boys Life",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.84": {
+    "Name": "Yoake Yori Ruriiro na - Brighter than Dawning Blue",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.85": {
+    "Name": "Elvandia Story",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.86": {
+    "Name": "Karutagura - Tamashii no Kunou [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.87": {
+    "Name": "Karutagura - Tamashii no Kunou [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.88": {
+    "Name": "White Princess the Second [2800 Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.89": {
+    "Name": "NBA Live '07",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.90": {
+    "Name": "Jikkyou Powerful Pro Yakyuu 13 Chou Ketteiban",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.91": {
+    "Name": "FlatOut 2 GTR",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.92": {
+    "Name": "Negima! 3-Jikanme [Theater Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.93": {
+    "Name": "Negima! 3-Jikanme [Live Version]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_665.94": {
+    "Name": "Rhapsodia [Konami the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.95": {
+    "Name": "J-League Winning Eleven 10 - Europa League '06-'07",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.96": {
+    "Name": "Prince of Tennis - Gakuensai no Oji-sama [Konami the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_665.98": {
+    "Name": "Yatohime Zankikou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.00": {
+    "Name": "Madden NFL '07",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.01": {
+    "Name": "SSX On Tour [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.02": {
+    "Name": "Ryu ga Gotoku 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.04": {
+    "Name": "Galaxy Angel - Moonlit Lovers [Banpresido the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.05": {
+    "Name": "Castle Fantasia - Arihato Senki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.06": {
+    "Name": "White Breath - Kizuna [First Print - Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.07": {
+    "Name": "White Breath - Kizuna",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.08": {
+    "Name": "Prince of Tennis - DokiDoki Survival - Sanroku no Mystic",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.09": {
+    "Name": "Dance Dance Revolution - SuperNOVA",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.10": {
+    "Name": "Prince of Tennis - DokiDoki Survival - Umibe no Secret",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.11": {
+    "Name": "Tomoyo After - It's Wonderful Life [CS Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.12": {
+    "Name": "School Love [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.13": {
+    "Name": "Medal of Honor - Rising Sun & Frontline [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.15": {
+    "Name": "James Bond 007 - Everything or Nothing & Nightfire [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.17": {
+    "Name": "Need for Speed - Carbon",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.18": {
+    "Name": "Yumemishi [First Print Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.19": {
+    "Name": "Yumemishi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.20": {
+    "Name": "Higurashi no Naku Koro ni Matsuri",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.21": {
+    "Name": "Beatmania IIDX 12 - Happy Sky",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.22": {
+    "Name": "Tom Clancy's Ghost Recon 2 [Ubisoft Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.23": {
+    "Name": "Dokapon the World [Asmik Tokudane Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.24": {
+    "Name": "Tsuyo Kiss - Mighty Heart [Princess Soft Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.25": {
+    "Name": "Trouble Fortune Comany - Happy Cure [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.26": {
+    "Name": "Trouble Fortune Comany - Happy Cure",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.27": {
+    "Name": "WWE SmackDown! vs. RAW 2007",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.28": {
+    "Name": "OutRun2 SP [First Print Limited Edition]",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPM_666.30": {
+    "Name": "Marheaven - Arm Fight Dream [Konami the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.31": {
+    "Name": "Gokujou Seitokai [Konami the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.32": {
+    "Name": "Kenka Banchou 2 - Full Throttle",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.33": {
+    "Name": "Shoujo Mahou Gaku Little Witch Romanesque",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.34": {
+    "Name": "Devil Summoner - Kuzunoha Raidou [Atlus Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.35": {
+    "Name": "Wind - A Breath of Heart [Alchemist Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.36": {
+    "Name": "Hyper Street Fighter II - The Anniversary Edition [CapKore]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.37": {
+    "Name": "Vampire Darkstalkers Collection [Capcom the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.38": {
+    "Name": "Demento [CapKore]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.39": {
+    "Name": "Street Fighter III - 3rd Strike [Capcom the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.40": {
+    "Name": "Full House Kiss [CapKore]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.41": {
+    "Name": "School Love",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.42": {
+    "Name": "Prince of Tennis, The - Card Hunter [First Print Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.43": {
+    "Name": "OutRun2 SP",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.44": {
+    "Name": "J-League Pro Soccer Club o Tsukurou 5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.45": {
+    "Name": "Bionicle Heroes",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.46": {
+    "Name": "Shining Force EXA",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.49": {
+    "Name": "Taito Memories II - Joukan",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.51": {
+    "Name": "Battlefield 2 - Modern Combat [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.52": {
+    "Name": "Burnout Revenge [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.53": {
+    "Name": "Akudaikan 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.54": {
+    "Name": "Harukanaru Toki no Naka de 2 [Koei Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.55": {
+    "Name": "Harukanaru Jikuu no Kade - Hachiha Katsunori [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.56": {
+    "Name": "Warship Gunner 2 - Change of Direction [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.57": {
+    "Name": "Shin Sangoku Musou 3 Mushoden [Koei Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.58": {
+    "Name": "Shin Sangoku Musou 3 Empires [Koei Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.59": {
+    "Name": "Soshite Kono Uchuu ni Kirameku Kimi no Shi XXX",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.60": {
+    "Name": "Hokuto no Ken",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_666.61": {
+    "Name": "Dessert Love - Sweet Plus [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.62": {
+    "Name": "Dog Island, The - Hitsotsuno no Hana no Monogatari",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.63": {
+    "Name": "Phantasy Star Universe - Ambition of the Illuminus",
+    "Region": "NTSC-J",
+    "eeRoundMode": "0"
+  },
+  "SLPM_666.64": {
+    "Name": "Full House Kiss 2 [CapKore]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.67": {
+    "Name": "Meine Liebe II [Konami Palace Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.68": {
+    "Name": "Akumajo Dracula - Yami no Juin [Konami the Best]",
+    "Region": "NTSC-J",
+    "vuClampMode": "0"
+  },
+  "SLPM_666.69": {
+    "Name": "Prince of Tennis, The - Card Hunter [First Print Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.70": {
+    "Name": "Stella Deus [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.71": {
+    "Name": "Shining Wind",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.72": {
+    "Name": "Tom Clancy's Splinter Cell - Double Agent",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.73": {
+    "Name": "Prince of Persia - Warrior Within [Ubisoft the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.74": {
+    "Name": "Tiger Woods PGA Tour '07",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.75": {
+    "Name": "Kingdom Hearts II - Final Mix +",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_666.76": {
+    "Name": "Kingdom Hearts Re: Chain of Memories",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_666.77": {
+    "Name": "Final Fantasy X - International [Ultimate Hits]",
+    "Region": "NTSC-J",
+    "IPUWaitHack": 1
+  },
+  "SLPM_666.78": {
+    "Name": "Final Fantasy X-2 - International + Last Mission [Ultimate Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.79": {
+    "Name": "Devil Summoner: Kuzunoha Raidou tai Abaddon Ou [Plus]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.83": {
+    "Name": "Devil Summoner: Kuzunoha Raidou tai Abaddon Ou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.85": {
+    "Name": "Seaman 2 - Peking Genjin Ikusei Kit",
+    "Region": "NTSC-J",
+    "Compat": 2
+  },
+  "SLPM_666.86": {
+    "Name": "GuitarFreaks & DrumMania Masterpiece Gold",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.87": {
+    "Name": "Hiiro no Kakera - Ano Sora no Shita de",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.88": {
+    "Name": "Harukanaru Jikuu no Kade 3 [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.89": {
+    "Name": "Persona 3 - Fes [Append Edition]",
+    "Region": "NTSC-J",
+    "VuClipFlagHack": 1
+  },
+  "SLPM_666.90": {
+    "Name": "Persona 3 - Fes [Independent Starting Version]",
+    "Region": "NTSC-J",
+    "VuClipFlagHack": 1
+  },
+  "SLPM_666.91": {
+    "Name": "Sengoku Basara 2 [CapKore]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.92": {
+    "Name": "Seikai no Senki [Best Hit]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.93": {
+    "Name": "Princess Maker 4 [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.94": {
+    "Name": "Spongebob",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.95": {
+    "Name": "Kono Aozora ni Yakusoku o - Melody of the Sun and Sea",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.96": {
+    "Name": "SuperLite 2000 Series - Memories Off - Sorekara Again",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.97": {
+    "Name": "Nightmare Before Christmas, The [CapKore]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_666.98": {
+    "Name": "Shijou Saikyou no Teishi - Kenichi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.00": {
+    "Name": "Konjiki no Corda 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.01": {
+    "Name": "Sangokushi XI [with Power-Up Kit]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.02": {
+    "Name": "Winning Post 7 - Maximum 2007",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.03": {
+    "Name": "Racing Game - Chuui!!!! [Konami the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.04": {
+    "Name": "Negima! Dream Tactic Yumemiru Otome Princess [Maihime Edition]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_667.05": {
+    "Name": "Negima! Dream Tactic Yumemiru Otome Princess [Utahime Edition]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_667.08": {
+    "Name": "Brothers In Arms - Earned In Blood [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.09": {
+    "Name": "Angel Profile",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.10": {
+    "Name": "Godfather, The",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.12": {
+    "Name": "Rozen Maiden - Geppetto Garden [Limited Edition]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_667.14": {
+    "Name": "Wrestle Kingdom 2 - Pro Wrestling Sekai Taisen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.15": {
+    "Name": "Shinki Gensou Spectral Souls II [IF Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.16": {
+    "Name": "Growlanser VI",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.17": {
+    "Name": "Standard Daisenryaku - Dengekisen [Sega the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.18": {
+    "Name": "Standard Daisenryoku - Shiwareta Shouri [Sega the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.19": {
+    "Name": "Tenka-bito [Sega the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.20": {
+    "Name": "Guilty Gear XX #Slash [Sega the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.21": {
+    "Name": "Musou Orochi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.22": {
+    "Name": "Jissen Pachinko Hisshouhou! CR Aladdin Destiny EX",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.23": {
+    "Name": "Zoids Infinity Fuzors [Tomy Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.24": {
+    "Name": "Zoids Tactics [Tomy Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.25": {
+    "Name": "Zoids Struggle [Tomy Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.26": {
+    "Name": "Ojousama Kumikyoku - Sweet Concert",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.27": {
+    "Name": "Love Drops",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.28": {
+    "Name": "Pro Yakyuu Spirits 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.29": {
+    "Name": "Shounen Onyouji - Tsubasa Yoima, Ten e Kare [Deluxe Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.30": {
+    "Name": "Shounen Onyouji - Tsubasa Yoima, Ten e Kare",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.31": {
+    "Name": "Black [EA Best Hits]",
+    "Region": "NTSC-J",
+    "vuClampMode": "0"
+  },
+  "SLPM_667.32": {
+    "Name": "Iinazuke [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.33": {
+    "Name": "Iinazuke",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.34": {
+    "Name": "Kiruto - Anata to Tsumugu Yume to Koi no Dress [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.35": {
+    "Name": "Kiruto - Anata to Tsumugu Yume to Koi no Dress",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.36": {
+    "Name": "Rogue Hearts Dungeon",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.37": {
+    "Name": "Sakura Ran Koukou Hosutobu [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.38": {
+    "Name": "Sakura Ran Koukou Hosutobu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.39": {
+    "Name": "Burnout Dominator",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.40": {
+    "Name": "Sentou Kokka Kai - Legend [DX Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.41": {
+    "Name": "Sentou Kokka Kai - Legend",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.42": {
+    "Name": "Pop'n Music 14 Fever",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_667.43": {
+    "Name": "Shinkyouku Soukai Polyphonica",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.44": {
+    "Name": "Killer 7 [CapKore]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.45": {
+    "Name": "Shadow of Rome [CapKore]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.46": {
+    "Name": "Guilty Gear XX - Accent Core",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_667.47": {
+    "Name": "Baroque",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.48": {
+    "Name": "Mana-Khemia - Gakuen no Renkinjutsu Shitachi",
+    "Region": "NTSC-J",
+    "DMABusyHack": 1
+  },
+  "SLPM_667.49": {
+    "Name": "Wizardry X 2 - Mugen no Gakuto [Wonder Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.50": {
+    "Name": "Final Fantasy XII International - Zodiac Job System [with Bonus DVD]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_667.51": {
+    "Name": "Mahoroba Stories",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.52": {
+    "Name": "Medal of Honor - Vanguard",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.53": {
+    "Name": "Getsumento Heiki Mina - Futatsu no Project M [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.54": {
+    "Name": "Getsumento Heiki Mina - Futatsu no Project M",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.55": {
+    "Name": "Majommusume - A La Mode II",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.56": {
+    "Name": "Que - Ancient Leaf no Yousei [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.57": {
+    "Name": "Que - Ancient Leaf no Yousei",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.58": {
+    "Name": "Neo Angelique [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.59": {
+    "Name": "Harukanaru Jikuu no Kade 3 - Izayoiki [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.60": {
+    "Name": "Nobunaga no Yabou - Soutensoku [with Power-Up Kit] [Koei Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.61": {
+    "Name": "Panic Palette [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.62": {
+    "Name": "Panic Palette",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.63": {
+    "Name": "Neon Genesis Evangelion - Battle Orchestra",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.64": {
+    "Name": "Izumo Zero",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.65": {
+    "Name": "Juujimoto Ripputai Sypher - Game of Survival [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.66": {
+    "Name": "Juujimoto Ripputai Sypher - Game of Survival",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.67": {
+    "Name": "Urban Chaos - Riot Response",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.68": {
+    "Name": "Missing Parts - The Tantei Stories - Side A [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.69": {
+    "Name": "Missing Parts - The Tantei Stories - Side B [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.70": {
+    "Name": "Kuon no Kizuna - Sairinsho [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.71": {
+    "Name": "Densha de Go! Shinkansen [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.72": {
+    "Name": "Densha de Go! Final [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.73": {
+    "Name": "Densha de Go! Professional 2 [Taito Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.74": {
+    "Name": "Energy Airforce - AimStrike! [Taito Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.75": {
+    "Name": "Taito Memories Joukan [Taito Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.76": {
+    "Name": "Taito Memories Gekan [Taito Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.77": {
+    "Name": "Jikkyou Powerful Pro Yakyuu 14",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.78": {
+    "Name": "Galaxy Angel - Eternal Lovers [Broccoli The Best Quality]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.79": {
+    "Name": "Galaxy Angel II - Mugen Kairou no Kagi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.81": {
+    "Name": "Dragon Quest - Shonen Yangus to Fushigi no Dungeon [Ultimate Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.82": {
+    "Name": "Valkyrie Profile 2 - Silmeria [Ultimate Hits]",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLPM_667.83": {
+    "Name": "Idol Janshi Suchie-Pai 4 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.85": {
+    "Name": "Idol Janshi Suchie-Pai 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.86": {
+    "Name": "Gift - Prism [Broccoli Best Quality]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.87": {
+    "Name": "Tsuika AS+ Eternal \"Name\"",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.88": {
+    "Name": "Grand Theft Auto - San Andreas [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.89": {
+    "Name": "Grand Theft Auto III [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.90": {
+    "Name": "Grand Theft Auto - Vice City [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.91": {
+    "Name": "Memories Off #5 Encore",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.92": {
+    "Name": "Metal Gear Solid 2 - Sons of Liberty [20th Anniversary Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.94": {
+    "Name": "Metal Gear Solid 3 - Snake Eater [20th Anniversary Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_667.96": {
+    "Name": "Metal Gear Solid - 20th Anniversary Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.00": {
+    "Name": "Pirates of the Caribbean - At World's End",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.01": {
+    "Name": "Izumo Complete [GN Software Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.02": {
+    "Name": "Kimore Hi no Namiki Michi [GN Software Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.03": {
+    "Name": "Shikaku Tantei - Sora no Sekai - Thousand Dreams",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.04": {
+    "Name": "Colorful Aquarium - My Little Mermaid [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.05": {
+    "Name": "Colorful Aquarium - My Little Mermaid",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.06": {
+    "Name": "Shuffle! On the Stage [Kadokawa the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.07": {
+    "Name": "Disney-Pixar's Remy no Oishii Restaurant (Ratatouille)",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.08": {
+    "Name": "Tom Clancy's Ghost Recon - Advanced Warfighter [Ubisoft the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.09": {
+    "Name": "Saishu Shiken Kujira - Alive",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.10": {
+    "Name": "J.League Winning Eleven 2007 Club Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.11": {
+    "Name": "Winning Post 7 [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.12": {
+    "Name": "GI Jockey 4 [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.13": {
+    "Name": "Sangokushi IX [Koei Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.14": {
+    "Name": "Pure x Cure Re-covery",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.15": {
+    "Name": "Baldr Bullet - Equilibrium",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.16": {
+    "Name": "Chanter# - Kimi no Uta ga Todoitara",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.17": {
+    "Name": "Palais de Reine",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.18": {
+    "Name": "Quiz & Variety SukuSuku Inufuku 2 - Motto SukuSuku",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.19": {
+    "Name": "Beat Down - Fists of Vengeance [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.20": {
+    "Name": "Jissen Pachinko Hisshouhou! CR Sakura Taisen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.21": {
+    "Name": "Sengoku Musou 2 Mushouden",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.22": {
+    "Name": "GuitarFreaks V3 & DrumMania V3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.23": {
+    "Name": "Taka Reet Ura Mahjong Retsuden - Mukoubushi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.24": {
+    "Name": "Hiiro no Kakera 2 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.25": {
+    "Name": "Hiiro no Kakera 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.26": {
+    "Name": "Youki Hime Den [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.27": {
+    "Name": "Youki Hime Den",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.28": {
+    "Name": "Beatmania IIDX 13 - DistorteD",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.29": {
+    "Name": "Major League Baseball 2K7",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.30": {
+    "Name": "Disney's Lewis to Mirai Dorobou (Meet the Robinsons)",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.35": {
+    "Name": "Kiniro no Corda 2 Anchor",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.36": {
+    "Name": "EA Sports Rugby '08",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.37": {
+    "Name": "Madden NFL '08",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.38": {
+    "Name": "Fantastic Fortune 2 - Triple Star [Best Hit Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.39": {
+    "Name": "We Are [Best Hit Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.40": {
+    "Name": "Nizu no Senritsu 2 [Best Hit Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.41": {
+    "Name": "Will O' Wisp [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.42": {
+    "Name": "Will O' Wisp",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.43": {
+    "Name": "Generations of Chaos - Desire",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.44": {
+    "Name": "Yuukyuu no Sakura [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.45": {
+    "Name": "Yuukyuu no Sakura",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.46": {
+    "Name": "Prism Ark - Awake",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.47": {
+    "Name": "Arabians Lost - The Engagement on Desert",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.48": {
+    "Name": "Sengoku Basara 2 Heroes",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.49": {
+    "Name": "Atelier Iris - Grand Phantasm [Gust Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.50": {
+    "Name": "Arcana Heart",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_668.51": {
+    "Name": "Grand Theft Auto - Liberty City Stories",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.52": {
+    "Name": "Capcom Classics Collection [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.53": {
+    "Name": "Jojo no Kimyouna Bouken - Ougon no Kaze [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.54": {
+    "Name": "Street Fighter Zero - Fighters Generation [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.55": {
+    "Name": "Togainu no Chi - True Blood [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.56": {
+    "Name": "Togainu no Chi - True Blood",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.57": {
+    "Name": "Itsuka, Todoku, Ano Sora ni [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.58": {
+    "Name": "Itsuka, Todoku, Ano Sora ni",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.59": {
+    "Name": "Sengoku Basara [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.60": {
+    "Name": "Nettai Teikiatsu Otome [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.61": {
+    "Name": "Nettai Teikiatsu Otome",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.62": {
+    "Name": "Ayaka Shibito [Best Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.63": {
+    "Name": "WWE SmackDown vs. RAW 2008",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.64": {
+    "Name": "Umisho",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.66": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! Hokuto no Ken 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.67": {
+    "Name": "MotoGP '07",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.68": {
+    "Name": "Tom Clancy's Splinter Cell - Double Agent [Ubisoft the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.69": {
+    "Name": "Need for Speed - Carbon [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.70": {
+    "Name": "Kuri no Okurimono [First Print Special Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.71": {
+    "Name": "Shoukan Shoujo - Elemental Girl Calling [DX Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.72": {
+    "Name": "Shoukan Shoujo - Elemental Girl Calling",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_668.73": {
+    "Name": "Lucky Star [DX Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.74": {
+    "Name": "Lucky Star",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.75": {
+    "Name": "Jikkyou Powerful Pro Major League 2",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.76": {
+    "Name": "Izumo 2 [GN Software Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.77": {
+    "Name": "Summer## [GN Software Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.78": {
+    "Name": "Dokapon Kingdom",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.79": {
+    "Name": "StarTRain - Your Past Makes Your Future [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.80": {
+    "Name": "StarTRain - Your Past Makes Your Future",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.81": {
+    "Name": "TOCA Race Driver 3 - Ultimate Racing Simulator",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.82": {
+    "Name": "Hakarena Heart [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.83": {
+    "Name": "Hakarena Heart",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.84": {
+    "Name": "NBA Live '08",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.85": {
+    "Name": "Winning Eleven 2008",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.86": {
+    "Name": "Harry Potter and the Order of the Phoenix",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.87": {
+    "Name": "Harukanaru Jikuu no Kade 3 - Unmei no Meikyuu [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.88": {
+    "Name": "GI Jockey 4 - 2007",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.89": {
+    "Name": "Pri-Saga! Princess o Sagase! [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.90": {
+    "Name": "Pri-Saga! Princess o Sagase!",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.91": {
+    "Name": "Myself, Yourself [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.92": {
+    "Name": "Myself, Yourself",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.93": {
+    "Name": "Final Fantasy XI - Vana'diel Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.94": {
+    "Name": "Final Fantasy XI - Wings of the Goddess",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.95": {
+    "Name": "Manea Sugoroku - Kabukuro",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.96": {
+    "Name": "Pia Carrot e Youkoso!! G.O. Summer Fair",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.97": {
+    "Name": "Tales of the Abyss",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.98": {
+    "Name": "Spectral Gene [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_668.99": {
+    "Name": "Spectral Gene",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.00": {
+    "Name": "Kuri no Okurimono",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.01": {
+    "Name": "12Riven - The Psi-Climinal of Integral",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.02": {
+    "Name": "Disney Princess - Enchanted Journey",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.03": {
+    "Name": "GI Jockey 4 - 2007 [with Winning Post 7 - 2007 - Premium Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.05": {
+    "Name": "D.C. Da Capo The Origin",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.06": {
+    "Name": "Tensho Gakuen Gekkoroku [Tokudame Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.07": {
+    "Name": "Iinazuke [Princess Soft Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.08": {
+    "Name": "Izumo 2 - Gakuen Kyousoukyoku - Double Tact",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.09": {
+    "Name": "Shinkyouku Soukai Polyphonica 3&4 Hanashi Kanketsuhen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.10": {
+    "Name": "Stuntman - Ignition",
+    "Region": "NTSC-J",
+    "VIFFIFOHack": 1
+  },
+  "SLPM_669.11": {
+    "Name": "Finalist [Princess Soft Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.12": {
+    "Name": "Higurashi no Naku Koro ni Matsuri - Kakera Asobi [Append Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.13": {
+    "Name": "Higurashi no Naku Koro ni Matsuri - Kakera Asobi",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.14": {
+    "Name": "Houkago wa Hakugin no Shirabe",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.15": {
+    "Name": "Yu-Gi-Oh Dual Monsters GX - Tag Force Evolution",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.16": {
+    "Name": "Jikkyou Powerful Pro Yakyuu 14 Chou Ketteiban",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.17": {
+    "Name": "Grand Theft Auto - Vice City Stories",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.18": {
+    "Name": "Princess Maker 5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.19": {
+    "Name": "Kyuuketsu Kitan Moonties",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.20": {
+    "Name": "Hoshi Furu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.21": {
+    "Name": "H2O",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.22": {
+    "Name": "D.C. II P.S. - Da Capo II Plus Situation [DX Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.24": {
+    "Name": "D.C. II P.S. - Da Capo II Plus Situation",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.26": {
+    "Name": "NiGHTS into Dreams...",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_669.27": {
+    "Name": "Wrestle Angels - Survivor [Good Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.29": {
+    "Name": "Elminage - Yami no Fujo to Kamigami no Yubiwa",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.31": {
+    "Name": "Juiced 2 - Hot Import Nights",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.32": {
+    "Name": "Need for Speed - ProStreet",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.33": {
+    "Name": "Kimi ga Aruji de Shitsuji ga Oro de - Oshie Nikki [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.34": {
+    "Name": "Kimi ga Aruji de Shitsuji ga Oro de - Oshie Nikki",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.35": {
+    "Name": "True Tears",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.36": {
+    "Name": "Night Wizard - The Video Game - Denial of the World",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.37": {
+    "Name": "Jan Sangoku Musou [Koei the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.38": {
+    "Name": "Angelique Etoile [Koei Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.39": {
+    "Name": "Boukoku no Aegis 2035 - Warship Gunner [Koei Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.40": {
+    "Name": "Gundam Musou Special",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.41": {
+    "Name": "Hokuto no Ken (Fist of the North Star) [Sega the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.42": {
+    "Name": "Final Approach 2 - 1st Priority [First Print Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.43": {
+    "Name": "Final Approach 2 - 1st Priority",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.44": {
+    "Name": "Petit Four [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.45": {
+    "Name": "Petit Four",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.46": {
+    "Name": "NBA Live '07 [EA Best Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.47": {
+    "Name": "Nobunaga no Yabou - Kakushin [with Power-Up Kit]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.48": {
+    "Name": "Nobunaga no Yabou - Kakushin [with Power-Up Kit and Sangokushi XI]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.50": {
+    "Name": "Winning Post 7 Maximum 2008",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.52": {
+    "Name": "Harukanaru Jikuu no Kade 4",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.53": {
+    "Name": "Musou Orochi - Maou Sairin",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.54": {
+    "Name": "Nobunaga no Yabou - Online - Souha no Shou",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.56": {
+    "Name": "Neo Angelique - Full Voice",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.57": {
+    "Name": "Neon Genesis Evangelion - Battle Orchestra [Broccoli Best Quality]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.58": {
+    "Name": "Aoishiro [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.59": {
+    "Name": "Aoishiro",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.60": {
+    "Name": "Need for Speed - Underground 2 [EA-SY! 1980]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.61": {
+    "Name": "Black [EA-SY! 1980]",
+    "Region": "NTSC-J",
+    "vuClampMode": "0"
+  },
+  "SLPM_669.62": {
+    "Name": "Burnout 3 - Takedown [EA-SY! 1980]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.63": {
+    "Name": "Medal of Honor - Frontline [EA-SY! 1980]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.64": {
+    "Name": "Guilty Gear XX - Accent Core Plus [Append Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.65": {
+    "Name": "Guilty Gear XX - Accent Core Plus",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPM_669.66": {
+    "Name": "Godfather, The [EA-SY! 1980]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.67": {
+    "Name": "Aria - The Natural [Alchemist Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.68": {
+    "Name": "Kamiwaza [Acquire the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.69": {
+    "Name": "Hoshigari Empusa",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.70": {
+    "Name": "Pro Yakyuu Spirits 5",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.71": {
+    "Name": "Sangokushi IX [with Power-Up Kit] [Koei Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.72": {
+    "Name": "Kurogane no Houkou 2 - Warship Commander [Koei Selection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.73": {
+    "Name": "Princess Nightmare",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.74": {
+    "Name": "Slotter Up Core 10 - Mach GoGoGo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.77": {
+    "Name": "Shinkyouku Soukai Polyphonica 0-4 Hanashi Full Pack",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.78": {
+    "Name": "Persona 4 [Konami-style Special Edition]",
+    "Region": "NTSC-J",
+    "VuClipFlagHack": 1
+  },
+  "SLPM_669.87": {
+    "Name": "Kowloon Youma Gakuen Ki [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.89": {
+    "Name": "Castle Fantasia - Arihato Senki [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.90": {
+    "Name": "Majommusume A La Mode II [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.91": {
+    "Name": "Fuuraiki [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.92": {
+    "Name": "Fuuuraiki 2 [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.93": {
+    "Name": "Rim Runners [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.94": {
+    "Name": "Mana-Khemia - Gakuen no Renkinjutsu Shitachi [Best Version]",
+    "Region": "NTSC-J",
+    "DMABusyHack": 1
+  },
+  "SLPM_669.96": {
+    "Name": "Shuumatsu Otome Gensou Alicematic Apocalypse [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.97": {
+    "Name": "Shuumatsu Otome Gensou Alicematic Apocalypse",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.98": {
+    "Name": "Fushigi Yuugi - Suzaku Ibun [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_669.99": {
+    "Name": "Fushigi Yuugi - Suzaku Ibun",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.00": {
+    "Name": "Fushigi Yuugi - Shigiyuugi Kurotake Kaiden Gaiden - Kagami no Fujo [IF Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.02": {
+    "Name": "Metal Gear Solid 2 - Substance",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.03": {
+    "Name": "Sakura Taisen - Atsuki Chishioni",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.04": {
+    "Name": "Medal of Honor - Rising Sun",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.05": {
+    "Name": "Lord of the Rings, The - The Return of the King",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.06": {
+    "Name": "Train Simulator - Kyushu Shinkansen",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.07": {
+    "Name": "Train Simulator - Keisei Toei Keikyu",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.08": {
+    "Name": "Metal Gear Solid 2 - Substance [Konami Dendou Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.09": {
+    "Name": "Sakura Taisen V - Saraba Itoshiki Hito Yo",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.10": {
+    "Name": "God of War",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.11": {
+    "Name": "God of War [CapKore]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.12": {
+    "Name": "God of War [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.13": {
+    "Name": "God of War II - The End Begins",
+    "Region": "NTSC-J"
+  },
+  "SLPM_670.15": {
+    "Name": "School Days LxH",
+    "Region": "NTSC-J"
+  },
+  "SLPM_675.02": {
+    "Name": "Devil May Cry",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLPM_675.07": {
+    "Name": "Onimusha Warlords",
+    "Region": "NTSC-K"
+  },
+  "SLPM_675.08": {
+    "Name": "Gitaroo Man",
+    "Region": "NTSC-K",
+    "Compat": 5,
+    "eeRoundMode": 1,
+    "vuRoundMode": 3
+  },
+  "SLPM_675.13": {
+    "Name": "Final Fantasy X International",
+    "Region": "NTSC-K",
+    "IPUWaitHack": 1
+  },
+  "SLPM_675.14": {
+    "Name": "Kessen",
+    "Region": "NTSC-K"
+  },
+  "SLPM_675.18": {
+    "Name": "Onimusha 2 Samurai's Destiny",
+    "Region": "NTSC-K"
+  },
+  "SLPM_675.24": {
+    "Name": "Armored Core 3",
+    "Region": "NTSC-K"
+  },
+  "SLPM_675.28": {
+    "Name": "Hajime no Ippo - Victorious Boxers [Championship Edition]",
+    "Region": "NTSC-K"
+  },
+  "SLPM_675.29": {
+    "Name": "Gun Survivor 3 Dino Crisis",
+    "Region": "NTSC-K"
+  },
+  "SLPM_675.31": {
+    "Name": "Kessen 2",
+    "Region": "NTSC-K"
+  },
+  "SLPM_675.35": {
+    "Name": "Memories Of",
+    "Region": "NTSC-J-K"
+  },
+  "SLPM_675.36": {
+    "Name": "Senkaiden Hoshin Engi",
+    "Region": "NTSC-K"
+  },
+  "SLPM_675.40": {
+    "Name": "Auto Modellista",
+    "Region": "NTSC-K",
+    "Compat": 5
+  },
+  "SLPM_675.46": {
+    "Name": "Lord of the Rings - The Two Towers",
+    "Region": "NTSC-K"
+  },
+  "SLPM_645.49": {
+    "Name": "Shikigami no Shiro",
+    "Region": "NTSC-K"
+  },
+  "SLPM_675.52": {
+    "Name": "Tomak - Save the Earth Again [Complete Edition]",
+    "Region": "NTSC-K"
+  },
+  "SLPM_680.18": {
+    "Name": "Virtua Fighter - 10th Anniversary Edition",
+    "Region": "NTSC-J"
+  },
+  "SLPM_685.03": {
+    "Name": "Metal Gear Solid 2 - Sons of Liberty [Shareholder Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_685.04": {
+    "Name": "Tokimeki Memorial 3 - Special Sound Track",
+    "Region": "NTSC-J"
+  },
+  "SLPM_685.13": {
+    "Name": "DragonBall Z - Budokai 2 V",
+    "Region": "NTSC-J"
+  },
+  "SLPM_685.16": {
+    "Name": "Metal Gear Solid 3 - Snake Eater [Shareholder Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_740.01": {
+    "Name": "Gungriffon Blaze [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_740.02": {
+    "Name": "Shin Sangoku Musou [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_740.03": {
+    "Name": "Crash Bandikoot 4 - Saikuretsu [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_740.04": {
+    "Name": "Maximo - Ghosts to Glory [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_740.05": {
+    "Name": "Romance of the Three Kingdoms VII [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_740.06": {
+    "Name": "Rez [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_740.07": {
+    "Name": "Busin - Wizardry Alternative [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_740.44": {
+    "Name": "Space Channel 5 - Part 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_741.01": {
+    "Name": "Bomberman Land 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_741.02": {
+    "Name": "Momotaro Densetsu 12 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_741.03": {
+    "Name": "Momotaro Dentetsu USA [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_741.04": {
+    "Name": "Momotarou Densetsu 15 [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.01": {
+    "Name": "Biohazard Outbreak [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.02": {
+    "Name": "Fuun Shinsengumi [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.04": {
+    "Name": "Shutokou Battle 01 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.05": {
+    "Name": "Shin Megami Tensei III - Nocturne [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "eeRoundMode": "0 "
+  },
+  "SLPM_742.06": {
+    "Name": "Onimusha [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.08": {
+    "Name": "Tengai Makyou 2 - Manjimaru [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.09": {
+    "Name": "Samurai Michi 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.10": {
+    "Name": "Puyo Puyo Fever [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.11": {
+    "Name": "Shutokou Battle 0 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.12": {
+    "Name": "Sengoku Musou [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.15": {
+    "Name": "Shin Sangoku Musou 3 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.18": {
+    "Name": "Shining Tears [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.19": {
+    "Name": "Shin Sangoku Musou 3 - Empires [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.20": {
+    "Name": "Kengo 3 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.21": {
+    "Name": "Kenka Banchou [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.22": {
+    "Name": "Samurai Kanzenban [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.24": {
+    "Name": "Sengoku Musou Moushouden [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.25": {
+    "Name": "Nobunaga no Yabou - Tenka Sousei [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.26": {
+    "Name": "Metal Saga - Sajin no Kusari [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "DMABusyHack": "1 "
+  },
+  "SLPM_742.27": {
+    "Name": "Ikusa Gami [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.28": {
+    "Name": "Fuun Bakumatsu-den [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.29": {
+    "Name": "BioHazard 4 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.30": {
+    "Name": "Devil May Cry [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.31": {
+    "Name": "Kessen III [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.32": {
+    "Name": "Shin Onimusha - Dawn of Dreams [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.34": {
+    "Name": "Ryu Ga Gotoku [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.35": {
+    "Name": "Sengoku Musou [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.36": {
+    "Name": "Shin Sangoku Musou 4 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.37": {
+    "Name": "New Jinsei Game [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.38": {
+    "Name": "Genso Suikoden V [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.39": {
+    "Name": "Okami [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.40": {
+    "Name": "Tengai Makyou III - Namida [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.41": {
+    "Name": "God Hand [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.42": {
+    "Name": "Devil May Cry 3 [Special Edition] [PlayStation 2 the Best]",
+    "Region": "NTSC-J",
+    "eeRoundMode": "0"
+  },
+  "SLPM_742.43": {
+    "Name": "True Crime - New York City [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.44": {
+    "Name": "Phantasy Star Universe [PlayStation 2 the Best]",
+    "Region": "NTSC-J",
+    "eeRoundMode": "0"
+  },
+  "SLPM_742.45": {
+    "Name": "Monster Hunter 2 [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.46": {
+    "Name": "Capcom vs. SNK 2 - Millionaire Fighting 2001 [PlayStation 2 the Best - Reprint]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.47": {
+    "Name": "Sengoku Musou 2 [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.48": {
+    "Name": "Monster Hunter G [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.49": {
+    "Name": "Sengoku Musou Moushouden [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.50": {
+    "Name": "Shin Sangoku Musou 4 Moushouden [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.51": {
+    "Name": "Shin Onimusha - Dawn of Dreams [PlayStation 2 the Best - Reprint Disc 1]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.52": {
+    "Name": "Shin Onimusha - Dawn of Dreams [Playstation 2 the Best - Reprint Disc 2]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.53": {
+    "Name": "Ryu ga Gotoku [PlayStation 2 the Best - Reprint]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.54": {
+    "Name": "EX Jinsei Game II [PlayStation 2 the Best - Reprint]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.59": {
+    "Name": "Odin Sphere [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.65": {
+    "Name": "Nobunaga no Yabou: Kakushin [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.76": {
+    "Name": "Sangoku Musou 2 [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_742.78": {
+    "Name": "Persona 4 [PlayStation 2 the Best]",
+    "Region": "NTSC-J",
+    "VuClipFlagHack": 1
+  },
+  "SLPM_742.86": {
+    "Name": "Shin Sangoku Musou 5 Special [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_743.01": {
+    "Name": "Ryu ga Gotoku 2 [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.02": {
+    "Name": "Capcom vs. SNK 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.03": {
+    "Name": "Densha de Go! Shinkansen [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.04": {
+    "Name": "Space Channel 5 - Part 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.05": {
+    "Name": "Samurai Complete Edition [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.06": {
+    "Name": "WRC - World Rally Chanpionship [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.07": {
+    "Name": "Jet de Go! 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.08": {
+    "Name": "Rakugaki Kingdom [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.09": {
+    "Name": "Gun Survivor 2 - Biohazard Code - Veronica [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.10": {
+    "Name": "Breath of Fire 5 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.11": {
+    "Name": "Culdcelt II - Expansion [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.12": {
+    "Name": "Kengo 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.14": {
+    "Name": "Energy Airforce",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.15": {
+    "Name": "Shinobi [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.16": {
+    "Name": "Clock Tower 3",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.20": {
+    "Name": "Initial D - Street Stage [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPM_744.21": {
+    "Name": "Virtual On - Marz [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.01": {
+    "Name": "Ridge Racer V",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_200.02": {
+    "Name": "Doukyu Billiards",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPS_200.03": {
+    "Name": "Street Fighter EX3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.05": {
+    "Name": "EX Billiards",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.06": {
+    "Name": "A-Train 6",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.07": {
+    "Name": "Driving Emotion Type S",
+    "Region": "NTSC-J",
+    "Compat": 4,
+    "EETimingHack": 1
+  },
+  "SLPS_200.09": {
+    "Name": "Golf Paradise",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.10": {
+    "Name": "Pro Baseball Gekikuukan",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.11": {
+    "Name": "American Arcade",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_200.12": {
+    "Name": "Sky Surfer",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.13": {
+    "Name": "Primal Image Vol.01",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.15": {
+    "Name": "Tekken Tag Tournament",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_200.16": {
+    "Name": "Dream Audition",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.17": {
+    "Name": "Street Mahjong Trance 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.18": {
+    "Name": "Stepping Selection [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.19": {
+    "Name": "Stepping Selection [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.20": {
+    "Name": "FIFA 2000 World Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.21": {
+    "Name": "Wild Wild Racing",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.22": {
+    "Name": "All-Star Pro Wrestling",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.23": {
+    "Name": "Cross Fire",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.24": {
+    "Name": "Hresvelgr",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.25": {
+    "Name": "SSX - Snowboard Supercross",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.27": {
+    "Name": "Aquaqua",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_200.28": {
+    "Name": "Game Select 5",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.29": {
+    "Name": "Surfroid",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.31": {
+    "Name": "Mechsmith, The - Run-Dim",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.33": {
+    "Name": "Gungriffon Blaze",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.34": {
+    "Name": "Velvet File",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.35": {
+    "Name": "Pro Mahjong Kiwame Next",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.36": {
+    "Name": "Magical Sports - 2000 Koushien",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.37": {
+    "Name": "Magical Sports - Go Go Golf",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.38": {
+    "Name": "Grappler Baki - Baki Saidai no Tournament",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.40": {
+    "Name": "Moto GP",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.41": {
+    "Name": "Mahjong Goku Taisei",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.42": {
+    "Name": "F1 Racing Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.43": {
+    "Name": "Lake Masters Fishing EX",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.44": {
+    "Name": "F1 Championship Season 2000",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.47": {
+    "Name": "Toudai Shogi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.48": {
+    "Name": "Sim Theme Park",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.50": {
+    "Name": "Happy! Happy!! Boarders",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.51": {
+    "Name": "Hissatsu Pachinko Station V",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.52": {
+    "Name": "Global Folktale",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.53": {
+    "Name": "Tenshi no Present - Marle Oukoku Monogatari",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.54": {
+    "Name": "FIFA World Championship 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.55": {
+    "Name": "Technictix",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_200.57": {
+    "Name": "Dog of Bay",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.58": {
+    "Name": "Kengo",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.59": {
+    "Name": "Hresvelgr [International Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.60": {
+    "Name": "Dream Audition 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.62": {
+    "Name": "Truck Kyousokyoku",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.64": {
+    "Name": "Top Gear Daredevil",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.65": {
+    "Name": "Madden NFL 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.66": {
+    "Name": "Rhapsody 3 - Tenshi no Present - The Marl Kingdom Stories",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.67": {
+    "Name": "Crazy Bumps",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.68": {
+    "Name": "Midnight Club - Street Racing",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.71": {
+    "Name": "Game Select 5",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.72": {
+    "Name": "Real Robots Regiment",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.73": {
+    "Name": "NBA Live 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.78": {
+    "Name": "Generation of Chaos",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.82": {
+    "Name": "Saikyou Toudai Shogi 3 [Mycom Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.83": {
+    "Name": "Air Ranger Rescue Helicopter",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.84": {
+    "Name": "Basic Studio [Disc 1]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.85": {
+    "Name": "Basic Studio [Disc 2]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.86": {
+    "Name": "Generation of Chaos [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.87": {
+    "Name": "Generation of Chaos",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.89": {
+    "Name": "Gun-Heats",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.91": {
+    "Name": "Gekisha Boy 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_200.92": {
+    "Name": "Tiger Woods PGA Tour 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.94": {
+    "Name": "Shinseiki Evangelion - Typing Project-E [TVware Information Revolution Series]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.95": {
+    "Name": "Knockout Kings 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.97": {
+    "Name": "Magical Sports - Koshien",
+    "Region": "NTSC-J"
+  },
+  "SLPS_200.98": {
+    "Name": "Magical Sports - Hard Hitter",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.00": {
+    "Name": "Tetsu-One Train Battle",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.01": {
+    "Name": "City Crisis",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.02": {
+    "Name": "Pachinko Paradise 6",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.03": {
+    "Name": "Lake Masters EX Super",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.04": {
+    "Name": "Bokujou Monogatari 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.05": {
+    "Name": "Growlanser II - The Sense of Justice [Deluxe Pack]",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPS_201.06": {
+    "Name": "Growlanser II - The Sense of Justice",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPS_201.08": {
+    "Name": "Quake III - Revolution",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.11": {
+    "Name": "Magical Sports - Pro Baseball 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.12": {
+    "Name": "Hissatsu Pachinko Station v2.0",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.13": {
+    "Name": "Time Crisis II [with Guncon 2]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.20": {
+    "Name": "Formula One 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.21": {
+    "Name": "Kanon",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.22": {
+    "Name": "Time Crisis II",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.25": {
+    "Name": "Shanghai - The Four Elements [Super Value 2800]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.28": {
+    "Name": "Toshiyuki Morikawa Private Collection - Puppet Princess of Marl's Kingdom",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.30": {
+    "Name": "New Best Play Professional Baseball",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.32": {
+    "Name": "Chenuen no San Goku Shi (Chen Wen's Romance of the Three Kingdoms)",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.36": {
+    "Name": "Guilty Gear X Plus [DX Pack]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_201.37": {
+    "Name": "Guilty Gear X Plus",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_201.39": {
+    "Name": "All Star Pro-Wrestling II",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.43": {
+    "Name": "RPG Tsukuru 5",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.44": {
+    "Name": "Seed, The",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.50": {
+    "Name": "Akira Psycho Ball",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.61": {
+    "Name": "Saikyou Toudai Shogi Special",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_201.62": {
+    "Name": "Typing Kengo 634 [with Keyboard]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.63": {
+    "Name": "Typing Kengo 634",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.65": {
+    "Name": "La Pucelle",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.67": {
+    "Name": "La Pucelle",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.71": {
+    "Name": "Smash Court Tennis Pro",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.75": {
+    "Name": "Typing Love Story - Boys Be",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.77": {
+    "Name": "Make Your Dream Home",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.78": {
+    "Name": "Samurai",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.85": {
+    "Name": "Wangan Midnight",
+    "Region": "NTSC-J",
+    "Compat": 1
+  },
+  "SLPS_201.87": {
+    "Name": "Black Matrix 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_201.94": {
+    "Name": "Underwater Unit",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.96": {
+    "Name": "Akagawa Jiro - Tsuki no Hikari - Shizumeru Kane no Satsujin",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.98": {
+    "Name": "Raging Bless",
+    "Region": "NTSC-J"
+  },
+  "SLPS_201.99": {
+    "Name": "F1 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.02": {
+    "Name": "Coloball 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.08": {
+    "Name": "I am Small!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.14": {
+    "Name": "3-D Fighting School 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.16": {
+    "Name": "Air Ranger - Rescue Helicopter",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.18": {
+    "Name": "Ninja Assault",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.19": {
+    "Name": "Tsukande! Mawashite! Dossun Pazuru Egg Mania",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.21": {
+    "Name": "Taiko no Tatsujin [with Tatacon Reproduction Controller]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.22": {
+    "Name": "Inaka Kurasi - Nan no Shima no Monogatari",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.26": {
+    "Name": "Yamasa Digital Slot World SP DX",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.30": {
+    "Name": "Chulip",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_202.43": {
+    "Name": "New Price Go Go Golf",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.45": {
+    "Name": "Low Rider",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.50": {
+    "Name": "Makai Senki Disaea [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.51": {
+    "Name": "Makai Senki Disaea",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.56": {
+    "Name": "Cool Shot - Yukawa Keiko",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_202.58": {
+    "Name": "Yamasa Digi World 4D",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.59": {
+    "Name": "Kotoba no Puzzle - Mojipittan",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.60": {
+    "Name": "Sakigake!! Kuromati Koukou",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.62": {
+    "Name": "Slot Pro DX - Fujiko 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.63": {
+    "Name": "J.League Tactics Manager - Realtime Soccer Simulation",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.65": {
+    "Name": "Fever 7",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.72": {
+    "Name": "Taiko no Tatsujin Doki",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_202.73": {
+    "Name": "Netsu Chu! Pro Baseball 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.79": {
+    "Name": "Hissatsu Pachinko Station v7 - Tensei Bakabon 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.80": {
+    "Name": "Mahou no Pumpkin",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.82": {
+    "Name": "Taiko no Tatsujin",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.84": {
+    "Name": "Marl de Jigsaw",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.85": {
+    "Name": "Slotter Up Core",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.87": {
+    "Name": "Yakiniku Bugyou Bonfire!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.88": {
+    "Name": "Saikyo Todai Shogi 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.89": {
+    "Name": "Yamasa Digi World SP - Umi Ichiban R",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.91": {
+    "Name": "Fish Eyes 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.93": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! Savanna Park",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.94": {
+    "Name": "Hanabi Shokunin Ninarou 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.96": {
+    "Name": "Dugout '03 - The Turning Point",
+    "Region": "NTSC-J"
+  },
+  "SLPS_202.99": {
+    "Name": "Black Matrix 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.00": {
+    "Name": "Mobile Suit - Gundam Seed",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.01": {
+    "Name": "Gachinko Professional Baseball",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.03": {
+    "Name": "Inaka Kurasi [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.05": {
+    "Name": "Real Sports Professional Baseball",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.11": {
+    "Name": "Primopuel - My Special Partner [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.12": {
+    "Name": "Primopuel - My Special Partner",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.16": {
+    "Name": "Hissatsu Pachinko Station v8",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.17": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! King Camel",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.20": {
+    "Name": "Taiko no Tatsujin 3 [with Tatacon Drum Bundle]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.21": {
+    "Name": "Taiko no Tatsujin - Appare Sandaime",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.22": {
+    "Name": "Netsu Chu! Pro Baseball 2003 Fall",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.23": {
+    "Name": "Pochinya",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_203.28": {
+    "Name": "Otona no Gal Jan - Kimi ni Hane Man",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.29": {
+    "Name": "Kamen Rider 555",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_203.30": {
+    "Name": "Taiko no Tatsujin 4 - Waku Waku Anime Maturi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.31": {
+    "Name": "Fever 9 - Sankyo",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.33": {
+    "Name": "Taisen 1 - Shogi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.34": {
+    "Name": "Taisen 2 - Go",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.35": {
+    "Name": "Taisen 3 - Mahjong",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.36": {
+    "Name": "Taisen 4 - Soldier",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.37": {
+    "Name": "Slotter UP - Core Alpha",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.39": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! Sammy's Collection 2 DX",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.40": {
+    "Name": "Jissen Pachi-Slot Hisshouhou! Sammy's Collection 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.43": {
+    "Name": "Net de Bomberman",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.44": {
+    "Name": "Phantom Brave [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.45": {
+    "Name": "Phantom Brave",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.47": {
+    "Name": "Saikyou Toudai Shogi 2004",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.49": {
+    "Name": "Mahjong Party - Duel with The Idol",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.50": {
+    "Name": "Soccer Life",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.51": {
+    "Name": "Slotter UP - Mania 4",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.52": {
+    "Name": "Sukisyo - First Limit & Target Nights",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.54": {
+    "Name": "Yamasa Digi World 3 [Best of Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.55": {
+    "Name": "Yamasa Digi World SP - Neo Magic Pulsar XX [Best of Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.56": {
+    "Name": "Yamasa Digi World 4 [Best of Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.57": {
+    "Name": "Yamasa Digi World SP - Umi Ichiban R [Best of Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.61": {
+    "Name": "Princess Maker - Refine",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.62": {
+    "Name": "Kaiketsu Zorro Mezase! Itazura King [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.64": {
+    "Name": "Sekai Saikyou Ginsei Igo 5",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.65": {
+    "Name": "RockMan Collection [Special Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.66": {
+    "Name": "CR Kamen Rider Pachi-Slot Expert 5",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.67": {
+    "Name": "Curry House Coco Ichibanya",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_203.68": {
+    "Name": "Kaiketsu Zorro Mezase! Itazura King",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.69": {
+    "Name": "Kinnikuman Generations",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.70": {
+    "Name": "Slotter Up Core 3 - Doronjo ni Omakase!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.71": {
+    "Name": "Mahjong Haou Shinken Battle",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.72": {
+    "Name": "Jisen Pachisuri Hissou Hou! Hokuto no Ken [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.73": {
+    "Name": "Jisen Pachisuri Hissou Hou! Hokuto no Ken",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.74": {
+    "Name": "Football Kingdom [Trial Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.75": {
+    "Name": "Sanyo Pachinko Paradise 10",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.76": {
+    "Name": "Daito Giken Koushiki Pachi-Slot Simulator Yoshimune",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.77": {
+    "Name": "Fish Eyes 3 [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.78": {
+    "Name": "Slotter UP - Core 4",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_203.79": {
+    "Name": "Eikan wa Kimini 2004 - Koshien no Kodou [Artdink Best Choice]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.80": {
+    "Name": "Shinkon Gattai Gondannar!!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.81": {
+    "Name": "Monkey Turn V",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.82": {
+    "Name": "Taiko no Tatsujin 4th Generation - Gathering Festival [with Drum Controller]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.83": {
+    "Name": "Taiko no Tatsujin - Atsumare Matsurida Yonndaime",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.84": {
+    "Name": "Hayarikami",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.86": {
+    "Name": "Value 2000 Series - Igo 4",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.87": {
+    "Name": "Value 2000 Series - Shogi 4",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.88": {
+    "Name": "CR Pachinko Yellow Cab - Pachitte Chonmage Tatsujin 6",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.89": {
+    "Name": "Saikyou Toudai Shogi 5 [Mycom Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.91": {
+    "Name": "Saiyuki Gunlock",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.92": {
+    "Name": "Toudai Shogi - Jouseki Dojo Kanketsuhen",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.93": {
+    "Name": "Princess Maker 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.94": {
+    "Name": "Suki na Mono wa Sukida Rashouganai + White Flower + Sukisyo!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.96": {
+    "Name": "Slotter UP - Mania 5",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.98": {
+    "Name": "La Pucelle - Hikari no Seijyo Densetsu Nijuu",
+    "Region": "NTSC-J"
+  },
+  "SLPS_203.99": {
+    "Name": "Taiko no Tatsujin - Go! Go! Godaime [with Tatacon]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.00": {
+    "Name": "Taiko no Tatsujin - Go! Go! Godaime",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.01": {
+    "Name": "Tecmo Hit Parade",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.02": {
+    "Name": "Kamen Rider Blade",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_204.03": {
+    "Name": "Shanghai - Sangoku Pai Tatagi [Super Value 2800]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.05": {
+    "Name": "Slotter UP - Core 5",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.06": {
+    "Name": "Cam-Station [with EyeToy & USB Headset]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.07": {
+    "Name": "Mahjong Sangokushi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.08": {
+    "Name": "Card Captor Sakura - Sakura-Chan to Asobo!",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPS_204.09": {
+    "Name": "Phantom Kingdom [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.10": {
+    "Name": "Phantom Kingdom [Limited Edition]",
+    "Region": "NTSC-J",
+    "Status": 5
+  },
+  "SLPS_204.11": {
+    "Name": "Hissatsu Pachinko Station v9",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.12": {
+    "Name": "Hissatsu Pachinko Station v10",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.13": {
+    "Name": "Taiko no Tatsujin - Taiko Drum Masters [with Drum Controller]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.14": {
+    "Name": "Taiko no Tatsujin - Taiko Drum Masters",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_204.16": {
+    "Name": "Inyou Taisenki - Byakko Enbu [with EyeToy]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.17": {
+    "Name": "Inyou Taisenki - Byakko Enbu",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.18": {
+    "Name": "Cam-Station",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.20": {
+    "Name": "Ultraman Nexus",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.21": {
+    "Name": "Sekai Saikyou Ginsei Igo 6",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.22": {
+    "Name": "Hayarikami Revenge",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.23": {
+    "Name": "LEGO Star Wars - The Video Game",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.24": {
+    "Name": "Taiko no Tatsujin - Tobikkiri! Anime Special [with Tatacon]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.25": {
+    "Name": "Taiko no Tatsujin - Tobikkiri! Anime Special",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.26": {
+    "Name": "Madagascar",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.28": {
+    "Name": "Monkey Turn V [Bandai the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.29": {
+    "Name": "Hissatsu Pachislot Ninja Hattori Kun V",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.30": {
+    "Name": "Simple 2000 Series Vol.91 - The All-Star Kakutou",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "XgKickHack": 1
+  },
+  "SLPS_204.31": {
+    "Name": "Simple 2000 Series Vol.86 - The Menkyou Shutoku Simulation",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.36": {
+    "Name": "Sakigake!! Otokojuku",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.39": {
+    "Name": "Simple 2000 Series Vol.79 - The Party Quiz - Akko ni Omakase",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.40": {
+    "Name": "Simple 2000 Series Vol.88 - The Mini Bijo Keikan",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.41": {
+    "Name": "Simple 2000 Series Vol.87 - The Senko",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.42": {
+    "Name": "Daito Giken Koushiki Pachi-Slot Simulator Banchou",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.43": {
+    "Name": "Blocks Club with Bumpy Trot",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.44": {
+    "Name": "Simple 2000 Series Vol.90 - The O-Ane-Chan Bara 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.45": {
+    "Name": "Simple 2000 Series Ultimate Vol.28 - The Gaidou! Genocide Grand Prix - Drive to Survive",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.46": {
+    "Name": "Simple 2000 Series Vol.89 - The Party Game 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.47": {
+    "Name": "Kamen Rider Hibiki",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_204.50": {
+    "Name": "Taiko no Tatsujin - Wai Wai Happy Muyome [with Tatacon]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.51": {
+    "Name": "Taiko no Tatsujin - Wai Wai Happy Muyome",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.52": {
+    "Name": "Simple 2000 Series Ultimate Vol.30 - Kourin! Zokusha Goddo!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.53": {
+    "Name": "Simple 2000 Series Ultimate Vol.29 - K-1 Premium 2005 Dynamite!!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.54": {
+    "Name": "Simple 2000 Series Vol.93 - The Right Brain Drill",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.55": {
+    "Name": "Simple 2000 Series Vol.94 - The Aka-Champion - Come on Baby",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.56": {
+    "Name": "Simple 2000 Series Vol.95 - The Zombie vs. Kyuukyuusha",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.57": {
+    "Name": "Hissatsu Pachislo Evolution 2 - Oso Matsu-Kun",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.58": {
+    "Name": "Simple 2000 Series Vol.96 - The Pirate",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.59": {
+    "Name": "Yamasa Digi World SP - Isao Lady",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.60": {
+    "Name": "Rakushou! Pachi-Slot Sengen 4",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.61": {
+    "Name": "Simple 2000 Series Vol.99 - The Genshijin",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_204.62": {
+    "Name": "Ougon Kishi Garo [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.63": {
+    "Name": "Ougon Kishi Garo",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.64": {
+    "Name": "Simple 2000 Series Vol.105 - The Maid Fuku to Kikanjuu",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.65": {
+    "Name": "Simple 2000 Series Vol.100 - The Otoko Tachi no Kijuu Houza",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.66": {
+    "Name": "Simple 2000 Series Vol.101 - The Oanechan Pon - Oanechan 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.67": {
+    "Name": "Simple 2000 Series Vol.102 - The Fuhyou - Senjou no Inu Tachi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.68": {
+    "Name": "Simple 2000 Series Vol.106 - The Block Kuzushi Quest - Dragon Kingdom",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_204.69": {
+    "Name": "Matching Maker 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_204.70": {
+    "Name": "Simple 2000 Series Vol.103 - The Chikyuu Boueigun Tactics",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.71": {
+    "Name": "Chulip [Super Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.72": {
+    "Name": "Daito Giken Koushiki Pachi-Slot Simulator - Hihouden",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.73": {
+    "Name": "Simple 2000 Series Vol.104 - The Robot Tsuku Rouze! - Gekitou! Robot Fight",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.74": {
+    "Name": "Simple 2000 Series Vol.107 - The Honoo no Kakutou Banchou",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.75": {
+    "Name": "Yamasa Digi World SP - Giant Pulsar",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_204.76": {
+    "Name": "Simple 2000 Series Vol.108 - The Nippon Tokushubutai",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.77": {
+    "Name": "Fish Eyes 3 [Super Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.78": {
+    "Name": "Simple 2000 Series Vol.109 - The Taxi 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.79": {
+    "Name": "Sokudoku Master",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.80": {
+    "Name": "Simple 2000 Series Vol.110 - The Toubou Prisoner",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.81": {
+    "Name": "Simple 2000 Series Vol.112 - The Tousou Highway 2 - Road Warrior 2050",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.82": {
+    "Name": "3-D Mahjong + Suzume Paitori",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.83": {
+    "Name": "Kamen Rider Kabuto",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.84": {
+    "Name": "Simple 2000 Series Ultimate Vol.34 - Sakigake!! Otokojuku",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.85": {
+    "Name": "Taiko no Tatsujin Doka! [with Tatacon Controller]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.86": {
+    "Name": "Taiko no Tatsujin Bang Tap! Toomori 7 Daimei",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.87": {
+    "Name": "Pachi-Slot King! Kagaku Ninja-Tai Gatchaman",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.88": {
+    "Name": "Simple 2000 Series Vol.113 - The Tairyou Jigoku",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.89": {
+    "Name": "Simple 2000 Series Vol.114 - The Jokouppichi Torimonochou - Oanechan Go Go Go!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.90": {
+    "Name": "Pachi-Slot Club Collection - IM Juggler EX - Juggler Selection",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.91": {
+    "Name": "Simple 2000 Series Vol.118 - The Raku Musha Dokaku Takeshi Samurai Toujou",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.92": {
+    "Name": "Simple 2000 Series Vol.115 - The Roomshare to Iu Seikatsu",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.93": {
+    "Name": "Simple 2000 Series Vol.116 - The Neko Mura no Hitobito Pagu Daikan no Akugyou Zanmai",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_204.94": {
+    "Name": "Simple 2000 Series Vol.117 - The Zerosen",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.96": {
+    "Name": "Daito Giken Koushiki Pachi-Slot Simulator - Shake II",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.97": {
+    "Name": "Simple 2000 Series Vol.119 - The Survival Game 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_204.99": {
+    "Name": "Inaka Kurashi - Nan no Shima no Monogatari [Super Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_205.00": {
+    "Name": "Simple 2000 Series Vol.120 - The Saigo no Nippon Tsuwamono",
+    "Region": "NTSC-J"
+  },
+  "SLPS_205.01": {
+    "Name": "Hayarikami 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_205.03": {
+    "Name": "Simple 2000 Series Vol.121 - The Boku no Machidzukuri 2 - Machi-ing Maker 2.1",
+    "Region": "NTSC-J"
+  },
+  "SLPS_205.04": {
+    "Name": "Daito Giken Koushiki Pachi-Slot Simulator - Shin Yoshimune",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.01": {
+    "Name": "Eternal Ring",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.02": {
+    "Name": "Dead or Alive 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_250.03": {
+    "Name": "Evergrace",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.04": {
+    "Name": "Kensetsu Juuki Kenka Battle - Buchigire Kongou!!",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPS_250.05": {
+    "Name": "Rock'n Mega Stage",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.06": {
+    "Name": "Koushien Baseball",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.07": {
+    "Name": "Armored Core 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.08": {
+    "Name": "Sorcerous Stabber Orphen",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.09": {
+    "Name": "G-Saviour",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.10": {
+    "Name": "Unison",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_250.11": {
+    "Name": "Sunrise Eiyuutan R",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.12": {
+    "Name": "Victorious Boxers",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.13": {
+    "Name": "Kurikuri Mix",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.14": {
+    "Name": "Choro Q - High Grade [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.15": {
+    "Name": "Choro Q - High Grade",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.16": {
+    "Name": "Neo Atlas 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.17": {
+    "Name": "A-Train 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.18": {
+    "Name": "Sidewinder Max",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.20": {
+    "Name": "Mobile Suit Gundam",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.22": {
+    "Name": "Cool Boarders - Code Alien",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.23": {
+    "Name": "Bouncer, The",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.25": {
+    "Name": "Seven Lance Moromos - Cavalryman Corps",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLPS_250.26": {
+    "Name": "Dead or Alive 2 - Hardcore",
+    "Region": "NTSC-J",
+    "Compat": 1
+  },
+  "SLPS_250.28": {
+    "Name": "Shutokou Battle 0",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.30": {
+    "Name": "Lunatic Dawn - Tempest",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.32": {
+    "Name": "Golful Golf",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.33": {
+    "Name": "Kaze no Klonoa 2 - Sekai ga Nozonda Wasuremono",
+    "Region": "NTSC-J",
+    "Compat": 4,
+    "eeClampMode": 3
+  },
+  "SLPS_250.34": {
+    "Name": "Flower, Sun and Rain",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.35": {
+    "Name": "Monster Farm 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.36": {
+    "Name": "Gallop Racer 5",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.37": {
+    "Name": "Velvet File Plus",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.38": {
+    "Name": "True Love Story 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.39": {
+    "Name": "Missing Blue [First Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.40": {
+    "Name": "Armored Core 2 - Another Age",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_250.41": {
+    "Name": "Shadow Hearts",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.42": {
+    "Name": "Maken Shao [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.44": {
+    "Name": "Evergrace 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.45": {
+    "Name": "Atelier Lilie",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.46": {
+    "Name": "Golf Navigator Vol.1",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.47": {
+    "Name": "Golf Navigator Vol.2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.48": {
+    "Name": "Zeonic Front - Mobile Suit Gundam 0079",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.50": {
+    "Name": "Final Fantasy X",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "IPUWaitHack": 1
+  },
+  "SLPS_250.51": {
+    "Name": "Missing Blue",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.52": {
+    "Name": "Ace Combat 4 - Shattered Skies",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_250.53": {
+    "Name": "Eikan wa Kimini - Koushien no Hasha",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.54": {
+    "Name": "Tamamayu Story 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.55": {
+    "Name": "Golf Navigator Vol.3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.57": {
+    "Name": "King's Field 4",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.59": {
+    "Name": "G-Breaker - Legend of Cloudia",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.60": {
+    "Name": "Mobile Suit Gundam - Megurial Sora [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.62": {
+    "Name": "Kidou Senshi Gundam - Meguriai Sora",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.64": {
+    "Name": "Sea-Man",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.69": {
+    "Name": "FIFA 2002 - Road to World Cup",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.70": {
+    "Name": "Tales of the Sunrise Heroes 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.71": {
+    "Name": "Visual Mix - Ayumi Hamasaki Dome Tour 2001",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.74": {
+    "Name": "Project Zero",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_250.75": {
+    "Name": "Sidewinder F",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.76": {
+    "Name": "Sidewinder F",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.77": {
+    "Name": "Vampire Night",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLPS_250.78": {
+    "Name": "SSX Tricky",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.79": {
+    "Name": "Madden NFL 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.80": {
+    "Name": "Uchuu Senkan Yamato - Iscandar he no Tsuioku [Special Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.81": {
+    "Name": "Saishuu Densha",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.84": {
+    "Name": "Thunder Strike - Operation Phoenix",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.85": {
+    "Name": "Soul Reaver 2 - Legacy of Kain",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.88": {
+    "Name": "Final Fantasy X International",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "IPUWaitHack": 1
+  },
+  "SLPS_250.94": {
+    "Name": "Reveal Fantasia",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.95": {
+    "Name": "Uchuu Senkan Yamato - Iscandar he no Tsuioku",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.96": {
+    "Name": "Galerians 2 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.97": {
+    "Name": "Velvet File Plus",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.98": {
+    "Name": "Air Ranger 2 - Rescue Helicopter",
+    "Region": "NTSC-J"
+  },
+  "SLPS_250.99": {
+    "Name": "WRC - World Rally Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.00": {
+    "Name": "Tekken 4",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_251.02": {
+    "Name": "Project Arms",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.03": {
+    "Name": "Super Robot Taisen Impact [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.04": {
+    "Name": "Super Robot Taisen Impact",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.05": {
+    "Name": "Kingdom Hearts",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.07": {
+    "Name": "Kengo 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_251.08": {
+    "Name": "Runabout 3 - Neo Age",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.11": {
+    "Name": "Higanbana",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.12": {
+    "Name": "Armored Core 3",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_251.13": {
+    "Name": "Zettai Zetsumei Toshi",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_251.14": {
+    "Name": "G-Breaker - Daisanshi Cloudia Taisen",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.15": {
+    "Name": "EOE - Eve of Evtinction",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.17": {
+    "Name": "Sankyo Fever 6",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.18": {
+    "Name": "FIFA 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.19": {
+    "Name": "Galerians 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.20": {
+    "Name": "Gundam Gihren's Ambition",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.21": {
+    "Name": "dot Hack Vol.1",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.22": {
+    "Name": "Mobile Suit Gundam - Lost War Chronicles [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.23": {
+    "Name": "Mobile Suit Gundam - Lost War Chronicles",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.24": {
+    "Name": "G-Breaker 2 - Doumei no Hangeki",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.25": {
+    "Name": "Iris [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.27": {
+    "Name": "Air",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.28": {
+    "Name": "Victorious Boxer - Championship Version",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.29": {
+    "Name": "Victorious Boxer - Championship Version",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.30": {
+    "Name": "Roommate Asami - Okusama wa Joshikousei",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.31": {
+    "Name": "Ghost Vibration",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.35": {
+    "Name": "Kamaitachi no Yoru 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.36": {
+    "Name": "Kuon no Kizuna Sairin Mikotonori",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.38": {
+    "Name": "Ever 17 - The Out of Infinity",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.39": {
+    "Name": "Baldur's Gate - Dark Alliance",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPS_251.42": {
+    "Name": "Tiger Woods PGA Tour 2002",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.43": {
+    "Name": "dot Hack Vol.2 - Mutation",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.44": {
+    "Name": "Memorial Song",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.45": {
+    "Name": "Hooligan [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.46": {
+    "Name": "Hooligan",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.49": {
+    "Name": "Ever 17 - The Out of Infinity",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.50": {
+    "Name": "Only You",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.51": {
+    "Name": "Medal of Honor - Jishousaidai no Sakusen",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.54": {
+    "Name": "Flower, Sun and Rain [Victor The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.55": {
+    "Name": "Ultraman Fighting Evolution 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.56": {
+    "Name": "King of Fighters 2000, The",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.58": {
+    "Name": "dot Hack - Vol.3 - Erosion Pollution",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.59": {
+    "Name": "Technic Beat",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.60": {
+    "Name": "Final Fantasy XI 2002 [Special Art Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.61": {
+    "Name": "Uchuu Senkan Yamato - Ankoku Seidan Teikoku no Gyakushuu [Special Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.62": {
+    "Name": "Uchuu Senkan Yamato - Ankoku Seidan Teikoku no Gyakushuu",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.64": {
+    "Name": "Uchuu Senkan Yamato - Nijuu Ginga no Houkai",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.65": {
+    "Name": "Gunvari Collection + Time Crisis",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.66": {
+    "Name": "Ingot 79",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.69": {
+    "Name": "Armored Core 3 - Silent Line",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.70": {
+    "Name": "SD Gundam G Generation Neo",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.71": {
+    "Name": "Lupin III - Majutsu no Isan",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.72": {
+    "Name": "Tales of Destiny 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.74": {
+    "Name": "DragonBall Z - Budokai",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.77": {
+    "Name": "Gallop Racer 6 - Revolution",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.78": {
+    "Name": "Argus no Senshi",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_251.79": {
+    "Name": "FIFA 2003",
+    "Region": "NTSC-J",
+    "vuClampMode": 2
+  },
+  "SLPS_251.81": {
+    "Name": "Gunvari Collection & Time Crisis",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.82": {
+    "Name": "Idol Janshi R - Jan-Guru Project [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.83": {
+    "Name": "Idol Janshi R - Jan-Guru Project",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.84": {
+    "Name": "Guilty Gear XX - The Midnight Carnival",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_251.85": {
+    "Name": "Unlimited SaGa [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.86": {
+    "Name": "Kidou Shin Sangumi Moeyo Ken",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.90": {
+    "Name": "Sweet Legacy",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.91": {
+    "Name": "Mizuiro Light Blue",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.92": {
+    "Name": "My Merry May",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.93": {
+    "Name": "My Merry May",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.95": {
+    "Name": "Venus & Braves [Premium Pack]",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLPS_251.96": {
+    "Name": "Venus & Braves",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLPS_251.97": {
+    "Name": "Kingdom Hearts - Final Mix [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_251.98": {
+    "Name": "Kingdom Hearts - Final Mix",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_251.99": {
+    "Name": "Unlimited Saga",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_252.00": {
+    "Name": "Final Fantasy XI",
+    "Region": "NTSC-J",
+    "Compat": 3
+  },
+  "SLPS_252.01": {
+    "Name": "Reveal Fantasia",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.02": {
+    "Name": "dot Hack - Vol.4 - Zettai Houi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.04": {
+    "Name": "Moto GP3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.05": {
+    "Name": "Ys I-II - Eternal Story [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.06": {
+    "Name": "Ys I-II - Eternal Story",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.09": {
+    "Name": "Metal Slug 3",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_252.12": {
+    "Name": "Giren no Yabou - Zeon Dokuritsu Sensouden",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.13": {
+    "Name": "Bass Landing 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.14": {
+    "Name": "Guardian Angel",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.15": {
+    "Name": "Iris [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.16": {
+    "Name": "Iris",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_252.17": {
+    "Name": "Shadow Tower Abyss",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_252.19": {
+    "Name": "Canary",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.20": {
+    "Name": "Elysion",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.21": {
+    "Name": "Pia - Welcome to Carrot 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.23": {
+    "Name": "Canvas",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.24": {
+    "Name": "Ai Yori Aoshi [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.25": {
+    "Name": "Ai Yori Aoshi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.26": {
+    "Name": "Memories Off - Duet",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.27": {
+    "Name": "Super Robot Wars - Alpha 2nd [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.28": {
+    "Name": "Super Robot Wars - Alpha 2nd",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.30": {
+    "Name": "Soul Calibur II",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_252.31": {
+    "Name": "Myst III - Exile",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.33": {
+    "Name": "Do DonPachi Daioujou",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.34": {
+    "Name": "Tenchu 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.35": {
+    "Name": "Yumeria",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_252.36": {
+    "Name": "Fantastic Fortune 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.37": {
+    "Name": "Only You",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.38": {
+    "Name": "My Merry Maybe",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.40": {
+    "Name": "Motion Gravure Series - Megumi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.41": {
+    "Name": "Motion Gravure Series - Hiroko Mori",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.42": {
+    "Name": "Motion Gravure Series - Tomomi Kitagawa",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.43": {
+    "Name": "Motion Gravure Series - Harumi Nemoto",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.44": {
+    "Name": "Max Payne",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.45": {
+    "Name": "True Love Story - Summer Days and Yet",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.46": {
+    "Name": "Tomb Raider - The Angel of Darkness",
+    "Region": "NTSC-J",
+    "OPHFlagHack": 1
+  },
+  "SLPS_252.47": {
+    "Name": "R-Type Final",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "EETimingHack": "1 "
+  },
+  "SLPS_252.48": {
+    "Name": "Kino no Tabi - The Beautiful World",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.50": {
+    "Name": "Final Fantasy X-2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.51": {
+    "Name": "MVP Baseball 2003",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.54": {
+    "Name": "Enter the Matrix",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPS_252.55": {
+    "Name": "Sidewinder V [Premium Flight Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.56": {
+    "Name": "Never 7 - The End of Infinity",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.57": {
+    "Name": "Close To",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.58": {
+    "Name": "Virtual View - R.C.T. Eyes Play",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.59": {
+    "Name": "Virtual View - Nemoto Harumi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.60": {
+    "Name": "Virtual View - Megumi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.61": {
+    "Name": "Guilty Gear XX #Reload",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.62": {
+    "Name": "Private Nurse Maria",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_252.64": {
+    "Name": "RahXephon [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.65": {
+    "Name": "RahXephon",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.66": {
+    "Name": "King of Fighters 2001, The",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.70": {
+    "Name": "Sunrise World War",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.71": {
+    "Name": "Sidewinder V",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_252.72": {
+    "Name": "Hulk, The",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.74": {
+    "Name": "Aikagi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.75": {
+    "Name": "Def Jam - Vendetta",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.76": {
+    "Name": "Natsuyume Ya Wa",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.78": {
+    "Name": "Memories Off - Mix",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.79": {
+    "Name": "Adventure Boy Club Magazine",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.82": {
+    "Name": "School Heaven - Boy's Love Scramble!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.83": {
+    "Name": "Interlude",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.87": {
+    "Name": "Victorious Boxers 2 - Ippo's Road to Glory",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.88": {
+    "Name": "D-A - Black [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.89": {
+    "Name": "Time Crisis 3 [with G-Con 2]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.90": {
+    "Name": "Time Crisis 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.91": {
+    "Name": "Baldur's Gate - Dark Alliance [PCCW The Best]",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPS_252.92": {
+    "Name": "D-A - Black",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.93": {
+    "Name": "Naruto - Narutimett Hero",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_252.94": {
+    "Name": "Uchuu no Stellvia",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.95": {
+    "Name": "Kaena",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLPS_252.96": {
+    "Name": "Super Robot Wars - Scramble Commander",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.98": {
+    "Name": "Tentama 1st - Sunny Side",
+    "Region": "NTSC-J"
+  },
+  "SLPS_252.99": {
+    "Name": "Shinseiki Evangelions 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.00": {
+    "Name": "R - Racing Evolution",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.01": {
+    "Name": "Missing Parts - The Tantei Stories - Side A",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.02": {
+    "Name": "Masked Rider - Geneology of Justice",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.03": {
+    "Name": "Zero - Crimson Butterfly",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_253.04": {
+    "Name": "Beast Sapp",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.05": {
+    "Name": "Mobile Suit Z Gundam - AEUG vs. Titans",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.07": {
+    "Name": "New Century GPX Cyber Formula - Road to the Infinity",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.08": {
+    "Name": "Crouching Tiger, Hidden Dragon",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.09": {
+    "Name": "WWE SmackDown! 4 - Shut your mouth [Yuke's The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.10": {
+    "Name": "Disney-Pixar's Finding Nemo",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.11": {
+    "Name": "Spy Fiction",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.12": {
+    "Name": "Zero Pilot - The Miracle in Lonely Air",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.13": {
+    "Name": "Seven Samurai 20XX",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.14": {
+    "Name": "Nebula - Echo Night",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPS_253.15": {
+    "Name": "One Piece - Grand Battle 3",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_253.16": {
+    "Name": "SNK vs. Capcom Chaos",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_253.17": {
+    "Name": "Shadow Hearts 2 [Deluxe Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.19": {
+    "Name": "Kero Kero King DX Plus",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.20": {
+    "Name": "InuYasha - Juso no Kamen",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.21": {
+    "Name": "Derby Stallion 2004",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.23": {
+    "Name": "Usagi - Yasei no Topai - Yamashiro Mahjong-Hen",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.24": {
+    "Name": "Rhapsody of Zephyr",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.26": {
+    "Name": "WWE Smackdown! Here Comes the Pain - Exciting Pro Wrestling 5 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.29": {
+    "Name": "Kuon",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPS_253.30": {
+    "Name": "DragonBall Z - Budokai 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.32": {
+    "Name": "Snow [First Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.33": {
+    "Name": "Gallop Racer Lucky 7",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.34": {
+    "Name": "Shadow Hearts 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.36": {
+    "Name": "Bass Landing 3 [with TsuriCon2+] [Sammy Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.37": {
+    "Name": "Bass Landing 3 [Sammy Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.38": {
+    "Name": "Armored Core - Nexus",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.40": {
+    "Name": "Missing Parts - Side B",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.41": {
+    "Name": "Backyard Wrestling - Don't Try This at Home",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.42": {
+    "Name": "Snow",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.43": {
+    "Name": "Gunslinger Girl Vol.1",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_253.44": {
+    "Name": "Saiyuki Reload",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.45": {
+    "Name": "Super Robot Wars MX",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_253.46": {
+    "Name": "Samurai Spirits Zero",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.47": {
+    "Name": "King of Fighters 2002, The",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.48": {
+    "Name": "Kokoro no Tobira [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.49": {
+    "Name": "Kokoro no Tobira",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.50": {
+    "Name": "Netsu Chu! Pro Baseball 2004",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.51": {
+    "Name": "Burnout 2 - Point of Impact",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.52": {
+    "Name": "Espgaluda",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_253.53": {
+    "Name": "Xenosaga Freaks",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.54": {
+    "Name": "Panzer Frony - Ausf. B",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.55": {
+    "Name": "UFC 2004 - Ultimate Fighting Championship",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.56": {
+    "Name": "Broken Sword - Nenereru Ryuu no Densetsu",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.57": {
+    "Name": "3-Nen B-Gumi Kinpachi Sensei - Densetsu no Kyoudan ni Tate!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.58": {
+    "Name": "Gold Gasho Bell! - Friendship Tag Battle",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.59": {
+    "Name": "Shaman King Funbari Spirits",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.60": {
+    "Name": "Katamari Damacy",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "mvuFlagSpeedHack": "0"
+  },
+  "SLPS_253.61": {
+    "Name": "Smash Court Professional Tournament 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.62": {
+    "Name": "Tetsujin 28 Go",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.63": {
+    "Name": "Sakura Zakashobotai",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.64": {
+    "Name": "Ultraman",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.65": {
+    "Name": "Missing Blue [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.66": {
+    "Name": "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.67": {
+    "Name": "Xenosaga Episode II - Jenseits von Gut und Bose [Premium Box] [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.68": {
+    "Name": "Xenosaga Episode II - Jenseits von Gut und Bose [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.69": {
+    "Name": "Xenosaga Episode II - Jenseits von Gut und Bose [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.70": {
+    "Name": "Spawn - Armageddon",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.71": {
+    "Name": "DearS [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.72": {
+    "Name": "DearS",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.73": {
+    "Name": "Gunslinger Girl Vol.2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.74": {
+    "Name": "Great Escape, The",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.75": {
+    "Name": "XIII",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.76": {
+    "Name": "Metal Slug 4",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_253.77": {
+    "Name": "Nightmare of Druaga, The - Fushigi no Dungeon",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.78": {
+    "Name": "Tokyo Majin Gakuen - Kaihoujyou Kefurokou [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.79": {
+    "Name": "Tokyo Majin Gakuen - Kaihoujyou Kefurokou",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.81": {
+    "Name": "Gakuen Heaven - Boy's Love Scramble! Type B",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.82": {
+    "Name": "One Piece - Land Land",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.83": {
+    "Name": "Digimon Battle Chronicle",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.84": {
+    "Name": "Tenchu Kurenai",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.85": {
+    "Name": "Friends Seishun no Kagayaki",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.86": {
+    "Name": "King of Fighters, The - Maximum Impact Maniax",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.87": {
+    "Name": "True Love Story - Summer Days, and Yet...",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.88": {
+    "Name": "Gunslinger Girl Vol.3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.89": {
+    "Name": "Gundam Seed - Never Ending Tomorrow",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.90": {
+    "Name": "Clover's Heart - Looking for Happiness [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.91": {
+    "Name": "Clover's Heart - Looking for Happiness",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.92": {
+    "Name": "Desire",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.93": {
+    "Name": "Rim Runners",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.94": {
+    "Name": "Another Century's Episode",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.95": {
+    "Name": "Sentimental Prelude",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.96": {
+    "Name": "Fantastic Fortune 2 - Triple Star",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.97": {
+    "Name": "Golden Voyage - Sinbad Adventure",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.98": {
+    "Name": "Naruto - Narutimett Hero 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_253.99": {
+    "Name": "Keroro Gunsou - Mero Mero Battle Royale",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.00": {
+    "Name": "Tales of Symphonia",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.01": {
+    "Name": "Magna Carta",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.02": {
+    "Name": "Hagane no Renkinjutsushi - Dream Carnival",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.03": {
+    "Name": "Hitman - Silent Assassin [Eidos The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.04": {
+    "Name": "RPG Maker 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.05": {
+    "Name": "Tokyo Majin Gakuen - Kaihoujyou Kefurokou [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.06": {
+    "Name": "Hitman - Contracts",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.07": {
+    "Name": "King of Fighters 2003, The",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.08": {
+    "Name": "Armored Core - Nine Breaker",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.09": {
+    "Name": "Futakoi [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.10": {
+    "Name": "Futakoi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.11": {
+    "Name": "To Heart 2 [Deluxe Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.13": {
+    "Name": "To Heart 2 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.14": {
+    "Name": "To Heart 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.15": {
+    "Name": "Chu-Kana Janshi [Collector's Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.16": {
+    "Name": "Chu Kana Janshi Tenho Pai-Nyan",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.17": {
+    "Name": "Panzer Front Ausf.B [Enterbrain Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.18": {
+    "Name": "Ace Combat 5 - The Unsung War",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.19": {
+    "Name": "Mobile Suit Gundam - Gundam vs. Z-Gundam",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.21": {
+    "Name": "Bokujou Monogarari - Oh! Wonderful Life",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.22": {
+    "Name": "Death by Degrees - Tekken - Nina Williams",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.23": {
+    "Name": "Kaitou Apricot - Complete Edition [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.24": {
+    "Name": "Kaitou Apricot - Complete Edition",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.25": {
+    "Name": "SD Gundam Force Daikessen!",
+    "Region": "NTSC-J",
+    "eeClampMode": 2
+  },
+  "SLPS_254.26": {
+    "Name": "Detective Conan - Inheritance of Britain",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.27": {
+    "Name": "Legions Gekitou! Saga Battle",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.28": {
+    "Name": "Metal Slug 3 [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.29": {
+    "Name": "King of Fighters 2000, The [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.30": {
+    "Name": "Lupin III - Columbus no Isan wa Akenisomar",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.32": {
+    "Name": "Majommusume A La Mode [Magical Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.33": {
+    "Name": "Teikoku Sensenki [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.34": {
+    "Name": "Rhapsody of Zephyr, The [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.35": {
+    "Name": "Majommusume A La Mode",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.36": {
+    "Name": "Teikoku Sensenki",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.37": {
+    "Name": "D A - White",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.38": {
+    "Name": "D A - White [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.39": {
+    "Name": "Hajime no Ippo - All-Stars",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.40": {
+    "Name": "Gold Gashbell!! Gekitou! Saikyou no Mamonotachi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.41": {
+    "Name": "Ultraman Fighting Evolution 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.43": {
+    "Name": "Kawa no Nushi Tsuri - Wonderful Journey",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.44": {
+    "Name": "Cherry Blossom",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.45": {
+    "Name": "Kagero II - Dark Illusion",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.47": {
+    "Name": "Aim for the Top! Gunbuster",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.48": {
+    "Name": "King of Fighters '94, The - Rebout [Special Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.49": {
+    "Name": "King of Fighters '94, The - Rebout",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.50": {
+    "Name": "Tales of Rebirth",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.51": {
+    "Name": "Hana to Taiyou to Ame to [Super Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.52": {
+    "Name": "Kino no Tabi - The Beautiful World [MediaWorks Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.53": {
+    "Name": "Digimon World X",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.54": {
+    "Name": "Daisenryaku VII Exceed",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.55": {
+    "Name": "Sanyo Pachinko Paradise 11",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.56": {
+    "Name": "Gladiator - Road to Freedom",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.57": {
+    "Name": "Poncotsu Roman Daikatsugeki Bumpy Trot",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.58": {
+    "Name": "King of Fighters 2001, The [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.59": {
+    "Name": "Sword of Destiny",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.60": {
+    "Name": "DragonBall Z 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.61": {
+    "Name": "Armored Core - Formula Front",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.62": {
+    "Name": "Armored Core - Last Raven",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.63": {
+    "Name": "My Home o Tsukurou 2! Takumi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.64": {
+    "Name": "Daisenryaku VII Exceed",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.65": {
+    "Name": "Azumi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.66": {
+    "Name": "Eternal Aselia - The Spirit of Eternity Sword [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.67": {
+    "Name": "Minna Daisuki Katamaki Damacy",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_254.68": {
+    "Name": "Eternal Aselia - The Spirit of Eternity Sword",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.69": {
+    "Name": "Baseball Live 2005",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.70": {
+    "Name": "Bouken-ou Beat - Dark Next Century",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.71": {
+    "Name": "Gakkou o Tsukurou - Happy Days!!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.72": {
+    "Name": "XIII (Thirteen) [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.73": {
+    "Name": "One Piece - Grand Battle! Combat Rush",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.74": {
+    "Name": "Beck - The Game",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.76": {
+    "Name": "Saint Seiya Seiiki Juunikyuu Hen",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_254.78": {
+    "Name": "Mobile Suit Gundam - One Year War",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.79": {
+    "Name": "Gold Gashbell - Friendship Tag Battle 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.80": {
+    "Name": "ZIPANG",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.81": {
+    "Name": "Gattsu!! Mori no Ishimatsu",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.82": {
+    "Name": "Yuki Katari [Renewal Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.83": {
+    "Name": "Sui-Toshi-Zun",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.84": {
+    "Name": "SNK vs. Capcom Chaos [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.85": {
+    "Name": "Mobile Suit Gundam Ver.1.5 [Gundam the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.86": {
+    "Name": "Mobile Suit Gundam - Lost War Chronicles [Gundam the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.87": {
+    "Name": "Mobile Suit Gundam - Megurial Sora [Gundam the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.88": {
+    "Name": "Zeonic Front - Mobile Suit Gundam 0079 [Gundam the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.89": {
+    "Name": "Ambition of Giren - Zeon Independence War + Direction Book of Capture [Gundam the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.91": {
+    "Name": "SD Gundam G Generation Neo [Gundam The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.92": {
+    "Name": "SD Gundam G Generation - Gundam Seed [Gundam The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.93": {
+    "Name": "Backyard Wrestling 2 - There Goes the Neighborhood",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.94": {
+    "Name": "Fragrence Tale",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.95": {
+    "Name": "Metal Slug 5",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_254.96": {
+    "Name": "Berwick Saga - Tear Ring Saga Series [Deluxe Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.97": {
+    "Name": "Berwick Saga - Tear Ring Saga Series",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.98": {
+    "Name": "Jikuu Bouken Zentrix",
+    "Region": "NTSC-J"
+  },
+  "SLPS_254.99": {
+    "Name": "Yu Yu Hakusho Forever",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.00": {
+    "Name": "Namco 50th Anniversary Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.01": {
+    "Name": "Onmyou Taisenki - Hasha no In",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.02": {
+    "Name": "Steamboy",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.03": {
+    "Name": "NeoGeo Online Collection Vol.2 - Bakumatsu Roman - Gekka no Kenshi 1&2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.04": {
+    "Name": "Garou - Mark of the Wolves [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.05": {
+    "Name": "Namco X Capcom",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.06": {
+    "Name": "For Symphony - With All One's Heart",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.07": {
+    "Name": "Mai-Hime [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.08": {
+    "Name": "Mai-Hime - The Another",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.09": {
+    "Name": "Garou - Mark of the Wolves",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.10": {
+    "Name": "Tekken 5",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "eeClampMode": 1
+  },
+  "SLPS_255.11": {
+    "Name": "Rasetsu Alternative",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.13": {
+    "Name": "Aoi Umi no Trista [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.14": {
+    "Name": "Aoi Umi no Trista",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.15": {
+    "Name": "Futakoi Alternative [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.16": {
+    "Name": "Futakoi Alternative",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.17": {
+    "Name": "Enjoy Golf!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.18": {
+    "Name": "InuYasha - Ougi Ranbu",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.19": {
+    "Name": "Sousei no Aquarion",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.20": {
+    "Name": "Gundam True Odyssey",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.21": {
+    "Name": "Soccer Life 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.22": {
+    "Name": "Yoshitsuneki [Goukakenran Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.23": {
+    "Name": "Yoshitsuneki",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.25": {
+    "Name": "King of Fighters, The - NeoWave",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.26": {
+    "Name": "Medical 91",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.27": {
+    "Name": "dot Hack - Fragment",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "EETimingHack": 1,
+    "OPHFlagHack": 1,
+    "DMABusyHack": 1
+  },
+  "SLPS_255.28": {
+    "Name": "Summon Night EX Thesis - Yoake no Tsubasa",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.29": {
+    "Name": "Ultraman Fighting Evolution - Rebirth",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.30": {
+    "Name": "Garouden Break Blow",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.31": {
+    "Name": "SD Gundam G Generation - Gundam Seed Edition",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.32": {
+    "Name": "Critical Velocity",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.33": {
+    "Name": "Tales of Legendia",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.34": {
+    "Name": "Twinkle Star Sprites - La Petite Princesse",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.35": {
+    "Name": "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection [Special Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.37": {
+    "Name": "Super Robot Wars - Alpha 3",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.38": {
+    "Name": "Super Robot Wars - Alpha [Premium Pack]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.39": {
+    "Name": "School Rumble [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.40": {
+    "Name": "School Rumble",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.41": {
+    "Name": "New Century GPX Cyber Formula - Road to the Infinity 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.42": {
+    "Name": "Naruto Uzumaki Ninden",
+    "Region": "NTSC-J",
+    "Compat": 4,
+    "OPHFLagHack": 1
+  },
+  "SLPS_255.43": {
+    "Name": "Futakoi - Koi to Mizugi no Survival",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.44": {
+    "Name": "Fatal Frame - Zero",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.45": {
+    "Name": "Fighting for One Piece",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.46": {
+    "Name": "Ichigo Mashimaro [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.47": {
+    "Name": "Ichigo Mashimaro",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.48": {
+    "Name": "Pachitte Ultra Seven Chonmage Tatsujin 8",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.49": {
+    "Name": "Gundam Seed Destiny - Generation of C.E.",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.50": {
+    "Name": "Cowboy Bebop - Tsuitou no Yakyoku [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.51": {
+    "Name": "Cowboy Bebop - Tsuitou no Yakyoku",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.52": {
+    "Name": "Inuyasha - Juuso no Kamen [Bandai the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.53": {
+    "Name": "Yoshitsune Eiyuuden Shura",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.54": {
+    "Name": "Eureka Seven TR1 - New Wave",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.56": {
+    "Name": "Hissatsu Pachinko Station V11",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.57": {
+    "Name": "Urban Reign",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.58": {
+    "Name": "NeoGeo Battle Coliseum",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.59": {
+    "Name": "Samurai Spirits - Tenkaichi Kenkakuden",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.60": {
+    "Name": "DragonBall Z - Sparking!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.61": {
+    "Name": "MotoGP 4",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.64": {
+    "Name": "Gallop Racer 8 - Live Horse Racing",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.65": {
+    "Name": "Hisshou Pachinko Kouryoku Series Vol.1 - CR Shinseiki Evangelion",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.66": {
+    "Name": "Simple 2000 Series Ultimate Vol.27 - After Class Love Beat",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.67": {
+    "Name": "Pachitte Chonmage Tatsujin 9",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.68": {
+    "Name": "Keroro Gunsou - Mero Mero Battle Royale [Bandai The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.69": {
+    "Name": "Kidou Senshi Gundam SEED - Rengou vs. Z.A.F.T.",
+    "Region": "NTSC-J",
+    "eeRoundMode": 1,
+    "FpuNegDivHack": 1
+  },
+  "SLPS_255.70": {
+    "Name": "Kino no Tabi 2 - The Beautiful World",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.71": {
+    "Name": "Metal Slug 4 [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.72": {
+    "Name": "Samurai Spirits Zero [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.73": {
+    "Name": "King of Fighters 2002, The [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.74": {
+    "Name": "Sanyo Pachinko Paradise 12",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.75": {
+    "Name": "Keroro Gunsou - Mero Mero Battle Royale Z",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.76": {
+    "Name": "One Piece - Pirates Carnival",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.77": {
+    "Name": "Soul Calibur III",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.78": {
+    "Name": "K-1 World Grand Prix 2005",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.79": {
+    "Name": "Little Aid",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.80": {
+    "Name": "Chicken Little",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.81": {
+    "Name": "Simple 2000 Series Vol.92 - The Game of a Curse",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.82": {
+    "Name": "Asutoro Kyudan Kessen",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.84": {
+    "Name": "From TV Animation - One Piece - Pirates Carnival [with Multitap for new models]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.85": {
+    "Name": "Monster Farm 5",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.86": {
+    "Name": "Tales of the Abyss",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_255.87": {
+    "Name": "Sugar Sugar Rune - Koimo Osharemo Pick-Up",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.88": {
+    "Name": "Meitantei Conan - Daiei Teikoku no Isan [Bandai The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.89": {
+    "Name": "Naruto Narutimett Hero 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.90": {
+    "Name": "Namco Museum Arcade Hits",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.91": {
+    "Name": "Last Escort - Shinya no Kokuchou Monogatari",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.92": {
+    "Name": "Sunrise Eiyuutan 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.93": {
+    "Name": "Hoshigari Empusa",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.96": {
+    "Name": "Konjiki no Gashbell! - Go!Go! Mamodo Fight",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.97": {
+    "Name": "Kawa no Nushi Tsuri - Wonderful Journey [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.98": {
+    "Name": "Gakkou o Tsukurou - Happy Days!! [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_255.99": {
+    "Name": "Shakugan no Shana",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.00": {
+    "Name": "Samurai Champloo - Sidetracked",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.01": {
+    "Name": "Ueki no Housoku - Taosu Zeroberuto Juudan!!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.02": {
+    "Name": "Hisshou Pachinko-Pachislot Kouryoku Series Vol.2 - Bomber Powerful & Yume Yume World DX",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.03": {
+    "Name": "Tensei - Swords of Destiny [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.04": {
+    "Name": "Ar Tonelico - Sekai no Owari de Utai Tsudukeru Shoujo",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.05": {
+    "Name": "NeoGeo Online Collection Vol.3 - The King of Fighters - Orochi Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.06": {
+    "Name": "Zettai Zetsumei Toshi 2 - Itetsuita Kioutachi",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.07": {
+    "Name": "Makai Senki Disgaea 2 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.08": {
+    "Name": "Makai Senki Disgaea 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.09": {
+    "Name": "King of Fighters, The - Maximum Impact 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.10": {
+    "Name": "Ryuuko no Ken - Ten-Chi-Jin (Art of Fighting Collection)",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.11": {
+    "Name": "Strawberry Panic [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.12": {
+    "Name": "Strawberry Panic",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.13": {
+    "Name": "My Home o Tsukurou 2! Takumi [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.14": {
+    "Name": "Mai-Hime - Unmei no Keitouju [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.15": {
+    "Name": "My Home wo Tsukurou 2! Kantan Sekkei!!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.16": {
+    "Name": "Ski Jumping Pairs Reloaded",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.17": {
+    "Name": "Etude Prologue - Yureugoku Kokoro no Katachi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.18": {
+    "Name": "D-A - Black [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.19": {
+    "Name": "D-A - White [Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.20": {
+    "Name": "Hisshou Pachinko-Pachislot Kouryoku Series Vol.3 - CR Marilyn Monroe",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.21": {
+    "Name": "Kashimashi! Girl Meets Girl [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.22": {
+    "Name": "Kashimashi! Girl Meets Girl",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.23": {
+    "Name": "Another Century's Episode 2",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.24": {
+    "Name": "Futakoi-Futakoi Island Collection",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.26": {
+    "Name": "Chronicles of Narnia, The - The Lion, The Witch and The Wardrobe",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.27": {
+    "Name": "Mobile Suit Gundam Climax U.C.",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.28": {
+    "Name": "IGPX",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.29": {
+    "Name": "Ace Combat Zero - The Belkan War",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.30": {
+    "Name": "Pro Yakyuu Netsu Star 2006",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.31": {
+    "Name": "Simple 2000 Series Vol.98 - Roman Sabou",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.32": {
+    "Name": "Simple 2000 Series Vol.97 - The Koi no Engine",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.33": {
+    "Name": "Futakoi Alternative - Koi to Shoujo to Machinegun [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.34": {
+    "Name": "Metal Slug 5 [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.35": {
+    "Name": "King of Fighters 2003, The [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.36": {
+    "Name": "King of Fighters, The - Maximum Impact",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.38": {
+    "Name": "King of Fighters, The - Maximum Impact 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.39": {
+    "Name": "Plus Plum 2 Again",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.40": {
+    "Name": "Xenosaga Episode III - Also Sprach Zarathustra [Disc1of2]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.41": {
+    "Name": "Xenosaga Episode III - Also Sprach Zarathustra [Disc2of2]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.42": {
+    "Name": "Super DragonBall Z",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.43": {
+    "Name": "Kimikisu",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.44": {
+    "Name": "Simple 2000 Ultimate Series Vol.31 - K-1 World Max 2005",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.45": {
+    "Name": "Hisshou Pachinko-Pachislot Kouryoku Series Vol.4 - CR Ashita Gaarusa Yoshimoto World",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.46": {
+    "Name": "Eureka Seven - New Vision",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.47": {
+    "Name": "Simple 2000 Series Ultimate Vol.32 - Azumi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.48": {
+    "Name": "Hisshou Pachinko-Pachislot Kouryoku Series Vol.5 - CR Shinseiki Evangelion Second Impact & Pachisuro Shinseiki Evangelion",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.49": {
+    "Name": "Space Sheriff Spirits",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.50": {
+    "Name": "Metal Slug 3D",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.51": {
+    "Name": "dot Hack G.U. Vol.1 - Saitan",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.53": {
+    "Name": "Cluster Edge [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.54": {
+    "Name": "Cluster Edge",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.55": {
+    "Name": "dot Hack G.U. Vol.2 - Kimi Omou Koe",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.56": {
+    "Name": "dot Hack - G.U. Vol.3 - Aruku Youna Hayasa de",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.57": {
+    "Name": "Fighting Beauty Wulong",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.58": {
+    "Name": "Binchou-Tan - Shiwase Koyomi [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.59": {
+    "Name": "Binchou-Tan - Shiwase Koyomi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.60": {
+    "Name": "King of Fighters XI, The",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.61": {
+    "Name": "King of Fighters, The - Nests",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.62": {
+    "Name": "Kyo Kara Maoh! The 1st trip of Maoh! [Premium Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.63": {
+    "Name": "Kyo Kara Maoh! The 1st trip of Maoh!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.64": {
+    "Name": "NeoGeo Online Collection - Garou Densetsu Battle Archives Vol.1",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.65": {
+    "Name": "Pachitte Chonmage Tatsujin 10",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.66": {
+    "Name": "Sakura Zakashobotai [Irem Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.67": {
+    "Name": "Daito Giken Premium Pachi-Slot Collection - Yoshimune",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.68": {
+    "Name": "Torikago no Mukougawa - The Angles with Strange Wings",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.69": {
+    "Name": "School Rumble 2nd Term [Limited Edition]",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.70": {
+    "Name": "School Rumble 2nd Term",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.71": {
+    "Name": "School Rumble [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.72": {
+    "Name": "7Cafe - Katashiki Mei Bonba Pawafuru 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.73": {
+    "Name": "Last Escort - The Black Butterfly Special Night",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.74": {
+    "Name": "Metal Slug 6",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.75": {
+    "Name": "Battle Stadium D.O.N.",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.76": {
+    "Name": "Kinnikuman Muscle Grand Prix Max",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.77": {
+    "Name": "Blood+ One Night Kiss",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_256.78": {
+    "Name": "Utawareru Mono [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.79": {
+    "Name": "Utawareru Mono",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.80": {
+    "Name": "Mai-Kinoto Hime [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.81": {
+    "Name": "Mai-Kinoto Hime",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.82": {
+    "Name": "Sanyo Pachinko Paradise 13",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.83": {
+    "Name": "Poncotsu Roman Daikatsugeki Bumpy Trot [Irem Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.84": {
+    "Name": "Mermaid Prism [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.85": {
+    "Name": "Rurouni Kenshin - Enjou! Kyoto Rinne",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.86": {
+    "Name": "Jojo no Kimyou na Bouken - Phantom Blood",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.87": {
+    "Name": "Korobotto Adventure",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.88": {
+    "Name": "Simoun - Shoubi Sensou - Fuuin no Remersion [First Print - Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.89": {
+    "Name": "Simoun - Shoubi Sensou - Fuuin no Remersion",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.90": {
+    "Name": "DragonBall Z - Sparking Neo",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.91": {
+    "Name": "Captain Tsubasa",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.93": {
+    "Name": "Shinseiki GPX - Road to the Infinity 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.94": {
+    "Name": "Princess Princess",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.95": {
+    "Name": "New Century GPX Cyber Formula - Road to the Infinity 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.96": {
+    "Name": "Mermaid Prism",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.97": {
+    "Name": "CR Fever Powerful Zero",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLPS_256.98": {
+    "Name": "Fatal Fury - Battle Archives 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_256.99": {
+    "Name": "Hisshou Pachinko-Pachislot Kouryoku Series Vol.8",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.00": {
+    "Name": "Aoi no Tristia [The Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.01": {
+    "Name": "Gallop Racer Inbreed",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.02": {
+    "Name": "Amekoushi no Kan",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.03": {
+    "Name": "Simple 2000 Series Vol.111 - The Itadaki Raider",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.04": {
+    "Name": "Summon Night 4",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.08": {
+    "Name": "Zero no Tsukaima [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.09": {
+    "Name": "Zero no Tsukaima",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.10": {
+    "Name": "K-1 World Grand Prix 2006",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.11": {
+    "Name": "Kashimashi! Girl Meets Girl [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.12": {
+    "Name": "King of Fighters Neowave [SNK the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.13": {
+    "Name": "Twinkle Star Sprites - La Petite Princesse [SNK the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.14": {
+    "Name": "Naruto - Konoha Spirits",
+    "Region": "NTSC-J",
+    "OPHFLagHack": 1
+  },
+  "SLPS_257.15": {
+    "Name": "Tales of Destiny",
+    "Region": "NTSC-J",
+    "FpuMulHack": 1
+  },
+  "SLPS_257.16": {
+    "Name": "Digimon Savers - Another Mission",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.17": {
+    "Name": "Simple 2000 Series Ultimate Vol.33 - Ururun Quest",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.18": {
+    "Name": "Mobile Suit Gundam Seed Destiny - Rengou vs. Z.A.F.T. II Plus",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "eeRoundMode": 1,
+    "FpuNegDivHack": 1
+  },
+  "SLPS_257.19": {
+    "Name": "Happiness! Deluxe [First Print Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.20": {
+    "Name": "Happiness! Deluxe",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.21": {
+    "Name": "HimeHibi - Princess Days",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.22": {
+    "Name": "Routes PE [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.23": {
+    "Name": "Reijou Tantei - Office Love Jiken",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.24": {
+    "Name": "Pachinko Kaou - Misora Hibari",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.25": {
+    "Name": "King's Field - Dark Side Box",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.26": {
+    "Name": "SNK Slot Panic Vol.1",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.27": {
+    "Name": "Routes PE",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.28": {
+    "Name": "Kujibiki Ambulance [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.29": {
+    "Name": "Kujibibi Unbalance",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.30": {
+    "Name": "Armored Core [Machine Side Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.33": {
+    "Name": "Super Robot Taisen OG - Original Generations",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.34": {
+    "Name": "Battle of Yu Yu Hakushou - Shitou! Ankoku Bujutsukai 120%",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.35": {
+    "Name": "Dragon Shadow Spell",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.36": {
+    "Name": "Samurai Spirits - Tenkaichi Kenkakuten [SNK Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.37": {
+    "Name": "Neo Geo Battle Coliseum [SNK Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.38": {
+    "Name": "Soul Cradle Sekai o Kurau Mono [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.39": {
+    "Name": "Soul Cradle Sekai o Kurau Mono",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.40": {
+    "Name": "Lupin III - Lupin ni wa Shi o, Zenigata ni wa Koi o",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.42": {
+    "Name": "Aammegami-Sama [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.43": {
+    "Name": "Aa Megami Sama",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.44": {
+    "Name": "Saint Seiya Meiou Hades Juunikyuu Hen",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.45": {
+    "Name": "Hisshou Pachinko-Pachislot Kouryoku Series Vol.1 - CR Shinseiki Evangelion",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.46": {
+    "Name": "CR Fever Captain Harlock",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.47": {
+    "Name": "Garouden Break Blow - Fist or Twist",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.48": {
+    "Name": "Aoi Sora no Neosphere - Nanoka Franka no Hatsumei Koubouki 2 [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.49": {
+    "Name": "Aoi Sora no Neosphere - Nanoka Franka no Hatsumei Koubouki 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.50": {
+    "Name": "Super Robot Taisen - Scramble Commander The 2nd",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.51": {
+    "Name": "Gakuen Utopia - Manabi Straight! KiraKira Happy Festa! [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.52": {
+    "Name": "Gakuen Utopia - Manabi Straight! KiraKira Happy Festa!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.53": {
+    "Name": "Ichigo Mashimaro [Shock SP]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.54": {
+    "Name": "Kino no Tabi 2 - The Beautiful World [Electric Shock SP]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.56": {
+    "Name": "dot Hack G.U. Vol.1 - Saitan [Bandai the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.57": {
+    "Name": "Nanatsu Iro - Drops Pure!! [First Print Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.58": {
+    "Name": "Nanatsu Iro - Drops Pure!!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.59": {
+    "Name": "Shiju Hachi",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPS_257.60": {
+    "Name": "VitaminX [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.61": {
+    "Name": "VitaminX",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.62": {
+    "Name": "Metal Slug Complete",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.63": {
+    "Name": "Shin Bokujou Monogatari - Pure Innocent Life",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.64": {
+    "Name": "Busou Renkin",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.65": {
+    "Name": "King of Fighters, The - Maximum Impact Regulation A",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.66": {
+    "Name": "Orange Honey - Boku wa Kimi ni Koishiteru [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.67": {
+    "Name": "Orange Honey - Boku wa Kimi ni Koishiteru",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.68": {
+    "Name": "Naruto Shippuuden Narutimate Accel",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.69": {
+    "Name": "Netsu Chu! Pro Baseball 2007",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.70": {
+    "Name": "Rakushou! Pachi-Slot Sengen 5",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.71": {
+    "Name": "Grim Grimoire",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_257.73": {
+    "Name": "Tales of Fandom Vol.2 [Tia Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.74": {
+    "Name": "Tales of Fandom Vol.2 [Luke Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.75": {
+    "Name": "Magician's Academy, The",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.76": {
+    "Name": "Pachitte Chonmage Tatsujin 12",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.77": {
+    "Name": "Sumomomomomo - Chijou Saikyou no Yome [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.78": {
+    "Name": "Sumomomomomo - Chijou Saikyou no Yome",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.79": {
+    "Name": "King of Fighters, The - Maximum Impact 2 [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.80": {
+    "Name": "Nodame Cantabile",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.81": {
+    "Name": "Fuuun Super Combo",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.82": {
+    "Name": "World Heroes - Gorgeous",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.83": {
+    "Name": "King of Fighters '98, The - Ultimate Match",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.84": {
+    "Name": "Another Century's Episode 3 - The Final",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.86": {
+    "Name": "Hisshou Pachinko-Pachislot Kouryoku Series Vol.10 - CR Shinseiki Evangelion - Kiseki no Hachi Ha",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.87": {
+    "Name": "Sanyo Pachinko Paradise 14",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_257.88": {
+    "Name": "Metal Slug [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.89": {
+    "Name": "King of Fighters XI, The [SNK Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.90": {
+    "Name": "Art of Fighting Collection [NeoGeo Online Collection the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.91": {
+    "Name": "King of Fighters, The - Orochi Collection [NeoGeo Online Collection the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.92": {
+    "Name": "Bakumatsu Roman - Last Blade 2-in-1 [NeoGeo Online Collection the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.93": {
+    "Name": "Garou - Mark of the Wolves [NeoGeo Online Collection the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.94": {
+    "Name": "Cluster Edge [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.95": {
+    "Name": "School Rumble - 2nd Term [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.96": {
+    "Name": "Ore no Shite Agake",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.97": {
+    "Name": "Ikki Tousen - Shining Dragon [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_257.98": {
+    "Name": "Ikki Tousen - Shining Dragon",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_257.99": {
+    "Name": "Ultraman Fighting Evolution 3 [Banpresto Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.00": {
+    "Name": "Ultraman Fighting Evolution - Rebirth [Banpresto Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.01": {
+    "Name": "Kyou Kara Maou! Shin Ma-Kuni no Kyuujitsu [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.02": {
+    "Name": "Kyou Kara Maou! Shin Ma-Kuni no Kyuujitsu",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.03": {
+    "Name": "xxxHolic - Shigatsu Tsuitachi no Izayoi Sowa",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.04": {
+    "Name": "Dear My Sun [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.06": {
+    "Name": "Kateikyoushi Hitman Reborn! Dream Hyper Battle",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.07": {
+    "Name": "Saint Beast - Rasen no Shou [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.08": {
+    "Name": "Saint Beast - Rasen no Shou",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.09": {
+    "Name": "Gintama Gin-San to Issho! Boku no Kabuki Machi Nikki",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.10": {
+    "Name": "Dear My Sun",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.11": {
+    "Name": "Happiness! Deluxe [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.12": {
+    "Name": "Tori no Hoshi - Aerial Planet",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.13": {
+    "Name": "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.11 - Shinseiki Evangelion - Magokoro o, Kimi ni",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.14": {
+    "Name": "Shinseiki GPX Cyber Formula - Road to the Infinity 4",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.15": {
+    "Name": "DragonBall Z Sparking! Meteor",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.16": {
+    "Name": "Yamasa Digi World - Collaboration SP Pachi-Slot Ridge Racer",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.17": {
+    "Name": "Bakumatsu Renka - Karyuu Kenshiden [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.18": {
+    "Name": "Bakumatsu Renka - Karyuu Kenshiden",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.19": {
+    "Name": "Ar Tonelico II Sekai ni Hibiku Shoujo Tachi no Souzoushi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.20": {
+    "Name": "Kateikyoushi Hitman Reborn!! Let's Ansatsu! Nerawareta 10 Daime!",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.21": {
+    "Name": "Suzumiya Haruhi no Tomadoi [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.22": {
+    "Name": "Suzumiya Haruhi no Tomadoi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.23": {
+    "Name": "Spider-Man 3",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.25": {
+    "Name": "Zero no Tsukaima [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.26": {
+    "Name": "My Home o Tsukurou 2! Easy Design [Best Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.27": {
+    "Name": "Soukou Kihei Votoms",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.28": {
+    "Name": "Pachitte Chonmage Tatsujin 13 - Pachinko Hissatsu Shigotojin III",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.29": {
+    "Name": "A.C.E. Another Century's Episode 2 [Special Vocal Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.30": {
+    "Name": "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Gensoukyoku [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.31": {
+    "Name": "Zero no Tsukaima - Muma ga Tsumugu Yokaze no Gensoukyoku",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.32": {
+    "Name": "SD Gundam G Generation Spirits",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.33": {
+    "Name": "Simple 2000 Series Vol.122 - The Ningyo Hime Monogatari - Mermaid Prism",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.34": {
+    "Name": "Transformers - The Game",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.35": {
+    "Name": "Super Robot Taisen OG - Original Generations Gaiden [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.36": {
+    "Name": "Super Robot Taisen OG - Original Generations Gaiden",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.37": {
+    "Name": "Naruto Shippuuden - Narutimate Accel 2",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.38": {
+    "Name": "Taiheiyou no Arashi - Senkan Yamato, Akatsuki ni Shutsugekisu",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.39": {
+    "Name": "Samurai Spirits: Rokuban Shoubu [NeoGeo Online Collection Vol. 12]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.40": {
+    "Name": "Guitar Hero III - Legends of Rock [with Guitar]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.41": {
+    "Name": "Tales of Destiny [Director's Cut] [Premium Box]",
+    "Region": "NTSC-J",
+    "FpuMulHack": 1
+  },
+  "SLPS_258.42": {
+    "Name": "Tales of Destiny [Director's Cut]",
+    "Region": "NTSC-J",
+    "Compat": 4,
+    "FpuMulHack": 1
+  },
+  "SLPS_258.43": {
+    "Name": "Tir-Na-Nog",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.44": {
+    "Name": "Last Escort 2 - Shiya no Amai Ira [Gorgeous Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.45": {
+    "Name": "Last Escort 2 - Shiya no Amai Ira",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.47": {
+    "Name": "Amekoushi no Kan [The Best Price]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.48": {
+    "Name": "Naraku no Shiro",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.49": {
+    "Name": "Sunsoft Collection",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLPS_258.50": {
+    "Name": "KimiKiss [ebKore+]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.51": {
+    "Name": "Zettai Zetsumei Toshi 2 - Itetsuita Kioku Tachi [Irem Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.52": {
+    "Name": "Sanyo Pachinko Paradise 13 [Irem Collection]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.53": {
+    "Name": "Pachinko Kamen Rider - Shocker Zenmetsu Daisakusen",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.54": {
+    "Name": "Poison Pink",
+    "Region": "NTSC-J",
+    "eeClampMode": "0"
+  },
+  "SLPS_258.55": {
+    "Name": "Battle of Sunrise",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.56": {
+    "Name": "Tomb Raider - Anniversary",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.58": {
+    "Name": "Dengeki SP - Shakugan no Shana",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.59": {
+    "Name": "Orange Honey - Boku wa Kimi ni Koishiteru [Best Version]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.60": {
+    "Name": "Code Geass - Hangyaku no Lelouch - Lost Colors",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.61": {
+    "Name": "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.10 [Special Price Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.62": {
+    "Name": "Hisshou Pachinko - Pachi-Slot Kouryoku Series Vol.05 - CR Neon Genesis Evangelion Sekandoinpakuto & Pachislot Neon Genesis Evangelion [Special Price Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.63": {
+    "Name": "Fatal Fury - Battle Archives 1 [SNK the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.64": {
+    "Name": "Fatal Fury - Battle Archives 2 [SNK the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.65": {
+    "Name": "King of Fighters, The - Nests [SNK the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.66": {
+    "Name": "Fuuun Super Combo [SNK the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.67": {
+    "Name": "Hanayoi Romanesque - Ai to Kanashimi [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.68": {
+    "Name": "Hanayoi Romanesque - Ai to Kanashimi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.69": {
+    "Name": "CR Shinseiki Evangelion - Shito, Futatabi",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.87": {
+    "Name": "Super Robot Taisen Z",
+    "Region": "NTSC-J"
+  },
+  "SLPS_258.92": {
+    "Name": "Nogizaka Haruka no Himitsu - Cosplay Hajimemashita",
+    "Region": "NTSC-J"
+  },
+  "SLPS_259.05": {
+    "Name": "Dragon Ball Z: Infinite World",
+    "Region": "NTSC-J"
+  },
+  "SLPS_259.06": {
+    "Name": "ADK Tamashii",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_259.14": {
+    "Name": "Kidou Senshi Gundam: Giren no Yabou - Axis no Kyoui V",
+    "Region": "NTSC-J",
+    "FpuNegDivHack": 1
+  },
+  "SLPS_259.27": {
+    "Name": "Tomb Raider Underworld",
+    "Region": "NTSC-J"
+  },
+  "SLPS_259.30": {
+    "Name": "Major League Baseball 2K9",
+    "Region": "NTSC-J"
+  },
+  "SLPS_259.34": {
+    "Name": "Samurai Spirits: Rokuban Shoubu [NeoGeo Online Collection the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_259.35": {
+    "Name": "The King of Fighters '98 Ultimate Match (NeoGeo Online Collection the Best)",
+    "Region": "NTSC-J"
+  },
+  "SLPS_259.44": {
+    "Name": "Kamen Rider Climax Heroes",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_259.59": {
+    "Name": "Kidou Senshi Gundam: Giren no Yabou - Axis no Kyoui V",
+    "Region": "NTSC-J",
+    "FpuNegDivHack": 1
+  },
+  "SLPS_290.01": {
+    "Name": "Xenosaga Episode 1 - Der Wille zur Macht [Premium Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_290.02": {
+    "Name": "Xenosaga Episode 1 - Der Wille zur Macht",
+    "Region": "NTSC-J",
+    "Compat": 5
+  },
+  "SLPS_290.03": {
+    "Name": "Lord of the Rings - The Two Towers [Collector's Box]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_290.04": {
+    "Name": "Lord of the Rings, The - The Two Towers",
+    "Region": "NTSC-J",
+    "Compat": 2
+  },
+  "SLPS_290.05": {
+    "Name": "Xenosaga Episode 1 - Der Wille zur Macht [Reloaded]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_725.01": {
+    "Name": "Final Fantasy X [Mega Hits]",
+    "Region": "NTSC-J",
+    "IPUWaitHack": 1
+  },
+  "SLPS_725.02": {
+    "Name": "Tales of Destiny 2 [Mega Hits]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_730.03": {
+    "Name": "Farms Story 3 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_730.05": {
+    "Name": "Guilty Gear X - Plus [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_730.06": {
+    "Name": "Time Crisis II [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_731.01": {
+    "Name": "Kotoba no Puzzle - Mojipittan [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_731.02": {
+    "Name": "Bokujou Monogatari 3 - Heart ni Hi o Tsukete [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_731.03": {
+    "Name": "Makai Senki Disgaea [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_731.04": {
+    "Name": "Tekken Tag Tournament [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_731.05": {
+    "Name": "Kinnikuman Generations [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_731.06": {
+    "Name": "Pilot Nina Rou! 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_731.07": {
+    "Name": "Taiko no Tatsujin 5 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_731.08": {
+    "Name": "Phantom Brave [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_731.09": {
+    "Name": "Bokujou Monogatari 3 - Heart ni Hi o Tsukete [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_731.10": {
+    "Name": "Taiko no Tatsujin - Appare Sandaime [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_731.11": {
+    "Name": "Taiko no Tatsujin Super Animehit [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.01": {
+    "Name": "Fatal Frame 2 - Crimson Butterfly [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.02": {
+    "Name": "Armored Core - Nexus [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.04": {
+    "Name": "Zettai Zetsumi Toshi [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.05": {
+    "Name": "Ace Combat 4 - Shattered Skies [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.06": {
+    "Name": "Super Robot Taisen Alpha 2nd [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.07": {
+    "Name": "DragonBall Z [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.08": {
+    "Name": "DragonBall Z 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.09": {
+    "Name": "Tekken 4 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.10": {
+    "Name": "Katamari Damacy [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "mvuFlagSpeedHack": "0"
+  },
+  "SLPS_732.11": {
+    "Name": "Summon Night 3 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.12": {
+    "Name": "Naruto Narutimett Hero [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.14": {
+    "Name": "Shadow Hearts 2 [Director's Cut] [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.16": {
+    "Name": "Magna Carta [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.17": {
+    "Name": "Tales of Symphonia [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.18": {
+    "Name": "Ace Combat 5 - The Unsung War [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.19": {
+    "Name": "Tales of Destiny 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.20": {
+    "Name": "Ultraman [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.21": {
+    "Name": "Naruto Narutimett Hero 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.22": {
+    "Name": "Harvest Moon - A Wonderful Life [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.23": {
+    "Name": "Tekken 5 [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "eeClampMode": 1
+  },
+  "SLPS_732.24": {
+    "Name": "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc1of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.25": {
+    "Name": "Xenosaga Episode II - Jenseits von Gut und Bose [PlayStation 2 The Best] [Disc2of2]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.26": {
+    "Name": "Tenchu Kurenai [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.27": {
+    "Name": "Another Century's Episode [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.28": {
+    "Name": "Fuun Bakumatsuden [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.29": {
+    "Name": "TearRing Saga Series - Berwick Saga [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.30": {
+    "Name": "dot Hack - Vol.1 & Vol.2 [PlayStation 2 The Best] [Vol.1 Disc]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.31": {
+    "Name": "dot Hack - Vol.1 & Vol.2 [PlayStation 2 The Best] [Vol.2 Disc]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.32": {
+    "Name": "dot Hack - Vol.3 & Vol.4 [PlayStation 2 The Best] [Vol.3 Disc]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.33": {
+    "Name": "dot Hack - Vol.3 & Vol.4 [PlayStation 2 The Best] [Vol.4 Disc]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.34": {
+    "Name": "Kidou Senshi Z-Gundam - AEUG vs. Titans [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.35": {
+    "Name": "DragonBall Z 3 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.36": {
+    "Name": "Venus & Braves [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.37": {
+    "Name": "Tenchu San [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.38": {
+    "Name": "Super Robot Wars - Alpha 3 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.39": {
+    "Name": "Yu Yu Hakusho Forever [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.40": {
+    "Name": "Katamari Damacy [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "mvuFlagSpeedHack": "0"
+  },
+  "SLPS_732.41": {
+    "Name": "Minna Daisuki Katamari Damacy [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "vuClampMode": 3,
+    "mvuFlagSpeedHack": "0"
+  },
+  "SLPS_732.42": {
+    "Name": "Tales of Legendia [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.43": {
+    "Name": "Namco X Capcom [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.44": {
+    "Name": "R-Type Final [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "Compat": 5,
+    "EETimingHack": "1 "
+  },
+  "SLPS_732.45": {
+    "Name": "Fatal Frame - Zero [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.46": {
+    "Name": "Gundam True Odyssey [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.47": {
+    "Name": "Armored Core - Last Raven [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.48": {
+    "Name": "Kagero 2 - Dark Illusion [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.49": {
+    "Name": "Ar-Tonelico - Sekai no Owari de Shi Tsudzukeru Shoujo [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.50": {
+    "Name": "Ace Combat Zero - The Belkan War [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.51": {
+    "Name": "Naruto - Narutimett Hero 3 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.52": {
+    "Name": "Tales of the Abyss [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.53": {
+    "Name": "Rurouni Kenshin - Enjou! Kyoto Rinne [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.54": {
+    "Name": "Disgaea - Hour of Darkness 2 [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.55": {
+    "Name": "Fatal Frame [PlayStation 2 the Best - Reprint]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.56": {
+    "Name": "Fatal Frame 2 - Crimson Butterfly [PlayStation 2 the Best - Reprint]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.57": {
+    "Name": "Fatal Frame III - The Tormented [PlayStation 2 the Best - Reprint]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.58": {
+    "Name": "Kenka Banchou 2 - Full Throttle [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_732.63": {
+    "Name": "Ar tonelico II: Sekai ni Hibiku Shoujo Tachi no Metafalica [PlayStation 2 the Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.01": {
+    "Name": "Victorious Boxers - Championship Edition [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.02": {
+    "Name": "Shutoko Battle Zero [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.03": {
+    "Name": "Armored Core 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.04": {
+    "Name": "Klonoa 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "eeClampMode": 3
+  },
+  "SLPS_734.05": {
+    "Name": "Zero [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.06": {
+    "Name": "Dead or Alive 2 - Hardcore [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.07": {
+    "Name": "Sidewinder MAX [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.10": {
+    "Name": "Ace Combat 4 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.11": {
+    "Name": "Armored Core 2 - Another Age [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.12": {
+    "Name": "Vampire Night [PlayStation 2 The Best]",
+    "Region": "NTSC-J",
+    "EETimingHack": 1
+  },
+  "SLPS_734.15": {
+    "Name": "Gallop Racer 6 - Revolution [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.16": {
+    "Name": "Super Robot Wars - Impact [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.17": {
+    "Name": "Armored Core 3 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.18": {
+    "Name": "Shadow Hearts [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.19": {
+    "Name": "Lupin III - Majutsu-Ou no Isan [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.20": {
+    "Name": "Armored Core 3 - Silent Line [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.21": {
+    "Name": "Tenchu 3 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.22": {
+    "Name": "Ultraman Fighting Evolution 2 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.23": {
+    "Name": "Monster Farm 4 [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_734.24": {
+    "Name": "Guilty Gear XX [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "SLPS_739.01": {
+    "Name": "Xenosaga Episode 1 - Der Wille zur Macht [PlayStation 2 The Best]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_100.58": {
+    "Name": "Densha de Go! Shinkansen [with Controller]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_100.68": {
+    "Name": "Densha de Go! Ryojo-hen [with Controller]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_100.74": {
+    "Name": "Space Invaders 25th Anniversary Bundle",
+    "Region": "NTSC-J"
+  },
+  "TCPS_100.84": {
+    "Name": "Zero Shinkikan Josentoki",
+    "Region": "NTSC-J"
+  },
+  "TCPS_100.85": {
+    "Name": "Densha de Go! Final [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_100.94": {
+    "Name": "Ys III - Wanderer from Ys",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.06": {
+    "Name": "Ys IV - Mask of the Sun - A New Theory",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.07": {
+    "Name": "Giga Wing Generations",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.09": {
+    "Name": "Ys III - Wanderer from Ys [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.11": {
+    "Name": "Eremental Gerad",
+    "Region": "NTSC-J",
+    "XgKickHack": "1  "
+  },
+  "TCPS_101.13": {
+    "Name": "Mushihime-sama",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.14": {
+    "Name": "Matantei Loki Ragnarok Mayoukaku",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.17": {
+    "Name": "Mushihime-sama [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.23": {
+    "Name": "Langrisser III",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.25": {
+    "Name": "Raiden III",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.28": {
+    "Name": "Ultimate Pro Pinball",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.30": {
+    "Name": "Homura",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.31": {
+    "Name": "Ibara",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.32": {
+    "Name": "Psychic Force Complete",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.33": {
+    "Name": "Psychic Force Complete [with Wong Figure]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.34": {
+    "Name": "Psychic Force Complete [with Emilio Figure]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.35": {
+    "Name": "Psychic Force Complete [with Wendy Figure]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.36": {
+    "Name": "Psychic Force Complete [with 3 Figures]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.47": {
+    "Name": "Zero Shikikan Josentoki Ni",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.48": {
+    "Name": "Zero Shikikan Josentoki Ni [Limited Edition]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.52": {
+    "Name": "Rozen Maiden - Duel Valzer",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.54": {
+    "Name": "Ys V - Lost Kefin - Kingdom of Sand",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.59": {
+    "Name": "Suzuki TT Super Bikes - Real Road Racing",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.66": {
+    "Name": "Wizardry Gaiden",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.68": {
+    "Name": "Mushihime-sama [Taito The Best]",
+    "Region": "NTSC-J"
+  },
+  "TCPS_101.72": {
+    "Name": "Homura [Taito the Best]",
+    "Region": "NTSC-J"
+  },
+  "PBPS_952.05": {
+    "Name": "Demo Disc",
+    "Region": "PAL-Unk"
+  },
+  "SCED_500.41": {
+    "Name": "Tekken Tag Tournament [Demo]",
+    "Region": "PAL-Unk"
+  },
+  "SCED_501.63": {
+    "Name": "PlayStation 2 Greatest Hits Vol.3 [Demo]",
+    "Region": "PAL-Unk"
+  },
+  "SCED_502.54": {
+    "Name": "Official Review of the 2000 FIA Formula 1 World Championship [Formula One 2001 Bonus Disc]",
+    "Region": "PAL-E"
+  },
+  "SCED_502.86": {
+    "Name": "Red Faction [Demo]",
+    "Region": "PAL-Unk"
+  },
+  "SCED_506.14": {
+    "Name": "Jak and Daxter - The Precursor Legacy [Demo]",
+    "Region": "PAL-Unk"
+  },
+  "SCED_506.42": {
+    "Name": "Final Fantasy X [Demo] [Final Fantasy VI PS1 - Bonus Disc]",
+    "Region": "PAL-E",
+    "IPUWaitHack": 1
+  },
+  "SCED_507.48": {
+    "Name": "Official PlayStation 2 Magazine Demo 26",
+    "Region": "PAL-Unk"
+  },
+  "SCED_509.07": {
+    "Name": "Final Fantasy X [Bonus Disc - Beyond Final Fantasy]",
+    "Region": "PAL-Unk",
+    "IPUWaitHack": 1
+  },
+  "SCED_515.31": {
+    "Name": "Official PlayStation 2 Magazine Demo 33",
+    "Region": "PAL-Unk"
+  },
+  "SCED_515.37": {
+    "Name": "Official PlayStation 2 Magazine Demo 37",
+    "Region": "PAL-Unk"
+  },
+  "SCED_528.18": {
+    "Name": "EyeToy - Chat [Light]",
+    "Region": "PAL-M11"
+  },
+  "SCED_529.70": {
+    "Name": "SCEE Hits Demo",
+    "Region": "PAL-Unk"
+  },
+  "SCED_531.63": {
+    "Name": "Official PlayStation 2 Magazine Demo 60",
+    "Region": "PAL-M12"
+  },
+  "SCES_500.00": {
+    "Name": "Ridge Racer V",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SCES_500.01": {
+    "Name": "Tekken Tag Tournament",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SCES_500.02": {
+    "Name": "FantaVision",
+    "Region": "PAL-M5"
+  },
+  "SCES_500.03": {
+    "Name": "Dead or Alive 2 - Hardcore",
+    "Region": "PAL-M5",
+    "Compat": 1
+  },
+  "SCES_500.04": {
+    "Name": "Formula One 2001",
+    "Region": "PAL-M6",
+    "Compat": 4
+  },
+  "SCES_500.05": {
+    "Name": "Wipeout Fusion",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SCES_500.06": {
+    "Name": "Drakan - The Ancients' Gates",
+    "Region": "PAL-M5",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SCES_500.09": {
+    "Name": "Wild Wild Racing",
+    "Region": "PAL-Unk"
+  },
+  "SCES_500.34": {
+    "Name": "MotoGP",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SCES_501.05": {
+    "Name": "Sky Odyssey",
+    "Region": "PAL-Unk"
+  },
+  "SCES_501.39": {
+    "Name": "World Rally Championship",
+    "Region": "PAL-M7",
+    "Compat": 5
+  },
+  "SCES_502.40": {
+    "Name": "Extermination",
+    "Region": "PAL-Unk"
+  },
+  "SCES_502.41": {
+    "Name": "Bouncer, The",
+    "Region": "PAL-M6",
+    "Compat": 5
+  },
+  "SCES_502.44": {
+    "Name": "This is Football 2002",
+    "Region": "PAL-E"
+  },
+  "SCES_502.46": {
+    "Name": "AirBlade",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_502.93": {
+    "Name": "ATV Off-Road",
+    "Region": "PAL-Unk"
+  },
+  "SCES_502.94": {
+    "Name": "Gran Turismo 3 A-Spec",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SCES_502.95": {
+    "Name": "Dark Cloud",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_503.00": {
+    "Name": "Time Crisis 2",
+    "Region": "PAL-Unk"
+  },
+  "SCES_503.54": {
+    "Name": "Klonoa 2 - Lunatea's Veil",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SCES_503.60": {
+    "Name": "Twisted Metal - Black",
+    "Region": "PAL-Unk"
+  },
+  "SCES_503.61": {
+    "Name": "Jak and Daxter - The Precursor Legacy",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_504.08": {
+    "Name": "PaRappa the Rapper 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_504.09": {
+    "Name": "MotoGP 2",
+    "Region": "PAL-Unk"
+  },
+  "SCES_504.10": {
+    "Name": "Ace Combat - Distant Thunder",
+    "Region": "PAL-Unk"
+  },
+  "SCES_504.11": {
+    "Name": "Vampire Night",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SCES_504.59": {
+    "Name": "Dropship - United Peace Force",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SCES_504.90": {
+    "Name": "Final Fantasy X",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "IPUWaitHack": 1
+  },
+  "SCES_504.91": {
+    "Name": "Final Fantasy X",
+    "Region": "PAL-F",
+    "IPUWaitHack": 1
+  },
+  "SCES_504.92": {
+    "Name": "Final Fantasy X",
+    "Region": "PAL-G",
+    "Compat": 5,
+    "IPUWaitHack": 1
+  },
+  "SCES_504.93": {
+    "Name": "Final Fantasy X",
+    "Region": "PAL-I",
+    "IPUWaitHack": 1
+  },
+  "SCES_504.94": {
+    "Name": "Final Fantasy X",
+    "Region": "PAL-S",
+    "IPUWaitHack": 1
+  },
+  "SCES_504.99": {
+    "Name": "Ecco the Dolphin - Defender of the Future",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SCES_505.00": {
+    "Name": "Headhunter",
+    "Region": "PAL-Unk"
+  },
+  "SCES_505.01": {
+    "Name": "Rez",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SCES_505.22": {
+    "Name": "Disney's Peter Pan - Adventures in Neverland",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SCES_505.26": {
+    "Name": "Peter Pan",
+    "Region": "PAL-Unk"
+  },
+  "SCES_505.31": {
+    "Name": "Peter Pan - Legenden om Onskeoen",
+    "Region": "PAL-Unk"
+  },
+  "SCES_505.95": {
+    "Name": "Disney-Pixar's Monsters Inc.",
+    "Region": "PAL-Unk"
+  },
+  "SCES_505.96": {
+    "Name": "Monsters Inc.",
+    "Region": "PAL-Unk"
+  },
+  "SCES_505.97": {
+    "Name": "Monsters Inc.",
+    "Region": "PAL-Unk"
+  },
+  "SCES_505.98": {
+    "Name": "Monsterit Oy",
+    "Region": "PAL-Unk"
+  },
+  "SCES_505.99": {
+    "Name": "Monsters Inc.",
+    "Region": "PAL-Unk"
+  },
+  "SCES_506.00": {
+    "Name": "Disney's Monster Inc. - Scare Island",
+    "Region": "PAL-Unk"
+  },
+  "SCES_506.01": {
+    "Name": "Monsters Inc.",
+    "Region": "PAL-Unk"
+  },
+  "SCES_506.02": {
+    "Name": "Monsters Inc.",
+    "Region": "PAL-Unk"
+  },
+  "SCES_506.03": {
+    "Name": "Monstruos S.A - La Isla de los Sustos",
+    "Region": "PAL-Unk"
+  },
+  "SCES_506.04": {
+    "Name": "Monsters Inc.",
+    "Region": "PAL-Unk"
+  },
+  "SCES_506.05": {
+    "Name": "Monsters Inc.",
+    "Region": "PAL-Unk"
+  },
+  "SCES_506.11": {
+    "Name": "Space Channel 5",
+    "Region": "PAL-E"
+  },
+  "SCES_506.12": {
+    "Name": "Space Channel 5 - Part 2",
+    "Region": "PAL-Unk"
+  },
+  "SCES_506.14": {
+    "Name": "Jak & Daxter - The Precursor Legacy",
+    "Region": "PAL-Unk"
+  },
+  "SCES_507.59": {
+    "Name": "Virtua Fighter 4",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_507.60": {
+    "Name": "Ico",
+    "Region": "PAL-M5",
+    "Compat": 5,
+    "eeClampMode": 2,
+    "vuClampMode": 1
+  },
+  "SCES_507.81": {
+    "Name": "Destruction Derby Arena [Beta, Promo, & Full Retail]",
+    "Region": "PAL-E",
+    "Compat": 4
+  },
+  "SCES_507.91": {
+    "Name": "Frequency",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_508.10": {
+    "Name": "Smash Court Tennis - Pro Tournament",
+    "Region": "PAL-Unk"
+  },
+  "SCES_508.50": {
+    "Name": "Gran Turismo - Concept 2002 Tokyo-Geneva",
+    "Region": "PAL-Unk"
+  },
+  "SCES_508.58": {
+    "Name": "Gran Turismo - Concept 2002 Tokyo-Geneva",
+    "Region": "PAL-M6",
+    "Compat": 5
+  },
+  "SCES_508.78": {
+    "Name": "Tekken 4",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_508.85": {
+    "Name": "Ape Escape 2",
+    "Region": "PAL-Unk"
+  },
+  "SCES_508.87": {
+    "Name": "Alpine Racer 3",
+    "Region": "PAL-Unk",
+    "Compat": 3
+  },
+  "SCES_508.88": {
+    "Name": "Pac-Man World 2",
+    "Region": "PAL-Unk"
+  },
+  "SCES_508.89": {
+    "Name": "Ninja Assault",
+    "Region": "PAL-Unk"
+  },
+  "SCES_509.16": {
+    "Name": "Ratchet & Clank",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SCES_509.17": {
+    "Name": "Sly Racoon",
+    "Region": "PAL-Unk"
+  },
+  "SCES_509.28": {
+    "Name": "SOCOM - U.S. Navy SEALs [Beta & Full Release]",
+    "Region": "PAL-M6"
+  },
+  "SCES_509.34": {
+    "Name": "World Rally Championship II Extreme",
+    "Region": "PAL-Unk"
+  },
+  "SCES_509.35": {
+    "Name": "World Rally Championship II Extreme",
+    "Region": "PAL-Unk"
+  },
+  "SCES_509.56": {
+    "Name": "Ferrari F355 Challenge",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_509.60": {
+    "Name": "Disney's Stitch: Experiment 626",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SCES_509.66": {
+    "Name": "Disney's Stitch - Experiment 626",
+    "Region": "PAL-Unk"
+  },
+  "SCES_509.67": {
+    "Name": "Kingdom Hearts",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_509.68": {
+    "Name": "Kingdom Hearts",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_509.69": {
+    "Name": "Kingdom Hearts",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SCES_509.70": {
+    "Name": "Kingdom Hearts",
+    "Region": "PAL-I"
+  },
+  "SCES_509.71": {
+    "Name": "Kingdom Hearts",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_509.82": {
+    "Name": "Moto GP 3",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_509.87": {
+    "Name": "Resident Evil - Outbreak",
+    "Region": "PAL-Unk"
+  },
+  "SCES_510.04": {
+    "Name": "Formula One 2002",
+    "Region": "PAL-Unk"
+  },
+  "SCES_510.39": {
+    "Name": "This is Football 2003",
+    "Region": "PAL-E"
+  },
+  "SCES_510.40": {
+    "Name": "Le Monde des Bleus 2003",
+    "Region": "PAL-Unk"
+  },
+  "SCES_510.41": {
+    "Name": "This is Football 2003",
+    "Region": "PAL-Unk"
+  },
+  "SCES_511.02": {
+    "Name": "Ape Escape 2",
+    "Region": "PAL-Unk"
+  },
+  "SCES_511.03": {
+    "Name": "Ape Escape 2",
+    "Region": "PAL-Unk"
+  },
+  "SCES_511.04": {
+    "Name": "Ape Escape 2",
+    "Region": "PAL-Unk"
+  },
+  "SCES_511.05": {
+    "Name": "Ape Escape 2",
+    "Region": "PAL-Unk"
+  },
+  "SCUS_972.25": {
+    "Name": "Primal [Demo]",
+    "Region": "NTSC-U"
+  },
+  "SCUS_971.42": {
+    "Name": "Primal - Civilization Is Only Skin Deep",
+    "Region": "NTSC-U",
+    "Compat": 5
+  },
+  "SCES_511.35": {
+    "Name": "Primal",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SCES_516.85": {
+    "Name": "Primal",
+    "Region": "PAL-R"
+  },
+  "SCES_511.59": {
+    "Name": "Getaway, The",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SCES_511.64": {
+    "Name": "Mark of Kri, The",
+    "Region": "PAL-Unk"
+  },
+  "SCES_511.76": {
+    "Name": "Disney's Treasure Planet",
+    "Region": "PAL-Unk"
+  },
+  "SCES_511.79": {
+    "Name": "This is Football 2003",
+    "Region": "PAL-Unk"
+  },
+  "SCES_511.90": {
+    "Name": "Dark Chronicle",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SCES_512.24": {
+    "Name": "War of the Monsters",
+    "Region": "PAL-Unk"
+  },
+  "SCES_512.48": {
+    "Name": "Dog's Life",
+    "Region": "PAL-Unk"
+  },
+  "SCES_514.26": {
+    "Name": "Getaway, The",
+    "Region": "PAL-Unk"
+  },
+  "SCES_514.28": {
+    "Name": "Shinobi",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SCES_514.63": {
+    "Name": "Ghosthunter",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_514.80": {
+    "Name": "Twisted Metal - Black - Online",
+    "Region": "PAL-M5"
+  },
+  "SCES_515.13": {
+    "Name": "EyeToy - Play",
+    "Region": "PAL-Unk"
+  },
+  "SCES_515.33": {
+    "Name": "God of War",
+    "Region": "PAL-Unk"
+  },
+  "SCES_515.78": {
+    "Name": "Network Access Disc [Original, v4.02 & v4.03]",
+    "Region": "PAL-M7"
+  },
+  "SCES_515.92": {
+    "Name": "Formula One 2003",
+    "Region": "PAL-M6",
+    "Compat": 5,
+    "XgKickHack": 1
+  },
+  "SCES_515.93": {
+    "Name": "Hardware Online Arena [Beta, Promo & Full Release]",
+    "Region": "PAL-M4"
+  },
+  "SCES_516.07": {
+    "Name": "Ratchet & Clank 2 - Locked & Loaded",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_516.08": {
+    "Name": "Jak & Daxter 2 - Renegade",
+    "Region": "PAL-Unk"
+  },
+  "SCES_516.10": {
+    "Name": "This is Football 2004 (Red Devils 2004)",
+    "Region": "PAL-Unk"
+  },
+  "SCES_516.11": {
+    "Name": "This is Football 2004",
+    "Region": "PAL-Unk"
+  },
+  "SCES_516.12": {
+    "Name": "This is Football 5",
+    "Region": "PAL-Unk"
+  },
+  "SCES_516.13": {
+    "Name": "This is Football 2004",
+    "Region": "PAL-Unk"
+  },
+  "SCES_516.14": {
+    "Name": "Monde des Bleus 2004, Le - Nouvelle Generation",
+    "Region": "PAL-Unk"
+  },
+  "SCES_516.18": {
+    "Name": "SOCOM",
+    "Region": "PAL-Unk"
+  },
+  "SCES_516.35": {
+    "Name": "Brave - The Search for Spirit Dancer",
+    "Region": "PAL-Unk"
+  },
+  "SCES_516.48": {
+    "Name": "Everquest - Online Adventures",
+    "Region": "PAL-E-I"
+  },
+  "SCES_516.77": {
+    "Name": "My Street",
+    "Region": "PAL-Unk"
+  },
+  "SCES_516.84": {
+    "Name": "World Rally Championship 3",
+    "Region": "PAL-Unk"
+  },
+  "SCES_517.06": {
+    "Name": "Amplitude",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_517.19": {
+    "Name": "Gran Turismo 4",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SCES_517.25": {
+    "Name": "Everquest Online Adventures",
+    "Region": "PAL-E",
+    "Compat": 3
+  },
+  "SCES_518.44": {
+    "Name": "Time Crisis 3",
+    "Region": "PAL-Unk"
+  },
+  "SCES_518.95": {
+    "Name": "EyeToy - Groove",
+    "Region": "PAL-Unk"
+  },
+  "SCES_519.04": {
+    "Name": "SOCOM II - U.S. Navy SEALs",
+    "Region": "PAL-M5",
+    "Compat": 5,
+    "EETimingHack": 1,
+    "VIF1StallHack": 1
+  },
+  "SCES_519.10": {
+    "Name": "Arc the Lad - Twilight of the Spirits",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SCES_519.20": {
+    "Name": "Forbidden Siren",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_519.71": {
+    "Name": "Rise to Honor",
+    "Region": "PAL-Unk"
+  },
+  "SCES_519.77": {
+    "Name": "Hardware Online Arena",
+    "Region": "PAL-Unk"
+  },
+  "SCES_519.79": {
+    "Name": "Destruction Derby Arenas",
+    "Region": "PAL-M6"
+  },
+  "SCES_520.04": {
+    "Name": "Killzone",
+    "Region": "PAL-M6"
+  },
+  "SCES_520.33": {
+    "Name": "Syphon Filter - The Omega Strain",
+    "Region": "PAL-M5",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SCES_520.42": {
+    "Name": "Formula One 2004",
+    "Region": "PAL-Unk"
+  },
+  "SCES_520.65": {
+    "Name": "Flipnic",
+    "Region": "PAL-Unk"
+  },
+  "SCES_520.99": {
+    "Name": "I-Ninja",
+    "Region": "PAL-Unk"
+  },
+  "SCES_521.24": {
+    "Name": "kill.switch",
+    "Region": "PAL-M5"
+  },
+  "SCES_521.54": {
+    "Name": "EyeToy - Chat",
+    "Region": "PAL-M11"
+  },
+  "SCES_521.56": {
+    "Name": "Ghosthunter - Hunter on the spectres",
+    "Region": "PAL-Unk"
+  },
+  "SCES_522.68": {
+    "Name": "Sing-Star",
+    "Region": "PAL-Unk"
+  },
+  "SCES_522.99": {
+    "Name": "SingStar",
+    "Region": "PAL-Unk"
+  },
+  "SCES_523.06": {
+    "Name": "SOCOM II - U.S. Navy SEALs",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "EETimingHack": 1,
+    "VIF1StallHack": 1
+  },
+  "SCES_523.27": {
+    "Name": "Forbidden Siren",
+    "Region": "PAL-Unk"
+  },
+  "SCES_523.28": {
+    "Name": "Forbidden Siren",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SCES_523.29": {
+    "Name": "Forbidden Siren",
+    "Region": "PAL-Unk"
+  },
+  "SCES_523.30": {
+    "Name": "Forbidden Siren - Viviendo la Pesadilla",
+    "Region": "PAL-S"
+  },
+  "SCES_523.89": {
+    "Name": "World Rally Championship 4",
+    "Region": "PAL-Unk",
+    "Compat": 1
+  },
+  "SCES_524.05": {
+    "Name": "DJ - Decks & FX - House Edition",
+    "Region": "PAL-M9",
+    "Compat": 5
+  },
+  "SCES_524.10": {
+    "Name": "Athens 2004 - Olympic Summer Games",
+    "Region": "PAL-Unk"
+  },
+  "SCES_524.11": {
+    "Name": "Athens '04",
+    "Region": "PAL-Unk"
+  },
+  "SCES_524.12": {
+    "Name": "Jackie Chan Adventures",
+    "Region": "PAL-Unk"
+  },
+  "SCES_524.23": {
+    "Name": "Smash Court Tennis - Pro Tournament 2",
+    "Region": "PAL-M5"
+  },
+  "SCES_524.24": {
+    "Name": "Ace Combat - Squadron Leader",
+    "Region": "PAL-E"
+  },
+  "SCES_524.25": {
+    "Name": "This is Football 5",
+    "Region": "PAL-Unk"
+  },
+  "SCES_524.26": {
+    "Name": "This is Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SCES_524.27": {
+    "Name": "This is Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SCES_524.29": {
+    "Name": "This is Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SCES_524.30": {
+    "Name": "Le Monde des Bleus 2005",
+    "Region": "PAL-Unk"
+  },
+  "SCES_524.31": {
+    "Name": "This is Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SCES_524.32": {
+    "Name": "This is Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SCED_524.36": {
+    "Name": "Playstation2 UK Demo 7-2004",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_524.38": {
+    "Name": "Gran Turismo 4 - Prologue",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SCES_524.56": {
+    "Name": "Ratchet & Clank 3",
+    "Region": "PAL-Unk"
+  },
+  "SCES_524.60": {
+    "Name": "Jak 3",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SCES_525.29": {
+    "Name": "Sly Racoon 2 - Band of Thieves",
+    "Region": "PAL-M11",
+    "Compat": 5
+  },
+  "SCES_525.30": {
+    "Name": "Crisis Zone",
+    "Region": "PAL-Unk"
+  },
+  "SCES_525.64": {
+    "Name": "Sing-Star",
+    "Region": "PAL-Unk"
+  },
+  "SCES_525.65": {
+    "Name": "Sing-Star",
+    "Region": "PAL-Unk"
+  },
+  "SCES_525.66": {
+    "Name": "SingStar",
+    "Region": "PAL-Unk"
+  },
+  "SCES_525.82": {
+    "Name": "Everybody's Golf",
+    "Region": "PAL-Unk"
+  },
+  "SCES_525.86": {
+    "Name": "Death by Degrees",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SCES_525.96": {
+    "Name": "This is Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SCES_526.77": {
+    "Name": "Network Access Disc & Hardware - Online Arena",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_527.48": {
+    "Name": "EyeToy - Play 2",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SCES_527.56": {
+    "Name": "DJ - Decks & FX - Claudio Coccoluto Edition",
+    "Region": "PAL-I"
+  },
+  "SCES_527.58": {
+    "Name": "Getaway, The - Black Monday",
+    "Region": "PAL-Unk"
+  },
+  "SCES_527.62": {
+    "Name": "DJ Decks & FX",
+    "Region": "PAL-Unk"
+  },
+  "SCES_527.63": {
+    "Name": "DJ Decks & FX Vol.1",
+    "Region": "PAL-Unk"
+  },
+  "SCES_528.26": {
+    "Name": "Sing-Star Party",
+    "Region": "PAL-Unk"
+  },
+  "SCES_528.27": {
+    "Name": "SingStar Party",
+    "Region": "PAL-Unk"
+  },
+  "SCES_528.28": {
+    "Name": "Sing-Star NRJ Music Tour",
+    "Region": "PAL-F"
+  },
+  "SCES_528.29": {
+    "Name": "Sing-Star Party",
+    "Region": "PAL-Unk"
+  },
+  "SCES_528.30": {
+    "Name": "SingStar Party",
+    "Region": "PAL-Unk"
+  },
+  "SCES_528.83": {
+    "Name": "EyeToy - Kinetic",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SCES_528.92": {
+    "Name": "Moto GP 4",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_528.93": {
+    "Name": "Killzone",
+    "Region": "PAL-E-Gr-R"
+  },
+  "SCES_529.30": {
+    "Name": "EyeToy - Monkey Mania",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SCES_529.48": {
+    "Name": "Getaway, The - Black Monday",
+    "Region": "PAL-Unk"
+  },
+  "SCES_530.33": {
+    "Name": "Formula One 2005",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SCES_530.53": {
+    "Name": "Death by Degrees",
+    "Region": "PAL-Unk"
+  },
+  "SCES_530.54": {
+    "Name": "Death by Degrees",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_530.55": {
+    "Name": "Eyetoy - Antigrav",
+    "Region": "PAL-M5"
+  },
+  "SCES_531.33": {
+    "Name": "God of War",
+    "Region": "PAL-E",
+    "Compat": 4
+  },
+  "SCES_531.78": {
+    "Name": "SingStar Pop",
+    "Region": "PAL-Unk"
+  },
+  "SCES_531.79": {
+    "Name": "SingStar Pop",
+    "Region": "PAL-Unk"
+  },
+  "SCES_531.80": {
+    "Name": "Sing-Star - The Dome",
+    "Region": "PAL-Unk"
+  },
+  "SCES_531.81": {
+    "Name": "SingStar",
+    "Region": "PAL-Unk"
+  },
+  "SCES_531.82": {
+    "Name": "Sing-Star Pop",
+    "Region": "PAL-S"
+  },
+  "SCES_531.83": {
+    "Name": "SingStar Pop",
+    "Region": "PAL-Unk"
+  },
+  "SCES_531.84": {
+    "Name": "SingStar Norske Hits",
+    "Region": "PAL-Unk"
+  },
+  "SCES_531.85": {
+    "Name": "SingStar Svenska Hits",
+    "Region": "PAL-Unk"
+  },
+  "SCES_532.02": {
+    "Name": "Tekken 5",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "eeClampMode": 1
+  },
+  "SCES_532.47": {
+    "Name": "WRC - World Rally Championship - Rally Evolved",
+    "Region": "PAL-Unk",
+    "Compat": 4,
+    "XgKickHack": 1
+  },
+  "SCES_532.85": {
+    "Name": "Ratchet - Gladiator",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_532.86": {
+    "Name": "Jak X - Combat Racing",
+    "Region": "PAL-Unk"
+  },
+  "SCES_533.00": {
+    "Name": "SOCOM 3 - U.S. Navy SEALs",
+    "Region": "PAL-M5"
+  },
+  "SCES_533.04": {
+    "Name": "Buzz! The Music Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_533.05": {
+    "Name": "Buzz! The Music Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_533.07": {
+    "Name": "Buzz! The Music Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_533.08": {
+    "Name": "Buzz! The Music Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_533.10": {
+    "Name": "Roland Garros 2005",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SCES_533.12": {
+    "Name": "Soul Calibur 3",
+    "Region": "PAL-Unk",
+    "Compat": 4,
+    "vuRoundMode": 3
+  },
+  "SCES_533.15": {
+    "Name": "EyeToy - Play 3",
+    "Region": "PAL-M12"
+  },
+  "SCES_533.23": {
+    "Name": "SingStar Pop World",
+    "Region": "PAL-Unk"
+  },
+  "SCES_533.26": {
+    "Name": "Shadow of the Colossus",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_533.28": {
+    "Name": "Genji",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_533.47": {
+    "Name": "SpyToy",
+    "Region": "PAL-Unk"
+  },
+  "SCES_533.58": {
+    "Name": "24 - The Game",
+    "Region": "PAL-Unk"
+  },
+  "SCES_533.72": {
+    "Name": "Tourist Trophy - The Real Riding Simulator",
+    "Region": "PAL-Unk"
+  },
+  "SCES_533.97": {
+    "Name": "SingStar Pop - World Events Code",
+    "Region": "PAL-Unk"
+  },
+  "SCES_534.09": {
+    "Name": "Sly 3",
+    "Region": "PAL-M11",
+    "Compat": 5
+  },
+  "SCES_534.22": {
+    "Name": "Stuart Little 3 - Big Photo Adventure",
+    "Region": "PAL-M9"
+  },
+  "SCES_534.49": {
+    "Name": "AFL Premiership 2005",
+    "Region": "PAL-Unk"
+  },
+  "SCES_534.50": {
+    "Name": "Gaelic Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SCES_535.65": {
+    "Name": "SingStar Pop",
+    "Region": "PAL-Unk"
+  },
+  "SCES_536.02": {
+    "Name": "Sing-Star '80s",
+    "Region": "PAL-E"
+  },
+  "SCES_536.03": {
+    "Name": "Sing-Star '80s",
+    "Region": "PAL-F"
+  },
+  "SCES_536.04": {
+    "Name": "Sing-Star '80s",
+    "Region": "PAL-G"
+  },
+  "SCES_536.05": {
+    "Name": "Sing-Star '80s",
+    "Region": "PAL-Unk"
+  },
+  "SCES_536.06": {
+    "Name": "Sing-Star '80s",
+    "Region": "PAL-Unk"
+  },
+  "SCES_536.07": {
+    "Name": "Sing-Star '80s",
+    "Region": "PAL-Unk"
+  },
+  "SCES_536.09": {
+    "Name": "Sing-Star '80s",
+    "Region": "PAL-Unk"
+  },
+  "SCES_536.10": {
+    "Name": "Sing-Star '80s",
+    "Region": "PAL-Unk"
+  },
+  "SCES_536.42": {
+    "Name": "Ape Escape 3",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_536.63": {
+    "Name": "Buzz! The Music Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_536.69": {
+    "Name": "Buzz! The Music Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_536.88": {
+    "Name": "Urban Reign",
+    "Region": "PAL-M5",
+    "Compat": 4
+  },
+  "SCES_537.95": {
+    "Name": "SingStar '80s",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.51": {
+    "Name": "Forbidden Siren 2",
+    "Region": "PAL-M5",
+    "Compat": 4,
+    "XgKickHack": 1
+  },
+  "SCES_538.79": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.80": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.81": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.82": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.83": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.84": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SCES_538.89": {
+    "Name": "SingStar Rocks!",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.90": {
+    "Name": "SingStar Rocks!",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.91": {
+    "Name": "SingStar Rocks!",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.93": {
+    "Name": "SingStar Rocks!",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.94": {
+    "Name": "SingStar Rocks!",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.95": {
+    "Name": "SingStar Rocks!",
+    "Region": "PAL-Unk"
+  },
+  "SCES_538.97": {
+    "Name": "Sing-Star Rocks!",
+    "Region": "PAL-F"
+  },
+  "SCES_538.98": {
+    "Name": "Sing-Star Rocks!",
+    "Region": "PAL-Unk"
+  },
+  "SCES_539.25": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SCES_539.26": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_539.27": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_539.29": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_539.31": {
+    "Name": "Shinobido - Way of the Ninja",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_539.50": {
+    "Name": "F1 '06",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_539.60": {
+    "Name": "B-Boy",
+    "Region": "PAL-Unk"
+  },
+  "SCES_540.25": {
+    "Name": "SingStar Rocks!",
+    "Region": "PAL-Unk"
+  },
+  "SCES_540.41": {
+    "Name": "Ace Combat - The Belkan War",
+    "Region": "PAL-E"
+  },
+  "SCES_540.71": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_540.73": {
+    "Name": "Buzz! The Big Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_540.77": {
+    "Name": "SingStar [Promo]",
+    "Region": "PAL-I"
+  },
+  "SCES_540.78": {
+    "Name": "SingStar Norsk pa Norsk",
+    "Region": "PAL-Unk"
+  },
+  "SCES_541.28": {
+    "Name": "Deutsch Rock-Pop",
+    "Region": "PAL-Unk"
+  },
+  "SCES_541.29": {
+    "Name": "SingStar",
+    "Region": "PAL-Unk"
+  },
+  "SCES_541.31": {
+    "Name": "Sing-Star Anthems",
+    "Region": "PAL-Unk",
+    "Compat": 3
+  },
+  "SCES_541.45": {
+    "Name": "Lemmings",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SCES_541.91": {
+    "Name": "Sing-Star Legends",
+    "Region": "PAL-Unk"
+  },
+  "SCES_541.97": {
+    "Name": "SingStar Legends",
+    "Region": "PAL-Unk"
+  },
+  "SCES_541.98": {
+    "Name": "SingStar Legends",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.06": {
+    "Name": "God of War II",
+    "Region": "PAL-M6",
+    "Compat": 5
+  },
+  "SCES_542.19": {
+    "Name": "Buzz! Junior - Jungle Party",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.20": {
+    "Name": "Buzz! Junior - Jungle Party",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.57": {
+    "Name": "SingStar Legends",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.58": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.59": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.60": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.61": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.62": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.63": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.64": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.65": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.66": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.67": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.68": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_542.69": {
+    "Name": "Buzz! The Sports Quiz",
+    "Region": "PAL-Unk"
+  },
+  "SCES_543.25": {
+    "Name": "SingStar Legendat",
+    "Region": "PAL-Unk"
+  },
+  "SCES_543.29": {
+    "Name": "SingStar Legends",
+    "Region": "PAL-Unk"
+  },
+  "SCES_543.30": {
+    "Name": "SingStar Legends",
+    "Region": "PAL-Unk"
+  },
+  "SCES_543.53": {
+    "Name": "SingStar Legends",
+    "Region": "PAL-Unk"
+  },
+  "SCES_544.77": {
+    "Name": "Socom US Navy Seals - Combined Assault",
+    "Region": "PAL-E",
+    "Compat": 4
+  },
+  "SCES_544.97": {
+    "Name": "Buzz! Le Mega Quiz",
+    "Region": "PAL-F"
+  },
+  "SCES_544.99": {
+    "Name": "Buzz! Das Mega-Quiz",
+    "Region": "PAL-G"
+  },
+  "SCES_545.00": {
+    "Name": "Buzz! El Mega Concurso",
+    "Region": "PAL-S"
+  },
+  "SCES_545.07": {
+    "Name": "Buzz! The Mega Quiz",
+    "Region": "PAL-M3"
+  },
+  "SCES_545.24": {
+    "Name": "Buzz! Junior - Jungle Party",
+    "Region": "PAL-Unk"
+  },
+  "SCES_545.35": {
+    "Name": "Everybody's Tennis",
+    "Region": "PAL-Unk"
+  },
+  "SCES_545.38": {
+    "Name": "Eyetoy - Play Astro Zoo",
+    "Region": "PAL-M15"
+  },
+  "SCES_545.52": {
+    "Name": "Rogue Galaxy",
+    "Region": "PAL-M5"
+  },
+  "SCES_545.71": {
+    "Name": "Sing-Star Pop Hits",
+    "Region": "PAL-G"
+  },
+  "SCES_545.97": {
+    "Name": "Buzz! The Mega Quiz",
+    "Region": "PAL-M3"
+  },
+  "SCES_545.98": {
+    "Name": "SingStar - Svenska Hits Schlager",
+    "Region": "PAL-Unk"
+  },
+  "SCES_545.99": {
+    "Name": "SingStar - '90s",
+    "Region": "PAL-E"
+  },
+  "SCES_546.00": {
+    "Name": "SingStar - Die Toten Hosen",
+    "Region": "PAL-G"
+  },
+  "SCES_546.01": {
+    "Name": "SingStar - Apres-Ski Party",
+    "Region": "PAL-G"
+  },
+  "SCES_546.25": {
+    "Name": "Buzz! Junior - Monster Rumble",
+    "Region": "PAL-M7"
+  },
+  "SCES_546.38": {
+    "Name": "Gaelic Games - Football 2",
+    "Region": "PAL-E"
+  },
+  "SCES_546.76": {
+    "Name": "Buzz! Junior - RoboJam",
+    "Region": "PAL-M7"
+  },
+  "SCES_546.88": {
+    "Name": "ATV Offroad Fury 4",
+    "Region": "PAL-M12"
+  },
+  "SCES_547.48": {
+    "Name": "WipEout Pulse",
+    "Region": "PAL-M5"
+  },
+  "SCES_547.49": {
+    "Name": "Buzz! Junior - Dino Den",
+    "Region": "PAL-M8"
+  },
+  "SCES_547.62": {
+    "Name": "SingStar R&B",
+    "Region": "PAL-G"
+  },
+  "SCES_547.94": {
+    "Name": "Syphon Filter - Dark Mirror",
+    "Region": "PAL-M5"
+  },
+  "SCES_548.23": {
+    "Name": "SingStar Bollywood",
+    "Region": "PAL-E"
+  },
+  "SCES_548.44": {
+    "Name": "Buzz! The Hollywood Quiz",
+    "Region": "PAL-E"
+  },
+  "SCES_548.45": {
+    "Name": "Buzz! The Hollywood Quiz",
+    "Region": "PAL-G"
+  },
+  "SCES_548.48": {
+    "Name": "Buzz! Hollywood",
+    "Region": "PAL-M2"
+  },
+  "SCES_548.51": {
+    "Name": "Buzz! The Hollywood Quiz",
+    "Region": "PAL-M3"
+  },
+  "SCES_550.93": {
+    "Name": "Buzz! The Pop Quiz",
+    "Region": "PAL-E"
+  },
+  "SCES_550.94": {
+    "Name": "Buzz! The Pop Quiz",
+    "Region": "PAL-M3"
+  },
+  "SCES_551.79": {
+    "Name": "SingStar Schlager",
+    "Region": "PAL-G"
+  },
+  "SCES_551.83": {
+    "Name": "SingStar Turkish Party",
+    "Region": "PAL-Unk"
+  },
+  "SCES_552.10": {
+    "Name": "Buzz! Junior - Ace Racers",
+    "Region": "PAL-M6"
+  },
+  "SCES_552.13": {
+    "Name": "Buzz! Escuela de Talentos",
+    "Region": "PAL-S"
+  },
+  "SCES_553.61": {
+    "Name": "SingStar Boy Bands vs Girl Bands",
+    "Region": "PAL-G"
+  },
+  "SCES_553.62": {
+    "Name": "SingStar Hottest Hits",
+    "Region": "PAL-G"
+  },
+  "SCES_553.85": {
+    "Name": "Buzz! Brain of the UK",
+    "Region": "PAL-E"
+  },
+  "SCES_553.87": {
+    "Name": "Buzz! Deutschlands Superquiz",
+    "Region": "PAL-G"
+  },
+  "SCES_554.37": {
+    "Name": "SingStar ABBA",
+    "Region": "PAL-G"
+  },
+  "SCES_554.54": {
+    "Name": "SingStar Queen",
+    "Region": "PAL-G"
+  },
+  "SCES_555.10": {
+    "Name": "Jak and Dexter - The Lost Frontier",
+    "Region": "PAL-M12"
+  },
+  "SCES_555.38": {
+    "Name": "SingStar",
+    "Region": "PAL-G"
+  },
+  "SCES_555.52": {
+    "Name": "SingStar MoTown",
+    "Region": "PAL-G"
+  },
+  "SCES_555.57": {
+    "Name": "SingStar Take That",
+    "Region": "PAL-G"
+  },
+  "SCES_555.70": {
+    "Name": "SingStar Chartbreaker",
+    "Region": "PAL-G"
+  },
+  "SCES_555.73": {
+    "Name": "MotorStorm - Arctic Edge",
+    "Region": "PAL-M14",
+    "OPHFLagHack": 1
+  },
+  "SCES_556.06": {
+    "Name": "SingStar Die groten Solokunstler",
+    "Region": "PAL-G"
+  },
+  "SCES_820.34": {
+    "Name": "Xenosaga II - Jenseits von Gut und Bose [Disc 1]",
+    "Region": "PAL-Unk"
+  },
+  "SCES_820.35": {
+    "Name": "Xenosaga II - Jenseits von Gut und Bose [Disc 2]",
+    "Region": "PAL-Unk"
+  },
+  "SLED_501.17": {
+    "Name": "Metal Gear Solid 2 - Sons of Liberty [Demo] [Zone of the Enders Bonus Disc]",
+    "Region": "PAL-E"
+  },
+  "SLED_503.59": {
+    "Name": "Devil May Cry [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_504.78": {
+    "Name": "WWF Smackdown! - Just Bring It [Demo]",
+    "Region": "PAL-Unk"
+  },
+  "SLED_504.88": {
+    "Name": "Spy Hunter [Demo]",
+    "Region": "PAL-Unk"
+  },
+  "SLED_508.84": {
+    "Name": "TimeSplitters 2 [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_512.11": {
+    "Name": "Burnout 2 - Point of Impact [Demo]",
+    "Region": "PAL-Unk"
+  },
+  "SLED_512.81": {
+    "Name": "Haven - Call of the King [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_519.01": {
+    "Name": "Soul Calibur II [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_523.75": {
+    "Name": "Fight Night 2004 [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_524.41": {
+    "Name": "Transformers [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_524.73": {
+    "Name": "Transformers - Optimus Prime [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_524.74": {
+    "Name": "Transformers - Red Alert [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_524.76": {
+    "Name": "UEFA Euro 2004 - Portugal [Demo]",
+    "Region": "PAL-M5"
+  },
+  "SLED_524.88": {
+    "Name": "The Suffering [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_529.29": {
+    "Name": "Prince of Persia - Warrior Within [Demo]",
+    "Region": "PAL-M5"
+  },
+  "SLED_530.83": {
+    "Name": "Monster Hunter [Demo]",
+    "Region": "PAL-M5"
+  },
+  "SLED_531.09": {
+    "Name": "Juiced [Demo]",
+    "Region": "PAL-M5"
+  },
+  "SLED_536.73": {
+    "Name": "007 - From Russia with Love [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_537.19": {
+    "Name": "Pro Evolution Soccer 5 [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_537.23": {
+    "Name": "Peter Jackson's king Kong [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_537.45": {
+    "Name": "Total Overdose [Demo]",
+    "Region": "PAL-M5"
+  },
+  "SLED_538.45": {
+    "Name": "Matrix - Path of Neo [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_539.37": {
+    "Name": "Black [Demo]",
+    "Region": "PAL-M5"
+  },
+  "SLED_539.51": {
+    "Name": "Honda Demo [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_539.53": {
+    "Name": "FIFA Street 2 [Demo]",
+    "Region": "PAL-E"
+  },
+  "SLED_540.35": {
+    "Name": "Play the Best Demos from Atari [Demo]",
+    "Region": "PAL-M5"
+  },
+  "SLED_543.12": {
+    "Name": "Need for Speed - Carbon [Demo]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.03": {
+    "Name": "Swap Magic DVD Disc v2.0",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.09": {
+    "Name": "Action Replay MAX",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_500.10": {
+    "Name": "Ready 2 Rumble - Round 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.11": {
+    "Name": "FIFA 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.12": {
+    "Name": "FIFA 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.13": {
+    "Name": "FIFA 2001",
+    "Region": "PAL-G"
+  },
+  "SLES_500.14": {
+    "Name": "FIFA 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.15": {
+    "Name": "FIFA 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.16": {
+    "Name": "FIFA 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.17": {
+    "Name": "F1 Championship Season 2000",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_500.18": {
+    "Name": "Kessen",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.19": {
+    "Name": "Kessen",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.20": {
+    "Name": "Kessen",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.21": {
+    "Name": "Madden NFL 2001",
+    "Region": "PAL-E"
+  },
+  "SLES_500.22": {
+    "Name": "NBA Live 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.23": {
+    "Name": "NBA Live 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.24": {
+    "Name": "NBA Live 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.25": {
+    "Name": "NBA 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.26": {
+    "Name": "NBA 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.27": {
+    "Name": "NHL 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.28": {
+    "Name": "NHL 2001",
+    "Region": "PAL-G"
+  },
+  "SLES_500.30": {
+    "Name": "SSX Snowboarding",
+    "Region": "PAL-M3"
+  },
+  "SLES_500.31": {
+    "Name": "X-Squad",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_500.32": {
+    "Name": "Theme Park World",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_500.33": {
+    "Name": "Swing Away Golf",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.35": {
+    "Name": "Winter X-games Snowboarding",
+    "Region": "PAL-M3"
+  },
+  "SLES_500.36": {
+    "Name": "ESPN International Track & Field",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_500.37": {
+    "Name": "Silent Scope",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.38": {
+    "Name": "Gradius III & IV",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_500.39": {
+    "Name": "International Superstar Soccer",
+    "Region": "PAL-E-G"
+  },
+  "SLES_500.42": {
+    "Name": "Disney's Dinosaur",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.43": {
+    "Name": "Disney's Dinosaur",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.44": {
+    "Name": "Rayman Revolution",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.45": {
+    "Name": "Disney's Jungle Book - Groove Party",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.46": {
+    "Name": "F1 Racing Championship",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_500.47": {
+    "Name": "F1 Racing Championship",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.48": {
+    "Name": "Donald Duck - Quack Attack",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_500.50": {
+    "Name": "Evergrace",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_500.51": {
+    "Name": "Eternal Ring",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.52": {
+    "Name": "Pool Master",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_500.53": {
+    "Name": "Aqua Aqua - Wetrix 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_500.54": {
+    "Name": "Midnight Club",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.55": {
+    "Name": "Smuggler's Run",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_500.56": {
+    "Name": "Surfing H3O",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.57": {
+    "Name": "Dynasty Warriors 2",
+    "Region": "PAL-E"
+  },
+  "SLES_500.59": {
+    "Name": "Dynasty Warriors 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.60": {
+    "Name": "International Superstar Soccer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.61": {
+    "Name": "Smuggler's Run",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_500.62": {
+    "Name": "Orphen - Scion of Sorcery",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.64": {
+    "Name": "Stunt GP",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.68": {
+    "Name": "Top Gear Daredevil",
+    "Region": "PAL-E"
+  },
+  "SLES_500.69": {
+    "Name": "Top Gear Daredevil",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.71": {
+    "Name": "Midnight Club - Street Racing",
+    "Region": "PAL-Unk",
+    "Compat": 3
+  },
+  "SLES_500.72": {
+    "Name": "Street Fighter EX3",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_500.73": {
+    "Name": "Driving Emotion Type-S",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.74": {
+    "Name": "Unreal Tournament",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_500.75": {
+    "Name": "ESPN NBA 2Night",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.76": {
+    "Name": "Super Bust-A-Move",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_500.77": {
+    "Name": "RC Revenge Pro",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_500.78": {
+    "Name": "TimeSplitters",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_500.79": {
+    "Name": "Armored Core 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_500.80": {
+    "Name": "NBA Hoopz",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.06": {
+    "Name": "Fur Fighters - Viggo's Revenge",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_501.07": {
+    "Name": "Legends of Wrestling",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.09": {
+    "Name": "7 Blades",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.10": {
+    "Name": "Ephemeral Fantasia",
+    "Region": "PAL-M3",
+    "Compat": 5
+  },
+  "SLES_501.11": {
+    "Name": "Zone of the Enders",
+    "Region": "PAL-M4"
+  },
+  "SLES_501.12": {
+    "Name": "Shadow of Memories",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.13": {
+    "Name": "Ring of Red",
+    "Region": "PAL-M3",
+    "Compat": 5
+  },
+  "SLES_501.14": {
+    "Name": "Kengo - Master of Bushido",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_501.15": {
+    "Name": "Tokyo Xtreme Racer",
+    "Region": "PAL-E"
+  },
+  "SLES_501.18": {
+    "Name": "Tiger Woods PGA Tour 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.20": {
+    "Name": "Rumble Racing",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_501.26": {
+    "Name": "Quake III - Revolution",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.27": {
+    "Name": "Quake III - Revolution",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.28": {
+    "Name": "Knockout Kings 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.30": {
+    "Name": "Knockout Kings 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.31": {
+    "Name": "Le Mans 24 Hours",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_501.32": {
+    "Name": "MX Rider",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.34": {
+    "Name": "Oni",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_501.36": {
+    "Name": "Robot Warlords",
+    "Region": "PAL-E"
+  },
+  "SLES_501.37": {
+    "Name": "Robot Warlords",
+    "Region": "PAL-F"
+  },
+  "SLES_501.38": {
+    "Name": "Robot Warlords",
+    "Region": "PAL-G"
+  },
+  "SLES_501.55": {
+    "Name": "Operation Winback",
+    "Region": "PAL-M3",
+    "Compat": 5,
+    "vuClampMode": 3
+  },
+  "SLES_501.58": {
+    "Name": "Gungriffon Blaze",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.59": {
+    "Name": "Gungriffon Blaze",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.60": {
+    "Name": "Gungriffon Blaze",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.65": {
+    "Name": "Star Wars - Starfighter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.66": {
+    "Name": "Star Wars - Starfighter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.67": {
+    "Name": "Star Wars - Starfighter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.68": {
+    "Name": "Star Wars - Starfighter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.69": {
+    "Name": "Star Wars - Starfighter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.70": {
+    "Name": "World Destruction League - Thunder Tanks",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.71": {
+    "Name": "ESPN National Hockey Night",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.76": {
+    "Name": "Oni",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.77": {
+    "Name": "Oni",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_501.82": {
+    "Name": "MTV Music Generator 2",
+    "Region": "PAL-M5"
+  },
+  "SLES_501.83": {
+    "Name": "Wacky Races",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_501.85": {
+    "Name": "Alone in the Dark 4",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_501.86": {
+    "Name": "Heroes of Might and Magic",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.87": {
+    "Name": "Warriors of Might and Magic",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.91": {
+    "Name": "Army Men - Green Rogue",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.92": {
+    "Name": "Army Men - Sarges Heroes 2",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_501.93": {
+    "Name": "Silpheed - The Lost Planet",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_501.94": {
+    "Name": "4x4 Evolution",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.95": {
+    "Name": "UEFA Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_501.96": {
+    "Name": "Soul Reaver 2 - Legacy of Kain",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_502.01": {
+    "Name": "Evil Twin - Cyprien's Chronicles",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_502.02": {
+    "Name": "DNA - Dark Native Apostle",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_502.03": {
+    "Name": "Bloody Roar 3",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_502.04": {
+    "Name": "Star Wars - Super Bombad Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.06": {
+    "Name": "Star Wars - Super Bombad Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.09": {
+    "Name": "Jeremy McGrath Supercross World",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.10": {
+    "Name": "XG3 - Extreme-G Racing",
+    "Region": "PAL-M4",
+    "Compat": 4
+  },
+  "SLES_502.11": {
+    "Name": "Gauntlet - Dark Legacy",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_502.12": {
+    "Name": "Paris-Dakar Rally",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "SkipMPEGPatch": 1
+  },
+  "SLES_502.13": {
+    "Name": "NFL Quarterback Club 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.14": {
+    "Name": "18 Wheeler",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_502.15": {
+    "Name": "Crazy Taxi",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_502.17": {
+    "Name": "Dave Mirra Freestyle BMX 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.18": {
+    "Name": "All-Star Baseball 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.19": {
+    "Name": "NBA Street",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.20": {
+    "Name": "EA Sports Rugby",
+    "Region": "PAL-E"
+  },
+  "SLES_502.21": {
+    "Name": "Conflict Zone",
+    "Region": "PAL-M3"
+  },
+  "SLES_502.24": {
+    "Name": "Kuri Kuri Mix",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_502.25": {
+    "Name": "Escape from Monkey Island",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.26": {
+    "Name": "Escape from Monkey Island 4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.27": {
+    "Name": "Escape from Monkey Island (Flucht von Monkey Island)",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_502.28": {
+    "Name": "Escape from Monkey Island 4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.29": {
+    "Name": "Monkey Island 4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.30": {
+    "Name": "Lotus Challenge",
+    "Region": "PAL-M5",
+    "Compat": 5,
+    "XgKickHack": 1
+  },
+  "SLES_502.31": {
+    "Name": "International League Soccer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.32": {
+    "Name": "Off-Road Wide Open",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_502.33": {
+    "Name": "Army Men - Air Attack - Blade's Revenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.43": {
+    "Name": "David Beckham Soccer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.47": {
+    "Name": "Onimusha - Warlords",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_502.48": {
+    "Name": "MDK 2 - Armageddon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.52": {
+    "Name": "Penny Racers",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.53": {
+    "Name": "Modern Groove - Ministry of Sound Edition",
+    "Region": "PAL-E"
+  },
+  "SLES_502.59": {
+    "Name": "Flintstones - Viva Rock Vegas",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.60": {
+    "Name": "Hidden Invasion",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.61": {
+    "Name": "Sky Surfer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.62": {
+    "Name": "World Destruction League - War Jets",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.63": {
+    "Name": "Portal Runner",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.66": {
+    "Name": "Playmobil - Hype - The Time Quest",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.67": {
+    "Name": "CART Fury Championship Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.68": {
+    "Name": "SpyHunter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.73": {
+    "Name": "Legion - The Legend of Excalibur",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.74": {
+    "Name": "Arctic Thunder",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.75": {
+    "Name": "EA Sports Rugby",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.76": {
+    "Name": "Gift, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.77": {
+    "Name": "Red Faction",
+    "Region": "PAL-E"
+  },
+  "SLES_502.78": {
+    "Name": "Red Faction",
+    "Region": "PAL-F"
+  },
+  "SLES_502.79": {
+    "Name": "Red Faction",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_502.80": {
+    "Name": "Victorious Boxers",
+    "Region": "PAL-E"
+  },
+  "SLES_502.82": {
+    "Name": "Age of Empires II - Age of Kings",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_502.83": {
+    "Name": "WTA Tour Tennis",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.84": {
+    "Name": "Silent Scope 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_502.85": {
+    "Name": "Police 24-7",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_502.88": {
+    "Name": "Stuntman",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_502.96": {
+    "Name": "Gift",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_502.97": {
+    "Name": "Gift",
+    "Region": "PAL-G"
+  },
+  "SLES_503.06": {
+    "Name": "Resident Evil - CODE Veronica X",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_503.10": {
+    "Name": "Freak Out",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_503.14": {
+    "Name": "Giants - Citizen Kabuto",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.25": {
+    "Name": "Max Payne",
+    "Region": "PAL-E",
+    "Compat": 4
+  },
+  "SLES_503.26": {
+    "Name": "Max Payne",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.30": {
+    "Name": "Grand Theft Auto III",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_503.35": {
+    "Name": "Rune - Viking Warlord",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.36": {
+    "Name": "Rune - Viking Warlord",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.37": {
+    "Name": "Rune - Viking Warlord",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.38": {
+    "Name": "Rune - Viking Warlord",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.39": {
+    "Name": "Rune - Viking Warlord",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.41": {
+    "Name": "Smuggler's Run 2 - Hostile Territory",
+    "Region": "PAL-M4"
+  },
+  "SLES_503.50": {
+    "Name": "Disney's Tarzan - Freeride",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.51": {
+    "Name": "Lake Masters EX",
+    "Region": "PAL-M3",
+    "Compat": 5
+  },
+  "SLES_503.55": {
+    "Name": "Batman Vengeance",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.56": {
+    "Name": "ESPN International Winter Sports",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.58": {
+    "Name": "Devil May Cry",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_503.62": {
+    "Name": "Jonny Moseley Mad Trix",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.64": {
+    "Name": "City Crisis",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.66": {
+    "Name": "Star Wars - Racer Revenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.71": {
+    "Name": "Star Wars - Jedi Starfighter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.72": {
+    "Name": "Star Wars - Jedi Starfighter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.73": {
+    "Name": "Star Wars - Jedi Starfighter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.74": {
+    "Name": "Star Wars - Jedi Starfighter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.75": {
+    "Name": "Star Wars - Jedi Starfighter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.82": {
+    "Name": "Silent Hill 2",
+    "Region": "PAL-M6",
+    "Compat": 5
+  },
+  "SLES_503.83": {
+    "Name": "Metal Gear Solid 2 - Sons of Liberty",
+    "Region": "PAL-M3",
+    "Compat": 5
+  },
+  "SLES_503.84": {
+    "Name": "Project Zero II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.85": {
+    "Name": "Metal Gear Solid 2 - Sons of Liberty",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.86": {
+    "Name": "Crash Bandicoot - Wrath of Cortex",
+    "Region": "PAL-M6",
+    "Compat": 5
+  },
+  "SLES_503.90": {
+    "Name": "Driven",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.95": {
+    "Name": "World Championship Snooker 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.96": {
+    "Name": "Mike Tyson Heavyweight Boxing",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_503.97": {
+    "Name": "Prisoner of War",
+    "Region": "PAL-Unk"
+  },
+  "SLES_503.98": {
+    "Name": "UEFA Champions League",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.00": {
+    "Name": "Shaun Palmer's Pro Snowboarder",
+    "Region": "PAL-E"
+  },
+  "SLES_504.01": {
+    "Name": "Shaun Palmer's Pro Snowboarder",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.02": {
+    "Name": "Shaun Palmer's Pro Snowboarder",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.12": {
+    "Name": "Pro Evolution Soccer",
+    "Region": "PAL-M3"
+  },
+  "SLES_504.21": {
+    "Name": "Supercar Street Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.22": {
+    "Name": "Madden NFL 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.23": {
+    "Name": "F1 2001",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_504.24": {
+    "Name": "Cricket 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.25": {
+    "Name": "NHL 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.26": {
+    "Name": "NHL 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.27": {
+    "Name": "NHL 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.28": {
+    "Name": "MX 2002 featuring Ricky Carmichael",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.29": {
+    "Name": "Alex Ferguson Player Manager 2002",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_504.30": {
+    "Name": "ESPN X-Games Skateboarding",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.31": {
+    "Name": "F1 2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.32": {
+    "Name": "Tony Hawk Pro Skater 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.33": {
+    "Name": "GoDai - Elemental Force",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.34": {
+    "Name": "Army Men - Real Time Strategy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.35": {
+    "Name": "Tony Hawk's Pro Skater 3",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_504.36": {
+    "Name": "Tony Hawk Pro Skater 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.37": {
+    "Name": "Tony Hawk's Pro Skater 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.38": {
+    "Name": "Motor Mayhem",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.43": {
+    "Name": "LEGO Racers 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.44": {
+    "Name": "Portal Runner",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.45": {
+    "Name": "Burnout",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_504.46": {
+    "Name": "Shadow Man - 2econd Coming",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_504.47": {
+    "Name": "All-Star Baseball 2003",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.51": {
+    "Name": "NHL Hitz 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.57": {
+    "Name": "Rayman M",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_504.60": {
+    "Name": "Official PlayStation 2 Magazine Demo 11",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.62": {
+    "Name": "Pro Evolution Soccer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.64": {
+    "Name": "FIFA 2002",
+    "Region": "PAL-M5"
+  },
+  "SLES_504.65": {
+    "Name": "FIFA 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.66": {
+    "Name": "FIFA 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.67": {
+    "Name": "FIFA 2002",
+    "Region": "PAL-G"
+  },
+  "SLES_504.69": {
+    "Name": "FIFA 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.70": {
+    "Name": "FIFA 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.71": {
+    "Name": "FIFA 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.72": {
+    "Name": "GTC Africa",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_504.77": {
+    "Name": "WWF Smackdown! - Just Bring It",
+    "Region": "PAL-E"
+  },
+  "SLES_504.79": {
+    "Name": "Turok Evolution",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_504.80": {
+    "Name": "Aggressive Inline Skating",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_504.81": {
+    "Name": "Vexx",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_504.84": {
+    "Name": "Rayman M",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.86": {
+    "Name": "Splashdown",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.87": {
+    "Name": "Space Race",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_504.95": {
+    "Name": "Who Wants to be a Millionaire - 2nd Edition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.96": {
+    "Name": "Qui Veut Gagner des Millions",
+    "Region": "PAL-Unk"
+  },
+  "SLES_504.97": {
+    "Name": "Who Wants to be a Millionaire 2 (Wer wird Millionar 2)",
+    "Region": "PAL-G"
+  },
+  "SLES_504.98": {
+    "Name": "Grandia II",
+    "Region": "PAL-E"
+  },
+  "SLES_505.03": {
+    "Name": "Weakest Link",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.04": {
+    "Name": "Half-Life",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_505.05": {
+    "Name": "Half-Life",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_505.06": {
+    "Name": "Half-Life",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.07": {
+    "Name": "Half-Life",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.08": {
+    "Name": "Half-Life",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.09": {
+    "Name": "Half-Life",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.10": {
+    "Name": "Mummy Returns, The",
+    "Region": "PAL-M5",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_505.11": {
+    "Name": "G-Surfers",
+    "Region": "PAL-E"
+  },
+  "SLES_505.12": {
+    "Name": "Bass Strike",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.33": {
+    "Name": "Sunny Garcia Surfing",
+    "Region": "PAL-E"
+  },
+  "SLES_505.34": {
+    "Name": "NBA Live 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.35": {
+    "Name": "NBA Live 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.36": {
+    "Name": "NBA Live 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.37": {
+    "Name": "NBA Live 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.38": {
+    "Name": "NBA Live 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.39": {
+    "Name": "James Bond 007 - Agent Under Fire",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.40": {
+    "Name": "Simpsons Road Rage",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.41": {
+    "Name": "Capcom vs. SNK 2 - Mark of the Millennium",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.44": {
+    "Name": "Jet Ion GP",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_505.45": {
+    "Name": "SSX Tricky",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.46": {
+    "Name": "LMA Manager 2002",
+    "Region": "PAL-E"
+  },
+  "SLES_505.47": {
+    "Name": "Roger Lemerre - La Selection des Champions 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.48": {
+    "Name": "BDFL Manager 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.49": {
+    "Name": "Football Manager Campionato 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.50": {
+    "Name": "Manager de Liga 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.51": {
+    "Name": "Tetris Worlds",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.52": {
+    "Name": "Jet Ski Riders",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.53": {
+    "Name": "Project Eden",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_505.54": {
+    "Name": "Thunderhawk - Operation Pheonix",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.56": {
+    "Name": "New York Race",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.58": {
+    "Name": "DSF Futball Manager 2002",
+    "Region": "PAL-G"
+  },
+  "SLES_505.59": {
+    "Name": "Guy Roux Manager 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.62": {
+    "Name": "Super Bust-A-Move 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.68": {
+    "Name": "Top Gun - Combat Zones",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.70": {
+    "Name": "Tour de France, Le",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_505.72": {
+    "Name": "Robot Wars - Arenas of Destruction",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.75": {
+    "Name": "Dark Summit",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.78": {
+    "Name": "Kessen II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.79": {
+    "Name": "Kessen II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.80": {
+    "Name": "Kessen II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.84": {
+    "Name": "G1 Jockey",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.86": {
+    "Name": "ESPN Winter Sports 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.89": {
+    "Name": "Worms Blast",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.90": {
+    "Name": "Music Maker",
+    "Region": "PAL-Unk"
+  },
+  "SLES_505.91": {
+    "Name": "Guilty Gear X",
+    "Region": "PAL-E"
+  },
+  "SLES_505.92": {
+    "Name": "No One Lives Forever",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.06": {
+    "Name": "State of Emergency",
+    "Region": "PAL-M4"
+  },
+  "SLES_506.08": {
+    "Name": "Shadow Man - 2econd Coming",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.13": {
+    "Name": "Woody Woodpecker",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_506.19": {
+    "Name": "Jonny Moseley Mad Trix",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.20": {
+    "Name": "Micro Machines",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.28": {
+    "Name": "Simpsons Road Rage",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.30": {
+    "Name": "Dragon Rage",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.31": {
+    "Name": "Dragon Rage",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.32": {
+    "Name": "Dragon Rage",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.33": {
+    "Name": "Gitaroo Man",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.36": {
+    "Name": "Centre Court - Hardhitter",
+    "Region": "PAL-M3"
+  },
+  "SLES_506.37": {
+    "Name": "Pro Rally 2002",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_506.38": {
+    "Name": "High Heat Major League Baseball 2003",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.39": {
+    "Name": "Everblue",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_506.40": {
+    "Name": "Salt Lake City 2002 Olympic Winter Games",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.41": {
+    "Name": "Dynasty Warriors 3",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_506.43": {
+    "Name": "Shifters",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.44": {
+    "Name": "Shifters",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.45": {
+    "Name": "Shifters",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.47": {
+    "Name": "Casper - Spirit Dimensions",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.49": {
+    "Name": "Taz Wanted",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_506.50": {
+    "Name": "Resident Evil Gun Survivor 2 - Code Veronica",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_506.53": {
+    "Name": "Gitaroo Man",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.54": {
+    "Name": "Dune, Frank Herbert's",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.61": {
+    "Name": "Atlantis III",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.62": {
+    "Name": "Shadow of Zorro, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.70": {
+    "Name": "ESPN Winter X-Games Snowboarding 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.72": {
+    "Name": "Baldur's Gate - Dark Alliance",
+    "Region": "PAL-M5",
+    "Compat": 4
+  },
+  "SLES_506.77": {
+    "Name": "Shadow Hearts",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_506.79": {
+    "Name": "Tenchu 3 - Wrath of Heaven",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.80": {
+    "Name": "Pirates - The Legend of Black Kat",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_506.83": {
+    "Name": "Sled Storm",
+    "Region": "PAL-M3"
+  },
+  "SLES_506.84": {
+    "Name": "Medal of Honor - Frontline",
+    "Region": "PAL-Unk"
+  },
+  "SLES_506.86": {
+    "Name": "Iron Aces 2 - Birds of Prey",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.03": {
+    "Name": "Maximo",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.04": {
+    "Name": "Godai - Elemental Force",
+    "Region": "PAL-F-G",
+    "Compat": 5
+  },
+  "SLES_507.06": {
+    "Name": "Army Men - Real Time Strategy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.09": {
+    "Name": "Weakest Link (Le Maillon Fable)",
+    "Region": "PAL-F"
+  },
+  "SLES_507.10": {
+    "Name": "Dr. Muto",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.11": {
+    "Name": "Red Card Football",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.13": {
+    "Name": "Freaky Flyers",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.14": {
+    "Name": "Defender",
+    "Region": "PAL-E"
+  },
+  "SLES_507.15": {
+    "Name": "Gravity Games Bike Street - Vertical Dirt",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.16": {
+    "Name": "Fireblade",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.17": {
+    "Name": "Mortal Kombat - Deadly Alliance",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_507.20": {
+    "Name": "FMX - Freestyle Metal X",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.21": {
+    "Name": "Pryzm - Dark Unicorn",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_507.22": {
+    "Name": "Premier Manager 2002-2003",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.23": {
+    "Name": "TOCA Race Driver",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.25": {
+    "Name": "V-Rally 3",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_507.26": {
+    "Name": "Myst III - Exile",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.27": {
+    "Name": "Knockout Kings 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.28": {
+    "Name": "Tiger Woods PGA Tour 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.30": {
+    "Name": "VIP",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.31": {
+    "Name": "Need for Speed - Hot Pursuit 2",
+    "Region": "PAL-M6",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SLES_507.35": {
+    "Name": "Jade Cocoon 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_507.38": {
+    "Name": "Star Trek Voyager - Elite Force",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_507.39": {
+    "Name": "Soldier of Fortune - Gold Edition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.51": {
+    "Name": "Herdy Gerdy",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SLES_507.52": {
+    "Name": "Pro Tennis WTA Tour",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.53": {
+    "Name": "Freekstyle",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.54": {
+    "Name": "Simpsons Skateboarding",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.55": {
+    "Name": "Simpsons Skateboarding",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.57": {
+    "Name": "Atlantis III",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.58": {
+    "Name": "Eve of Extinction",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.63": {
+    "Name": "Rally Championship",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_507.65": {
+    "Name": "Music Maker",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.67": {
+    "Name": "V8 Supercars Australia - Race Driver",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.68": {
+    "Name": "Rally Championship",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.69": {
+    "Name": "Mr. Moskeeto",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.70": {
+    "Name": "Mad Maestro!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.71": {
+    "Name": "Blood Omen 2 - Legend of Kain",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_507.72": {
+    "Name": "Blood Omen 2 - Legend of Kain",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.73": {
+    "Name": "Donald Duck Phantomias Platyrhynchos Kineticus",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_507.77": {
+    "Name": "Battle Engine Aquila",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.78": {
+    "Name": "TD Overdrive - The Brotherhood of Speed",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SLES_507.79": {
+    "Name": "ESPN NBA 2Night 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.87": {
+    "Name": "International Superstar Soccer 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.88": {
+    "Name": "Frogger - The Great Quest",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.90": {
+    "Name": "International Superstar Soccer 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.93": {
+    "Name": "Grand Theft Auto III",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.94": {
+    "Name": "Sven-Goran Eriksson's World Manager 2002",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_507.95": {
+    "Name": "Superman - Shadow of Apokolips",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.96": {
+    "Name": "FIFA World Cup 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.97": {
+    "Name": "FIFA World Cup 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_507.98": {
+    "Name": "FIFA World Cup 2002",
+    "Region": "PAL-Unk",
+    "Compat": 4,
+    "EETimingHack": 1
+  },
+  "SLES_507.99": {
+    "Name": "FIFA World Cup 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.00": {
+    "Name": "FIFA World Cup 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.01": {
+    "Name": "FIFA World Cup 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.02": {
+    "Name": "Knockout Kings 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.04": {
+    "Name": "Deus Ex",
+    "Region": "PAL-E"
+  },
+  "SLES_508.05": {
+    "Name": "Deus Ex",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.06": {
+    "Name": "Deus Ex",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.07": {
+    "Name": "Deus Ex",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.08": {
+    "Name": "Deus Ex",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.09": {
+    "Name": "Next Generation Tennis 2003",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.12": {
+    "Name": "Spider-Man",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.13": {
+    "Name": "Spider-Man",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.14": {
+    "Name": "Spider-Man",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_508.15": {
+    "Name": "Blood Omen 2 - Legend of Kain",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.16": {
+    "Name": "DTM Race Driver",
+    "Region": "PAL-M3",
+    "Compat": 5
+  },
+  "SLES_508.18": {
+    "Name": "Pro Race Driver",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.20": {
+    "Name": "Micro Machines",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.21": {
+    "Name": "Project Zero",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_508.22": {
+    "Name": "Shadow Hearts",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.26": {
+    "Name": "Star Wars - Clone Wars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.29": {
+    "Name": "Commandos 2 - Men of Courage",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.31": {
+    "Name": "Star Wars - Bounty Hunter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.32": {
+    "Name": "Star Wars - Bounty Hunter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.33": {
+    "Name": "Star Wars - Bounty Hunter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.34": {
+    "Name": "Star Wars - Bounty Hunter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.35": {
+    "Name": "Star Wars - Bounty Hunter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.36": {
+    "Name": "Indiana Jones and The Emperor's Tomb",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_508.37": {
+    "Name": "Indiana Jones and The Emperor's Tomb",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_508.38": {
+    "Name": "Indiana Jones and The Emperor's Tomb",
+    "Region": "PAL-G",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_508.39": {
+    "Name": "Indiana Jones and The Emperor's Tomb",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_508.40": {
+    "Name": "Indiana Jones and The Emperor's Tomb",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_508.41": {
+    "Name": "Largo Winch - Empire Under Threat",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_508.42": {
+    "Name": "Downforce",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_508.43": {
+    "Name": "Crashed",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.45": {
+    "Name": "Medal of Honour - Frontline",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.46": {
+    "Name": "Medal of Honor - Frontline",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.48": {
+    "Name": "Speed Kings",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.49": {
+    "Name": "Urban Freestyle Soccer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.50": {
+    "Name": "ATV Off-Road 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.52": {
+    "Name": "Sven-Goran Eriksson's World Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.53": {
+    "Name": "Marcel DeSaily Pro Football",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.54": {
+    "Name": "WM Nationalspieler",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.59": {
+    "Name": "Commandos 2 - Men of Courage",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.60": {
+    "Name": "Commandos 2 - Men of Courage",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.61": {
+    "Name": "Top Angler",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.62": {
+    "Name": "Street Hoops",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.70": {
+    "Name": "Mat Hoffman's Pro BMX 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.71": {
+    "Name": "Mat Hoffman's Pro BMX 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.72": {
+    "Name": "Mat Hoffman's Pro BMX 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.73": {
+    "Name": "Reign of Fire",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.74": {
+    "Name": "F1 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.75": {
+    "Name": "F1 2002",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.76": {
+    "Name": "Driv3r",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.77": {
+    "Name": "TimeSplitters 2",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_508.79": {
+    "Name": "Paris-Dakar 2",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "FPUNegDivHack": 1,
+    "EETimingHack": 1
+  },
+  "SLES_508.80": {
+    "Name": "BMX XXX",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_508.82": {
+    "Name": "Mary-Kate and Ashley - Sweet 16",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.86": {
+    "Name": "Transworld Surf",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.91": {
+    "Name": "Legaia 2 - Duel Saga",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.92": {
+    "Name": "Lethal Skies Elite Pilot - Team SW",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.97": {
+    "Name": "Super Trucks",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_508.98": {
+    "Name": "X-Men - The Next Dimension",
+    "Region": "PAL-Unk"
+  },
+  "SLES_508.99": {
+    "Name": "X-Men - The Next Dimension",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.00": {
+    "Name": "X-Men - The Next Dimension",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.02": {
+    "Name": "Conflict - Desert Storm",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.05": {
+    "Name": "Armored Core 2 - Another Age",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.06": {
+    "Name": "Master Rally",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.08": {
+    "Name": "Monster Jam - Maximum Destruction",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.14": {
+    "Name": "International Cue Club",
+    "Region": "PAL-E"
+  },
+  "SLES_509.19": {
+    "Name": "Akira Psycho Ball",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_509.20": {
+    "Name": "King's Field IV",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_509.21": {
+    "Name": "Way of the Samurai",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.22": {
+    "Name": "Terminator, The - Dawn of Fate",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.27": {
+    "Name": "Commandos 2 - Men of Courage",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.30": {
+    "Name": "Dino Stalker",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.32": {
+    "Name": "Smash Court Tennis - Pro Tournament",
+    "Region": "PAL-M5"
+  },
+  "SLES_509.33": {
+    "Name": "eJay Clubworld",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.35": {
+    "Name": "Circus Maximus - Chariot Wars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.36": {
+    "Name": "Endgame",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.37": {
+    "Name": "LEGO Football Mania",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.39": {
+    "Name": "USA Racer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.46": {
+    "Name": "Britney's Dance Beat",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.47": {
+    "Name": "Britney's Dance Beat",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.48": {
+    "Name": "Britney's Dance Beat",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.53": {
+    "Name": "Air Rescue Ranger",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.54": {
+    "Name": "Tokyo Road Race",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_509.55": {
+    "Name": "London Racer 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_509.58": {
+    "Name": "Warhammer 40,000 - Firewarrior",
+    "Region": "PAL-E"
+  },
+  "SLES_509.63": {
+    "Name": "Riding Spirits",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.64": {
+    "Name": "Antz Extreme Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.65": {
+    "Name": "Spider-Man",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.72": {
+    "Name": "Barbarian",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_509.74": {
+    "Name": "Zapper - One Wicked Cricket!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.75": {
+    "Name": "Thing, The",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_509.76": {
+    "Name": "Thing, The (Das Ding)",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_509.78": {
+    "Name": "Onimusha 2 - Samurai's Destiny",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_509.81": {
+    "Name": "RC Sports Copter Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.84": {
+    "Name": "Gumball 3000",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_509.85": {
+    "Name": "Gumball 3000",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_509.86": {
+    "Name": "Twin Caliber",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_509.87": {
+    "Name": "Scorpion King, The - Rise of an Akkadian",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.88": {
+    "Name": "Lord of the Rings, The - The Fellowship of the Ring (Der Herr der Ringe - Die Gefahrten)",
+    "Region": "PAL-G"
+  },
+  "SLES_509.92": {
+    "Name": "Hitman 2 - Silent Assassin",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_509.94": {
+    "Name": "Paris-Marseille Racing II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.95": {
+    "Name": "Fireblade",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.97": {
+    "Name": "Rally Fusion - Race of Champions",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.98": {
+    "Name": "Xtreme Express - World Grand Prix",
+    "Region": "PAL-Unk"
+  },
+  "SLES_509.99": {
+    "Name": "UFC Throwdown",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.09": {
+    "Name": "Autobahn Raser IV",
+    "Region": "PAL-G"
+  },
+  "SLES_510.11": {
+    "Name": "Knight Rider - The Game",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_510.13": {
+    "Name": "Blade 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.14": {
+    "Name": "Blade 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.17": {
+    "Name": "Scooby-Doo! and The Night of 100 Frights",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.18": {
+    "Name": "Scooby-Doo! and The Night of 100 Frights",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.19": {
+    "Name": "Scooby-Doo! and The Night of 100 Frights",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.22": {
+    "Name": "Virtual Racer - Jaques Villeneuve",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.23": {
+    "Name": "LMA Manager 2003",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_510.25": {
+    "Name": "BDFL Manager 2003",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.38": {
+    "Name": "MX Superfly featuring Ricky Carmichael",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.42": {
+    "Name": "Disney Golf",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.43": {
+    "Name": "Spyro - Enter the Dragonfly",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.44": {
+    "Name": "Burnout 2 - Point of Impact",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_510.45": {
+    "Name": "Legends of Wrestling II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.46": {
+    "Name": "State of Emergency",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.53": {
+    "Name": "Tom & Jerry's War of the Wiskers",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.54": {
+    "Name": "Midnight Club 2",
+    "Region": "PAL-Unk",
+    "Compat": 3
+  },
+  "SLES_510.55": {
+    "Name": "Go Go Golf",
+    "Region": "PAL-E"
+  },
+  "SLES_510.56": {
+    "Name": "Fighting Fury",
+    "Region": "PAL-E"
+  },
+  "SLES_510.57": {
+    "Name": "Hard Hitter 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.58": {
+    "Name": "Maken Shao - Demon Sword",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.60": {
+    "Name": "Butt Ugly Martians",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.61": {
+    "Name": "Grand Theft Auto - Vice City",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_510.64": {
+    "Name": "Gladius",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.65": {
+    "Name": "Gladius",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.66": {
+    "Name": "Gladius",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.69": {
+    "Name": "RTX - Red Rock",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.70": {
+    "Name": "RTX Red Rock",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.71": {
+    "Name": "RTX - Red Rock",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_510.72": {
+    "Name": "RTX - Red Rock",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.73": {
+    "Name": "RTX Red Rock",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.76": {
+    "Name": "Liverpool FC - Club Football",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.77": {
+    "Name": "Club Football Real Madrid",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.78": {
+    "Name": "FC Barcelona - Club Football",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_510.79": {
+    "Name": "Ajax Club Football",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.80": {
+    "Name": "AC Milan Club Football",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.81": {
+    "Name": "Club Football - Juventus 2003-2004 Season",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.82": {
+    "Name": "Hamburger SV Club Football - Saison 2003-2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.83": {
+    "Name": "Borussia Dortmund Club Football - Saison 2003-2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.84": {
+    "Name": "BDFL Manager 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.85": {
+    "Name": "Aston Villa - Club Football",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.86": {
+    "Name": "Club Football - Chelsea",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.87": {
+    "Name": "Leeds United - Club Football",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.88": {
+    "Name": "Club Football - Rangers",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.89": {
+    "Name": "Club Football - Arsenal",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.90": {
+    "Name": "Club Football - Manchester United",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.93": {
+    "Name": "Largo Winch - Empire Under Threat",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_510.94": {
+    "Name": "FC Internazionale - Club Football",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.95": {
+    "Name": "Dino Stalker",
+    "Region": "PAL-Unk"
+  },
+  "SLES_510.96": {
+    "Name": "Dino Stalker",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.00": {
+    "Name": "Club Football - Liverpool - 2003-2004 Season",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.01": {
+    "Name": "Eggo Mania",
+    "Region": "PAL-M3",
+    "Compat": 5
+  },
+  "SLES_511.08": {
+    "Name": "Hitman 2 - Silent Assassin",
+    "Region": "PAL-F"
+  },
+  "SLES_511.09": {
+    "Name": "Hitman 2 - Silent Assassin",
+    "Region": "PAL-G"
+  },
+  "SLES_511.13": {
+    "Name": "Zone of the Enders - The 2nd Runner",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_511.14": {
+    "Name": "Pro Evolution Soccer 2",
+    "Region": "PAL-M5"
+  },
+  "SLES_511.17": {
+    "Name": "Colin McRae Rally 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.18": {
+    "Name": "Wizardry - Tales of the Forsaken Land",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_511.24": {
+    "Name": "Turok Evolution",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_511.25": {
+    "Name": "Sega Soccer Slam",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.26": {
+    "Name": "Whirl Tour",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.28": {
+    "Name": "Total Immersion Racing",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_511.30": {
+    "Name": "Tony Hawk's Pro Skater 4",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "vuRoundMode": "0"
+  },
+  "SLES_511.32": {
+    "Name": "Tony Hawk's Pro Skater 4",
+    "Region": "PAL-Unk",
+    "vuRoundMode": "0"
+  },
+  "SLES_511.33": {
+    "Name": "Red Faction 2",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_511.34": {
+    "Name": "Powerpuff Girls - Relish Rampage",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_511.41": {
+    "Name": "Summoner 2",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_511.42": {
+    "Name": "Summoner 2",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_511.43": {
+    "Name": "Summoner 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.44": {
+    "Name": "Shox - Rally Reinvented",
+    "Region": "PAL-M7",
+    "Compat": 5
+  },
+  "SLES_511.45": {
+    "Name": "Monopoly Party",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.50": {
+    "Name": "Scrabble Interactive - 2003 Edition",
+    "Region": "PAL-M3"
+  },
+  "SLES_511.51": {
+    "Name": "NHL 2003",
+    "Region": "PAL-Unk",
+    "vuClampMode": 2
+  },
+  "SLES_511.53": {
+    "Name": "LEGO Island - Extreme Stunts",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.54": {
+    "Name": "Madden NFL 2003",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.56": {
+    "Name": "Silent Hill 2 - Director's Cut",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_511.57": {
+    "Name": "Silent Scope 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.60": {
+    "Name": "Sub Rebellion",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.62": {
+    "Name": "Metropolismania",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.68": {
+    "Name": "AFL Live 2004 - Aussie Rules Football",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_511.74": {
+    "Name": "Marvel vs. Capcom 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.80": {
+    "Name": "Tom Clancy's The Sum of All Fears",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_511.81": {
+    "Name": "Tom Clancy's Ghost Recon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.82": {
+    "Name": "Tom Clancy's Ghost Recon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.88": {
+    "Name": "Rocket Power - Beach Bandits",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.89": {
+    "Name": "MTV's Celebrity Deathmatch",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.91": {
+    "Name": "Auto Modellista",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_511.92": {
+    "Name": "Harry Potter and the Chamber of Secrets",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.94": {
+    "Name": "Harry Potter - Kammer D Schreckens",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.95": {
+    "Name": "Harry Potter y La Camara Secreta",
+    "Region": "PAL-S"
+  },
+  "SLES_511.96": {
+    "Name": "Harry Potter e La Camera dei Secreti",
+    "Region": "PAL-I"
+  },
+  "SLES_511.97": {
+    "Name": "FIFA 2003",
+    "Region": "PAL-M7",
+    "Compat": 4,
+    "vuClampMode": 2
+  },
+  "SLES_511.98": {
+    "Name": "NBA Live 2003",
+    "Region": "PAL-Unk"
+  },
+  "SLES_511.99": {
+    "Name": "4x4 Evolution II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.00": {
+    "Name": "Kelly Slater's Pro Surfer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.01": {
+    "Name": "Kelly Slater's Pro Surfer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.02": {
+    "Name": "Wreckless - The Yakuza Missions",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.03": {
+    "Name": "Enter the Matrix",
+    "Region": "PAL-M5",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_512.08": {
+    "Name": "Rocky",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.09": {
+    "Name": "Haven - Call of the King",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_512.14": {
+    "Name": "18 Wheeler - American Pro Trucker",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.20": {
+    "Name": "Ty - The Tazmanian Tiger",
+    "Region": "PAL-5",
+    "Compat": 5
+  },
+  "SLES_512.22": {
+    "Name": "Rayman 3 - Hoodlum Havoc",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.23": {
+    "Name": "Runabout 3 - Neo Age",
+    "Region": "PAL-E"
+  },
+  "SLES_512.26": {
+    "Name": "Twin Caliber",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_512.27": {
+    "Name": "Tomb Raider - Angel of Darkness",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "OPHFlagHack": 1
+  },
+  "SLES_512.29": {
+    "Name": "Virtua Cop - Elite Edition",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_512.30": {
+    "Name": "Minority Report",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.32": {
+    "Name": "Virtua Tennis 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_512.33": {
+    "Name": "DragonBall Z - Budokai",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_512.35": {
+    "Name": "Raging Blades",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.36": {
+    "Name": "Gungrave",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.44": {
+    "Name": "XIII",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_512.47": {
+    "Name": "Inspector Gadget - Mad Robots Invasion",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_512.49": {
+    "Name": "Castleween",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_512.50": {
+    "Name": "Shox - Rally Reinvented",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_512.51": {
+    "Name": "Shox - Rally Reinvented",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.52": {
+    "Name": "Lord of the Rings, The - The Two Towers",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_512.53": {
+    "Name": "Lord of the Rings, The - The Two Towers (Seigneur des Anneaux - Les Deux Tours)",
+    "Region": "PAL-F"
+  },
+  "SLES_512.54": {
+    "Name": "Lord of the Rings, The - The Two Towers (Der Herr der Ringe - Die Zwei Turme)",
+    "Region": "PAL-G"
+  },
+  "SLES_512.55": {
+    "Name": "Lord of the Rings, The - The Two Towers",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.56": {
+    "Name": "Lord of the Rings, The - The Two Towers (El Senor de Los Anillos - Las Dos Torres)",
+    "Region": "PAL-S",
+    "Compat": 5
+  },
+  "SLES_512.57": {
+    "Name": "Sims, The (Die Sims)",
+    "Region": "PAL-G"
+  },
+  "SLES_512.58": {
+    "Name": "James Bond 007 - Nightfire",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.60": {
+    "Name": "James Bond 007 - Nightfire",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_512.65": {
+    "Name": "Dynasty Warriors Tactics",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.66": {
+    "Name": "Dynasty Tactics",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.67": {
+    "Name": "Dynasty Tactics",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.71": {
+    "Name": "Mobile Suit Gundam - Federation vs. Zeon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.72": {
+    "Name": "Wakeboarding Unleashed",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.73": {
+    "Name": "Wakeboarding Unleashed",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.82": {
+    "Name": "Tiger Woods PGA Tour 2003",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.83": {
+    "Name": "WWE Smackdown! 4 - Shut Your Mouth",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.84": {
+    "Name": "Contra - Shattered Soldier",
+    "Region": "PAL-M3"
+  },
+  "SLES_512.85": {
+    "Name": "Spongebob Squarepants - Revenge of the Flying Dutchman",
+    "Region": "PAL-Unk",
+    "Compat": 3
+  },
+  "SLES_512.86": {
+    "Name": "X-Men 2 - Wolverine's Revenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.87": {
+    "Name": "X-Men 2 - Wolverine's Revenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.89": {
+    "Name": "Gunfighter 2 - Legend of Jesse James",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.90": {
+    "Name": "Sword of the Samurai",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_512.94": {
+    "Name": "XIII",
+    "Region": "PAL-Unk"
+  },
+  "SLES_512.96": {
+    "Name": "Grand Prix Challenge",
+    "Region": "PAL-Unk",
+    "Compat": 4,
+    "VIFFIFOHack": 1
+  },
+  "SLES_512.98": {
+    "Name": "Jimmy Neutron - Boy Genius",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.01": {
+    "Name": "SOS - The Final Escape",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.02": {
+    "Name": "Bomberman Kart",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.03": {
+    "Name": "LEGO Dome Racers",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.07": {
+    "Name": "Wild Arms 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.08": {
+    "Name": "Reel Fishing 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.11": {
+    "Name": "Rugrats Royal Ransom",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.12": {
+    "Name": "Rugrats Royal Ransom",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.13": {
+    "Name": "Activision Anthology",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.15": {
+    "Name": "Great Escape, The",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_513.16": {
+    "Name": "Grand Theft Auto - Vice City",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.17": {
+    "Name": "Minority Report",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.18": {
+    "Name": "Minority Report",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.22": {
+    "Name": "Robotech Battlecry",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.33": {
+    "Name": "Dark Angel",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_513.39": {
+    "Name": "NFL 2K3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.40": {
+    "Name": "NBA 2K3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.41": {
+    "Name": "NHL 2K3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.43": {
+    "Name": "Galerians - Ash",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.44": {
+    "Name": "Guilty Gear X2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.45": {
+    "Name": "Run Like Hell",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.47": {
+    "Name": "Die Hard - Vendetta",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_513.48": {
+    "Name": "Die Hard - Vendetta",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_513.49": {
+    "Name": "Evolution Skateboarding",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.50": {
+    "Name": "Ben Hur",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.54": {
+    "Name": "Jurassic Park - Operation Genesis",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.55": {
+    "Name": "Big Mutha Truckers",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_513.56": {
+    "Name": "Road Trip Adventure",
+    "Region": "PAL-M3"
+  },
+  "SLES_513.57": {
+    "Name": "G1 Jockey 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.58": {
+    "Name": "Mystic Heroes",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.60": {
+    "Name": "Simpsons Skateboarding",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.61": {
+    "Name": "Simpsons Skateboarding",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.62": {
+    "Name": "Simpsons Skateboarding",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.63": {
+    "Name": "Music 3000",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.65": {
+    "Name": "BMX XXX",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.71": {
+    "Name": "Pride FC",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.72": {
+    "Name": "Wallace & Gromit in Project Zoo",
+    "Region": "PAL-Unk",
+    "Compat": 1
+  },
+  "SLES_513.74": {
+    "Name": "RoboCop",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_513.81": {
+    "Name": "Everblue 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.82": {
+    "Name": "Shrek - Super Party",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.83": {
+    "Name": "Beach King Stunt Racer",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_513.85": {
+    "Name": "Rugrats Rescate Real",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.87": {
+    "Name": "World Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.88": {
+    "Name": "Sega Bass Fishing Duel",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.90": {
+    "Name": "Fightbox",
+    "Region": "PAL-E"
+  },
+  "SLES_513.91": {
+    "Name": "RTL Skispringen 2003",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.92": {
+    "Name": "Evolution Snowboarding",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.93": {
+    "Name": "Syberia",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_513.97": {
+    "Name": "IndyCar Series",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.98": {
+    "Name": "World Championship Snooker 2003",
+    "Region": "PAL-Unk"
+  },
+  "SLES_513.99": {
+    "Name": "Armored Core 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.00": {
+    "Name": "Tenchu - Wrath of Heaven",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.01": {
+    "Name": "Tenchu - Wrath of Heaven",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.02": {
+    "Name": "Tenchu - Wrath of Heaven",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_514.03": {
+    "Name": "Tenchu - Wrath of Heaven",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.09": {
+    "Name": "Frogger Beyond",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.18": {
+    "Name": "Fisherman's Challenge",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_514.23": {
+    "Name": "Celtic - Club Football",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.33": {
+    "Name": "Ghost Vibration",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.34": {
+    "Name": "Silent Hill 3",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_514.35": {
+    "Name": "International Superstar Soccer 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.36": {
+    "Name": "Chessmaster 9000",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.39": {
+    "Name": "Mortal Kombat - Deadly Alliance",
+    "Region": "PAL-G"
+  },
+  "SLES_514.41": {
+    "Name": "Dynasty Warriors 3 - Extreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.42": {
+    "Name": "Dynasty Warriors 3 - Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.43": {
+    "Name": "Dynasty Warriors 3 - Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.45": {
+    "Name": "Rygar - The Legendary Adventure",
+    "Region": "PAL-M5"
+  },
+  "SLES_514.48": {
+    "Name": "Resident Evil - Dead Aim",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_514.49": {
+    "Name": "Return to Castle Wolfenstein - Operation Resurrection",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.51": {
+    "Name": "Whiteout",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.56": {
+    "Name": "LMA Manager 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.58": {
+    "Name": "BDFL Manager 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.60": {
+    "Name": "Football Manager 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.62": {
+    "Name": "Shrek Super Party",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.66": {
+    "Name": "Tom Clancy's Splinter Cell",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_514.67": {
+    "Name": "Freedom Fighters",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.69": {
+    "Name": "Freedom Fighters",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.70": {
+    "Name": "Freedom Fighters",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.73": {
+    "Name": "Kya - Dark Lineage",
+    "Region": "PAL-M5"
+  },
+  "SLES_514.74": {
+    "Name": "Blood Rayne",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_514.76": {
+    "Name": "Mystic Heroes",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.77": {
+    "Name": "Mystic Heroes",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.79": {
+    "Name": "Def Jam Vendetta",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.81": {
+    "Name": "NBA Street 2",
+    "Region": "PAL-M2",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SLES_514.82": {
+    "Name": "Downtown Run",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.88": {
+    "Name": "Tour de France, Le - Centenary Edition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.92": {
+    "Name": "Pro Beach Soccer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.93": {
+    "Name": "Mr. Golf",
+    "Region": "PAL-Unk"
+  },
+  "SLES_514.95": {
+    "Name": "SX Superstar",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_514.96": {
+    "Name": "Breath of Fire - Dragon Quarter",
+    "Region": "PAL-M5"
+  },
+  "SLES_515.03": {
+    "Name": "Ace Lightning",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.04": {
+    "Name": "Chessmaster",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.07": {
+    "Name": "Futurama",
+    "Region": "PAL-M5"
+  },
+  "SLES_515.08": {
+    "Name": "Hulk, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.09": {
+    "Name": "World of Outlaws - Sprint Cars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.10": {
+    "Name": "Dancing Stage Fever MegaMix",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_515.11": {
+    "Name": "Crash Nitro Kart",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.23": {
+    "Name": "Conflict - Desert Storm II",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_515.25": {
+    "Name": "Fallout - Brotherhood of Steel",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.26": {
+    "Name": "Fallout - Brotherhood of Steel",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.41": {
+    "Name": "Grand Theft Auto - San Andreas",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.47": {
+    "Name": "Next Generation Tennis 2003",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.48": {
+    "Name": "This is Football",
+    "Region": "PAL-I-S"
+  },
+  "SLES_515.53": {
+    "Name": "Chaos Legion",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.54": {
+    "Name": "Cell Damage Overdrive",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.55": {
+    "Name": "Play It Pinball",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_515.57": {
+    "Name": "Broken Sword - The Sleeping Dragon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.79": {
+    "Name": "Yu-Gi-Oh! - The Duelists of the Roses",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.80": {
+    "Name": "London Racer World Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.81": {
+    "Name": "Dead to Rights",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_515.84": {
+    "Name": "F1 Career Challenge",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_515.88": {
+    "Name": "Evil Dead - A Fistful of Boomstick (with Bonus DVD Movie)",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.89": {
+    "Name": "Resident Evil - Outbreak",
+    "Region": "PAL-M5"
+  },
+  "SLES_515.90": {
+    "Name": "Cabela's Big Game Hunter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.94": {
+    "Name": "Disney's Piglet's Big Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_515.95": {
+    "Name": "Grand Theft Auto - Vice City",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.00": {
+    "Name": "WWE Crush Hour",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.02": {
+    "Name": "All-Stars Baseball 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.03": {
+    "Name": "Seek & Destroy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.05": {
+    "Name": "Motorsiege - Warriors of Prime Time",
+    "Region": "PAL-E"
+  },
+  "SLES_516.06": {
+    "Name": "Unlimited Saga",
+    "Region": "PAL-E"
+  },
+  "SLES_516.15": {
+    "Name": "King of Route 66, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.16": {
+    "Name": "Virtua Fighter 4 Evolution",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_516.17": {
+    "Name": "Starsky & Hutch",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_516.18": {
+    "Name": "Starsky & Hutch",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.19": {
+    "Name": "Clock Tower 3",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_516.20": {
+    "Name": "Black and Bruised",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.21": {
+    "Name": "Dirt Track Devils",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.22": {
+    "Name": "Maxxed Out Racing",
+    "Region": "PAL-E"
+  },
+  "SLES_516.23": {
+    "Name": "Sniper 2, The",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_516.24": {
+    "Name": "Eternal Quest",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_516.25": {
+    "Name": "Ultimate Mindgames",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.29": {
+    "Name": "International Pool Championship",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.30": {
+    "Name": "Play It Chess Challenger",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_516.33": {
+    "Name": "Racing Simulation 3",
+    "Region": "PAL-M5"
+  },
+  "SLES_516.36": {
+    "Name": "XGRA - Extreme G Racing Association",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.46": {
+    "Name": "Energy Airforce",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_516.49": {
+    "Name": "Judge Dredd vs. Judge Death",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.50": {
+    "Name": "Judge Dredd - Dredd vs. Death",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.53": {
+    "Name": "Mace Griffin - Bounty Hunter",
+    "Region": "PAL-E"
+  },
+  "SLES_516.54": {
+    "Name": "Mace Griffin - Bounty Hunter",
+    "Region": "PAL-G"
+  },
+  "SLES_516.58": {
+    "Name": "Piglet's Big Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.59": {
+    "Name": "Piglet's Big Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.60": {
+    "Name": "Risk - Global Domination",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.61": {
+    "Name": "Dynasty Warriors 4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.62": {
+    "Name": "Dynasty Warriors 4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.63": {
+    "Name": "Dynasty Warriors 4",
+    "Region": "PAL-G"
+  },
+  "SLES_516.64": {
+    "Name": "Dynasty Warriors 4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.65": {
+    "Name": "Dynasty Warriors 4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.66": {
+    "Name": "Piglet's Big Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.67": {
+    "Name": "Piglet's Big Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.68": {
+    "Name": "Piglet's Big Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.70": {
+    "Name": "Alter Echo",
+    "Region": "PAL-E"
+  },
+  "SLES_516.71": {
+    "Name": "Alter Echo",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.75": {
+    "Name": "Psyvariar",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.78": {
+    "Name": "Super Farm",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.80": {
+    "Name": "Splashdown 2 - Rides Gone Wild",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.81": {
+    "Name": "Splashdown 2 - Rides Gone Wild",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.82": {
+    "Name": "Headhunter - Redemption",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.86": {
+    "Name": "Pitfall - The Lost Expedition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.87": {
+    "Name": "Pitfall - The Lost Expedition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.88": {
+    "Name": "Pitfall - The Lost Expedition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.89": {
+    "Name": "Pitfall - The Lost Expedition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.90": {
+    "Name": "Pitfall - The Lost Expedition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.93": {
+    "Name": "Suffering, The",
+    "Region": "PAL-E"
+  },
+  "SLES_516.96": {
+    "Name": "Dragon's Lair 3D - Special Edition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_516.97": {
+    "Name": "SSX 3",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_516.98": {
+    "Name": "Mobile Light Force 2",
+    "Region": "PAL-M5"
+  },
+  "SLES_516.99": {
+    "Name": "Virtua Fighter - 10th Anniversary Edition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.02": {
+    "Name": "Battlestar Galactica - Apostasy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.04": {
+    "Name": "XII Stag",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.05": {
+    "Name": "Ford Racing 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.07": {
+    "Name": "Secret Weapons Over Normandy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.08": {
+    "Name": "Secret Weapons over Normandy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.09": {
+    "Name": "Secret Weapons over Normandy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.10": {
+    "Name": "Secret Weapons over Normandy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.11": {
+    "Name": "Secret Weapons over Normandy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.12": {
+    "Name": "Snowboard Racer 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.13": {
+    "Name": "Bust-A-Bloc",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_517.14": {
+    "Name": "BCV - Battle Construction Vehicles",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.15": {
+    "Name": "Seed, The - War Zone",
+    "Region": "PAL-E"
+  },
+  "SLES_517.16": {
+    "Name": "A-Train 6",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.17": {
+    "Name": "Boxing Champions",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.18": {
+    "Name": "League Series Baseball 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_517.20": {
+    "Name": "Disney's Extreme Skate Adventure",
+    "Region": "PAL-Unk",
+    "vuRoundMode": "0"
+  },
+  "SLES_517.23": {
+    "Name": "Hobbit, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.31": {
+    "Name": "Bust-A-Block",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.32": {
+    "Name": "EA Sports Rugby 2004",
+    "Region": "PAL-E"
+  },
+  "SLES_517.33": {
+    "Name": "EA SPORTS RUGBY 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.35": {
+    "Name": "Perfect Ace - Pro Tournament Tennis",
+    "Region": "PAL-M5"
+  },
+  "SLES_517.41": {
+    "Name": "1945 I & II - The Arcade Games",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.46": {
+    "Name": "Space Invaders - Invasion Day",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_517.49": {
+    "Name": "Mark Davis Pro Bass Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.50": {
+    "Name": "Charlie's Angels",
+    "Region": "PAL-M3",
+    "Compat": 5
+  },
+  "SLES_517.52": {
+    "Name": "Tony Hawks Underground",
+    "Region": "PAL-Unk",
+    "vuRoundMode": "0"
+  },
+  "SLES_517.53": {
+    "Name": "True Crime - Streets of L.A.",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.54": {
+    "Name": "True Crime - Streets of L.A.",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.55": {
+    "Name": "Disney-Pixar's Finding Nemo",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.56": {
+    "Name": "Batman 2 - The Rise of Sin Tsu",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.57": {
+    "Name": "Dancing Stage Fever",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_517.58": {
+    "Name": "Metal Arms - Glitch in the System",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.59": {
+    "Name": "Maximo vs. Army of Zin",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.61": {
+    "Name": "Italian Job, The - L.A. Heist",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.65": {
+    "Name": "Volleyball Xciting",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_517.66": {
+    "Name": "Gladiator - Sword of Vengeance",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.72": {
+    "Name": "Bad Boys II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.78": {
+    "Name": "Summer Heat Beach Volleyball",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_517.82": {
+    "Name": "Fire Warrior",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.83": {
+    "Name": "Starsky & Hutch",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_517.85": {
+    "Name": "Cool Shot",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_517.87": {
+    "Name": "Harry Potter - Quidditch World Cup",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.92": {
+    "Name": "Aliens vs. Predator - Extinction",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.94": {
+    "Name": "Looney Toons - Back in Action",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_517.97": {
+    "Name": "Madden NFL 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.98": {
+    "Name": "NHL 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_517.99": {
+    "Name": "Soul Calibur II",
+    "Region": "PAL-M5",
+    "Compat": 3
+  },
+  "SLES_518.00": {
+    "Name": "Smash Cars Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.06": {
+    "Name": "Evil Dead - A Fistful of Boomstick",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.12": {
+    "Name": "Homerun",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.13": {
+    "Name": "European Tennis Pro",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.14": {
+    "Name": "ATV Off-Road Fury 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.15": {
+    "Name": "Final Fantasy X-2",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_518.16": {
+    "Name": "Final Fantasy X-2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.17": {
+    "Name": "Final Fantasy X-2",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_518.18": {
+    "Name": "Final Fantasy X-2",
+    "Region": "PAL-I"
+  },
+  "SLES_518.19": {
+    "Name": "Final Fantasy X-2",
+    "Region": "PAL-S",
+    "Compat": 5
+  },
+  "SLES_518.21": {
+    "Name": "Alias",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.22": {
+    "Name": "Alias",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.23": {
+    "Name": "Hunter - The Reckoning Wayward",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.24": {
+    "Name": "Colin McRae Rally '04",
+    "Region": "PAL-M5"
+  },
+  "SLES_518.25": {
+    "Name": "Pop Idol",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.26": {
+    "Name": "AFL Live 2004",
+    "Region": "PAL-E"
+  },
+  "SLES_518.28": {
+    "Name": "Gladiator - Sword of Vengeance",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.31": {
+    "Name": "Sphinx and The Cursed Mummy",
+    "Region": "PAL-Unk",
+    "OPHFLagHack": 1
+  },
+  "SLES_518.33": {
+    "Name": "Premier Manager 2003-2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.34": {
+    "Name": "Premier Manager 2003-2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.38": {
+    "Name": "Asterix & Obelix XXL2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.39": {
+    "Name": "DragonBall Z - Budokai 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_518.40": {
+    "Name": "NHL Hitz Pro",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.41": {
+    "Name": "SpyHunter 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.42": {
+    "Name": "Road Kill",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.43": {
+    "Name": "Worms 3D",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.45": {
+    "Name": "Barbie - Horse Adventure",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.46": {
+    "Name": "Deutschland sucht den Superstar",
+    "Region": "PAL-G"
+  },
+  "SLES_518.48": {
+    "Name": "Tony Hawk's Underground",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "vuRoundMode": "0"
+  },
+  "SLES_518.50": {
+    "Name": "Basketball Xciting",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.51": {
+    "Name": "Tony Hawk's Underground",
+    "Region": "PAL-F",
+    "vuRoundMode": "0"
+  },
+  "SLES_518.52": {
+    "Name": "Thug MOTX [Demo]",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SLES_518.53": {
+    "Name": "Tony Hawk's Underground",
+    "Region": "PAL-F",
+    "vuRoundMode": "0"
+  },
+  "SLES_518.54": {
+    "Name": "Tony Hawk Underground",
+    "Region": "PAL-Unk",
+    "vuRoundMode": "0"
+  },
+  "SLES_518.55": {
+    "Name": "Tank Elite",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.56": {
+    "Name": "Monster Attack",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.59": {
+    "Name": "Billiards Xciting",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_518.60": {
+    "Name": "Tennis Court Smash",
+    "Region": "PAL-Unk",
+    "Compat": 3
+  },
+  "SLES_518.61": {
+    "Name": "Bowling Xciting",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.62": {
+    "Name": "Bass Master Fishing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.63": {
+    "Name": "Maze Action",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.64": {
+    "Name": "Police Chase Down",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.65": {
+    "Name": "Heartbeat Boxing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.67": {
+    "Name": "Dynasty Tactics 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.68": {
+    "Name": "Dynasty Tactics 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.69": {
+    "Name": "Dynasty Tactics 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.70": {
+    "Name": "Disney-Pixar's Finding Nemo",
+    "Region": "PAL-"
+  },
+  "SLES_518.71": {
+    "Name": "Disney-Pixar's Finding Nemo",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.72": {
+    "Name": "Disney-Pixar's Finding Nemo",
+    "Region": "PAL-unk"
+  },
+  "SLES_518.73": {
+    "Name": "Medal of Honor - Rising Sun",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_518.74": {
+    "Name": "Medal of Honor - Rising Sun",
+    "Region": "PAL-F"
+  },
+  "SLES_518.75": {
+    "Name": "Medal of Honor - Rising Sun",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.76": {
+    "Name": "Medal of Honor - Rising Sun",
+    "Region": "PAL-F"
+  },
+  "SLES_518.77": {
+    "Name": "Bloody Roar 4",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_518.79": {
+    "Name": "Hot Wheels World Race",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.81": {
+    "Name": "Mercedes Bens World Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.83": {
+    "Name": "Scooby Doo! Mystery Mayhem",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.85": {
+    "Name": "MegaMan X7",
+    "Region": "PAL-M5",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SLES_518.86": {
+    "Name": "Lethal Skies 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.87": {
+    "Name": "Tiger Woods PGA Tour 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.88": {
+    "Name": "RTL Skiijumping 2004",
+    "Region": "PAL-M2"
+  },
+  "SLES_518.90": {
+    "Name": "Buffy the Vampire Slayer - Chaos Bleeds",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "OPHFLagHack": 1
+  },
+  "SLES_518.93": {
+    "Name": "Naval Ops - Warship Gunner",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.96": {
+    "Name": "Gallop Racer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_518.97": {
+    "Name": "Simpsons, The - Hit & Run",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_519.03": {
+    "Name": "AFL Live 2004 - Aussie Rules Football",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.06": {
+    "Name": "Rolling",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.08": {
+    "Name": "Van Helsing",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_519.11": {
+    "Name": "Gadget Racers",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.12": {
+    "Name": "Pro Evolution Soccer 3",
+    "Region": "PAL-M4"
+  },
+  "SLES_519.13": {
+    "Name": "Onimusha Blade Warrior",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.14": {
+    "Name": "Onimusha 3 - Demon Siege",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_519.15": {
+    "Name": "Pro Evolution Soccer 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.16": {
+    "Name": "Crouching Tiger, Hidden Dragon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.17": {
+    "Name": "Beyond Good and Evil",
+    "Region": "PAL-M6"
+  },
+  "SLES_519.18": {
+    "Name": "Prince of Persia - The Sands of Time",
+    "Region": "PAL-M5",
+    "Compat": 4
+  },
+  "SLES_519.24": {
+    "Name": "World War Zero - Ironstorm",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.25": {
+    "Name": "Splashdown 2 - Rides Gone Wild",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.26": {
+    "Name": "Outlaw Golf",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.27": {
+    "Name": "Midway Arcade Treasures",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.30": {
+    "Name": "Road Rage 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.31": {
+    "Name": "Teenage Mutant Ninja Turtles",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_519.32": {
+    "Name": "Jimmy Neutron - Jet Fusion",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.33": {
+    "Name": "Gregory Horror Show",
+    "Region": "PAL-Unk",
+    "Compat": 1
+  },
+  "SLES_519.34": {
+    "Name": "Curse - The Eye of Isis",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.46": {
+    "Name": "Robin Hood - Defender of the Crown",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SLES_519.47": {
+    "Name": "ESPN NFL 2K4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.48": {
+    "Name": "ESPN NHL Hockey 2K4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.49": {
+    "Name": "NBA 2K4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.50": {
+    "Name": "Sonic Heroes",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.51": {
+    "Name": "Puyo Pop Fever",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_519.52": {
+    "Name": "R-Type Final",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "EETimingHack": "1 "
+  },
+  "SLES_519.53": {
+    "Name": "FIFA 2004",
+    "Region": "PAL-E-Sw"
+  },
+  "SLES_519.54": {
+    "Name": "Max Payne 2 - The Fall of Max Payne",
+    "Region": "PAL-Unk",
+    "vuClampMode": 2
+  },
+  "SLES_519.56": {
+    "Name": "Bionicle - The Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.57": {
+    "Name": "Terminator 3 - Rise of the Machines",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.58": {
+    "Name": "Whiplash",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_519.59": {
+    "Name": "Football Generation",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.63": {
+    "Name": "FIFA 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.64": {
+    "Name": "FIFA 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.66": {
+    "Name": "Bombastic",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_519.67": {
+    "Name": "Need for Speed - Underground",
+    "Region": "PAL-M4",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_519.68": {
+    "Name": "Spongebob Squarepants - Battle for Bikini Bottom",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.70": {
+    "Name": "Spongebob Schwammkopf - Schlacht um Bikini Bottom",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_519.72": {
+    "Name": "NBA Jam 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.73": {
+    "Name": "War Chess",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.74": {
+    "Name": "XS Junior League Soccer",
+    "Region": "PAL-E"
+  },
+  "SLES_519.76": {
+    "Name": "Tom Clancy's Ghost Recon - Jungle Storm",
+    "Region": "PAL-M5"
+  },
+  "SLES_519.78": {
+    "Name": "Baphomets Fluch - Der Schlafende Drache",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_519.80": {
+    "Name": "TT Superbikes",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.81": {
+    "Name": "ShellShock - Nam '67",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.82": {
+    "Name": "ShellShock - Nam '67",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.86": {
+    "Name": "Backyard Wrestling - Don't Try This At Home",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.89": {
+    "Name": "Wallace & Gromit in Project Zoo",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_519.91": {
+    "Name": "Dance UK",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.96": {
+    "Name": "International Snooker Championship",
+    "Region": "PAL-M5"
+  },
+  "SLES_519.97": {
+    "Name": "SWAT - Global Strike Team",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SLES_519.98": {
+    "Name": "Kao the Kangaroo - Round 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_519.99": {
+    "Name": "GrooveRider Slot Car Thunder",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.01": {
+    "Name": "Mission Impossible - Operation Surma",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.02": {
+    "Name": "Rogue Ops",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.05": {
+    "Name": "James Bond 007 - Everything or Nothing",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SLES_520.08": {
+    "Name": "NBA Live 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.11": {
+    "Name": "Tak and The Power of Juju",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.15": {
+    "Name": "Les Chevaliers de Baphomet",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.17": {
+    "Name": "Lord of the Rings, The - Return of the King",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_520.18": {
+    "Name": "Lord of the Rings, The - Return of the King (Der Herr der Ringe, Die Ruckkehr des Konigs)",
+    "Region": "PAL-G"
+  },
+  "SLES_520.19": {
+    "Name": "Lord of the Rings, The - Return of the King",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.20": {
+    "Name": "Lord of the Rings, The - The Return of the King",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.21": {
+    "Name": "Lord of the Rings, The - The Return of the King",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.22": {
+    "Name": "Total Club Manager 2004",
+    "Region": "PAL-E"
+  },
+  "SLES_520.23": {
+    "Name": "Manhunt",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.25": {
+    "Name": "NFL Street",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.26": {
+    "Name": "Wallace & Gromit in Project Zoo",
+    "Region": "PAL-G",
+    "Compat": 1
+  },
+  "SLES_520.28": {
+    "Name": "Junior Sports Basketball",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.34": {
+    "Name": "Dr. Seuss' Cat in the Hat",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.36": {
+    "Name": "WWE SmackDown! - Here Comes the Pain!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.38": {
+    "Name": "Terminator 3 - Rise of the Machines",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.41": {
+    "Name": "Detonator",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_520.43": {
+    "Name": "MX Unleashed Migrated",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.44": {
+    "Name": "Crescent Suzuki Racing - Superbikes and Super Sidecars",
+    "Region": "PAL-E"
+  },
+  "SLES_520.45": {
+    "Name": "GTR 400",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_520.46": {
+    "Name": "James Bond 007 - Everything or Nothing (Alles oder Nichts)",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_520.47": {
+    "Name": "Sims, The - Bustin' Out",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_520.48": {
+    "Name": "Sims, The - Bustin' Out",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.55": {
+    "Name": "Harry Potter and the Philosopher's Stone",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_520.56": {
+    "Name": "Harry Potter and The Philosopher's Stone",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_520.58": {
+    "Name": "Groove Rider - Slot Car Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.60": {
+    "Name": "Fame Academy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.61": {
+    "Name": "Star Academy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.62": {
+    "Name": "Pop Star Academy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.63": {
+    "Name": "Alarm for Cobra 11 Autobahn",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.65": {
+    "Name": "Flipnic",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.95": {
+    "Name": "Gradius V",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_520.96": {
+    "Name": "Firefighter F.D. 18",
+    "Region": "PAL-Unk"
+  },
+  "SLES_520.97": {
+    "Name": "SWAT - Global Strike Force",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SLES_521.00": {
+    "Name": "NRL Rugby League",
+    "Region": "PAL-E"
+  },
+  "SLES_521.01": {
+    "Name": "Wrath Unleashed",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.02": {
+    "Name": "Hugo Bukkazoom!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.03": {
+    "Name": "Tak & Le Pouvoir de Juju",
+    "Region": "PAL-F"
+  },
+  "SLES_521.04": {
+    "Name": "Tak and the Power of JuJu",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.06": {
+    "Name": "Cabela's Dangerous Hunts",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.07": {
+    "Name": "Dance Europe",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.08": {
+    "Name": "Underworld - The Eternal War",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.09": {
+    "Name": "Underworld - The Eternal War",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.11": {
+    "Name": "Mojo!",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_521.16": {
+    "Name": "Sitting Duck",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.17": {
+    "Name": "Go Go Copter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.18": {
+    "Name": "Castlevania - Lament of Innocence",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_521.22": {
+    "Name": "Crime Life - Gang Wars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.23": {
+    "Name": "EA Sports Cricket 2004",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_521.24": {
+    "Name": "Kill Switch",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.25": {
+    "Name": "Agassi Tennis Generation",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.32": {
+    "Name": "Hitman - Contracts",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.33": {
+    "Name": "Hitman - Contracts",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.35": {
+    "Name": "Hitman - Contracts",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.36": {
+    "Name": "Hitman - Contracts",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.43": {
+    "Name": "Carmen Sandiego - The Secret of the Stolen Drums",
+    "Region": "PAL-Unk",
+    "Compat": 3
+  },
+  "SLES_521.49": {
+    "Name": "Tom Clancy's Splinter Cell - Pandora Tomorrow",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_521.50": {
+    "Name": "Legacy of Kain - Defiance",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.51": {
+    "Name": "Terminator 3 - Le Macchine Ribelli",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.52": {
+    "Name": "Terminator 3 - Rise of the Machines",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.53": {
+    "Name": "Driver 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.59": {
+    "Name": "Myth Makers Super Kart GP",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.71": {
+    "Name": "Dynasty Warriors 4 - Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.72": {
+    "Name": "Dynasty Warriors 4 - Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.73": {
+    "Name": "Dynasty Warriors 4 - Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.74": {
+    "Name": "Dynasty Warriors 4 - Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.75": {
+    "Name": "Dynasty Warriors 4 - Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_521.78": {
+    "Name": "Casino Challenge",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_521.79": {
+    "Name": "Kaan Barbarian Blade",
+    "Region": "PAL-Unk"
+  },
+  "SLUS_206.75": {
+    "Name": "Baldur's Gate - Dark Alliance 2",
+    "Region": "NTSC-U",
+    "Compat": 4
+  },
+  "SLES_521.87": {
+    "Name": "Baldur's Gate - Dark Alliance 2",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_521.88": {
+    "Name": "Baldur's Gate - Dark Alliance 2",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLPM_658.45": {
+    "Name": "Baldur's Gate - Dark Alliance II",
+    "Region": "NTSC-J",
+    "Compat": 4
+  },
+  "SLES_521.90": {
+    "Name": "RPM Tuning",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SLES_522.02": {
+    "Name": "Downhill Domination",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_522.03": {
+    "Name": "Armored Core - Silent Line",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_522.04": {
+    "Name": "UFC Sudden Impact",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.09": {
+    "Name": "Star Trek - Shattered Universe",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.14": {
+    "Name": "Disney's The Haunted Mansion",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.16": {
+    "Name": "Disney's The Haunted Mansion",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.19": {
+    "Name": "Corvette",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.30": {
+    "Name": "Muppets Party Cruise",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_522.37": {
+    "Name": "dot Hack - Part 1 - Infection",
+    "Region": "PAL-M5"
+  },
+  "SLES_522.38": {
+    "Name": "Nightshade",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_522.40": {
+    "Name": "International Pool Championship",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.41": {
+    "Name": "Myth Makers - Orbs of Doom",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.42": {
+    "Name": "Dalmatians 3",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_522.43": {
+    "Name": "Dinosaur Adventure",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.44": {
+    "Name": "Legend of Herkules",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.46": {
+    "Name": "Pool Paradise",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_522.47": {
+    "Name": "Hobbit, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.49": {
+    "Name": "Premier Manager 2003-2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.56": {
+    "Name": "Max Payne 2 - The Fall of Max Payne",
+    "Region": "PAL-Unk",
+    "vuClampMode": 2
+  },
+  "SLES_522.57": {
+    "Name": "P.T.O. IV - Pacific Theater of Operations IV",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.58": {
+    "Name": "Romance of the Three Kingdoms VIII",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.59": {
+    "Name": "Outlaw Volleyball",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.65": {
+    "Name": "Energy Airforce - Aim Strike!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.66": {
+    "Name": "Energy Airforce - Aim Strike!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.67": {
+    "Name": "Energy Airforce - Aim Strike!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.75": {
+    "Name": "Way of the Samurai 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_522.76": {
+    "Name": "187 - Ride or Die",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.77": {
+    "Name": "Riding Spirits 2",
+    "Region": "PAL-M5",
+    "Compat": 4
+  },
+  "SLES_522.78": {
+    "Name": "Mafia",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_522.79": {
+    "Name": "Mafia",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_522.80": {
+    "Name": "Mafia",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_522.82": {
+    "Name": "Mafia",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.83": {
+    "Name": "Terminator 3 - The Redemption",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.84": {
+    "Name": "Deadly Skies II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.86": {
+    "Name": "Tak and The Poer of JuJu",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.87": {
+    "Name": "Tak and The Poer of JuJu",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.88": {
+    "Name": "Tom Clancy's Rainbow Six 3",
+    "Region": "PAL-E"
+  },
+  "SLES_522.89": {
+    "Name": "MTX Mototrax",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.90": {
+    "Name": "MTX Mototrax",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.91": {
+    "Name": "Countryside Bears",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.92": {
+    "Name": "Disney's Mighty Mulan",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.93": {
+    "Name": "Disney's Son of the Lion King",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.94": {
+    "Name": "Toys Room, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_522.95": {
+    "Name": "Master Chess",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_522.98": {
+    "Name": "IndyCar Series 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.08": {
+    "Name": "Karaoke Stage",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.09": {
+    "Name": "R - Racing",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_523.12": {
+    "Name": "World Championship Rugby",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.13": {
+    "Name": "Space Invaders Anniversary",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_523.14": {
+    "Name": "Hugo - Bukkazoom",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.22": {
+    "Name": "Drakengard",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SLES_523.23": {
+    "Name": "Richard Burns Rally",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.25": {
+    "Name": "Champions of Norrath - Realms of EverQuest",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.26": {
+    "Name": "Spawn - Armageddon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.36": {
+    "Name": "Max Payne 2 - The Fall of Max Payne",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SLES_523.37": {
+    "Name": "Max Payne 2 - The Fall of Max Payne",
+    "Region": "PAL-Unk",
+    "vuClampMode": 2
+  },
+  "SLES_523.38": {
+    "Name": "Max Payne 2 - The Fall of Max Payne",
+    "Region": "PAL-Unk",
+    "vuClampMode": 2
+  },
+  "SLES_523.39": {
+    "Name": "Crash 'n Burn",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_523.40": {
+    "Name": "Rollercoaster World",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.41": {
+    "Name": "X-Files - Resist or Serve",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.42": {
+    "Name": "Worms - Forts Under Seige",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_523.43": {
+    "Name": "Midway Arcade Treasures",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.48": {
+    "Name": "Seven Samurai 20XX",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.49": {
+    "Name": "International Golf Pro",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.50": {
+    "Name": "International Golf Pro",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.58": {
+    "Name": "Glass Rose",
+    "Region": "PAL-E"
+  },
+  "SLES_523.62": {
+    "Name": "Bad Boys II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.63": {
+    "Name": "Bad Boys II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.66": {
+    "Name": "America's 10 Most Wanted",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.67": {
+    "Name": "America's 10 Most Wanted",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.68": {
+    "Name": "AFL Live - Premiership Edition",
+    "Region": "PAL-E"
+  },
+  "SLES_523.69": {
+    "Name": "Empires of Atlantis",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.70": {
+    "Name": "Mouse Police, The",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_523.71": {
+    "Name": "Animal Soccer World",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.72": {
+    "Name": "Spider-Man 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.74": {
+    "Name": "Fight Night 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.78": {
+    "Name": "Euro Rally Champion",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_523.79": {
+    "Name": "Shrek 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.80": {
+    "Name": "Shrek 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.81": {
+    "Name": "Shrek 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.82": {
+    "Name": "Shrek 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.83": {
+    "Name": "Shrek 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.84": {
+    "Name": "Project Zero 2 - Crimson Butterfly",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_523.85": {
+    "Name": "England International Football",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_523.86": {
+    "Name": "World Championship Snooker 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.87": {
+    "Name": "SpyHunter 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.88": {
+    "Name": "Transformers Armada - Prelude to Energon [Special Edition]",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "VIFFIFOHack": 1
+  },
+  "SLES_523.93": {
+    "Name": "Pinball Fun",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.94": {
+    "Name": "UFEA Euro 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.95": {
+    "Name": "UFEA Euro 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.96": {
+    "Name": "Euro 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.97": {
+    "Name": "Euro 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_523.98": {
+    "Name": "Euro 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.02": {
+    "Name": "Perfect Ace 2 - The Championships",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.03": {
+    "Name": "Formula Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.04": {
+    "Name": "MTV Music Generator 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.13": {
+    "Name": "Malice",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_524.18": {
+    "Name": "Powerdrome",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.23": {
+    "Name": "Smash Court Tennis - Pro Tournament 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.33": {
+    "Name": "Goblin Commander - Unleash The Horde",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.39": {
+    "Name": "Suffering, The",
+    "Region": "PAL-E"
+  },
+  "SLES_524.40": {
+    "Name": "Harry Potter and the Prisoner of Azkaban",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.44": {
+    "Name": "Hyper Street Fighter II - The Anniversary Edition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.45": {
+    "Name": "Silent Hill 4 - The Room",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_524.46": {
+    "Name": "Mashed",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.48": {
+    "Name": "Knights of the Temple",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.49": {
+    "Name": "Kidz Sports Basketball",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.50": {
+    "Name": "Serious Sam - Next Encounter",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_524.51": {
+    "Name": "Conan - The Dark Axe",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.57": {
+    "Name": "Shrek 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.58": {
+    "Name": "Disgaea - Hour of Darkness",
+    "Region": "PAL-E"
+  },
+  "SLES_524.59": {
+    "Name": "Autobahn Raser - Das Spiel zum Film",
+    "Region": "PAL-G"
+  },
+  "SLES_524.66": {
+    "Name": "Ribbit King",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.67": {
+    "Name": "dot Hack - Part 2 - Mutation",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_524.68": {
+    "Name": "dot Hack - Part 4 - Quarantine",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_524.69": {
+    "Name": "dot Hack - Part 3 - Outbreak",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_524.71": {
+    "Name": "Naval Ops - Commander",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.72": {
+    "Name": "Project Minerva",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.77": {
+    "Name": "Vegas Casino II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.78": {
+    "Name": "Red Dead Revolver",
+    "Region": "PAL-M5",
+    "Compat": 4
+  },
+  "SLES_524.79": {
+    "Name": "Samurai Jack - The Shadow of Aku",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.80": {
+    "Name": "Yu-Gi-Oh! - The Duelists of the Roses",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.81": {
+    "Name": "Hot Wheels - Stunt Track Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.82": {
+    "Name": "Steel Dragon EX",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_524.83": {
+    "Name": "World Championship Pool 2004",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.86": {
+    "Name": "Astroboy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.90": {
+    "Name": "Dance UK - Extra Trax",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.93": {
+    "Name": "Spider-Man 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_524.95": {
+    "Name": "Bujingai - Swordmaster",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.04": {
+    "Name": "Trivial Pursuit Unhinged",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.05": {
+    "Name": "Spy Fiction",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.07": {
+    "Name": "Def Jam - Fight for New York",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_525.08": {
+    "Name": "Obscure",
+    "Region": "PAL-G"
+  },
+  "SLES_525.09": {
+    "Name": "Tiger Woods PGA Tour Golf 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.10": {
+    "Name": "Neo Contra",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_525.11": {
+    "Name": "Headhunter - Redemption (EX)",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.12": {
+    "Name": "Headhunter - Redemption",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.15": {
+    "Name": "Ultimate Casino",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_525.16": {
+    "Name": "World Fighting",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.17": {
+    "Name": "Radio Helicopter",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_525.18": {
+    "Name": "Motorbike King",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "eeClampMode": 3
+  },
+  "SLES_525.19": {
+    "Name": "Pink Pong",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_525.20": {
+    "Name": "Volleyball Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.21": {
+    "Name": "Adibou & Les Voleurs d'Energie",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.23": {
+    "Name": "Cocoto - Platform Jumper",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.25": {
+    "Name": "Mouse Trophy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.27": {
+    "Name": "Harry Potter og Fangen fra Azkaban",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.31": {
+    "Name": "Suffering, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.32": {
+    "Name": "Aces of War",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.33": {
+    "Name": "Zoo Puzzle",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.34": {
+    "Name": "Crimson Tears",
+    "Region": "PAL-M3"
+  },
+  "SLES_525.35": {
+    "Name": "Rumble Roses",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_525.36": {
+    "Name": "Shark Tale",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.37": {
+    "Name": "Shark Tale",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.39": {
+    "Name": "Shark Tale",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.41": {
+    "Name": "Grand Theft Auto - San Andreas",
+    "Region": "PAL-M5",
+    "Compat": 4
+  },
+  "SLES_525.44": {
+    "Name": "Trivial Pursuit Unhinged",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.45": {
+    "Name": "Star Wars Battlefront",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_525.46": {
+    "Name": "Star Wars Battlefront",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.47": {
+    "Name": "Star Wars Battlefront",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.51": {
+    "Name": "Samurai Warriors",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.53": {
+    "Name": "Samurai Warriors",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.55": {
+    "Name": "Samurai Warriors",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.56": {
+    "Name": "Crimson Sea 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.57": {
+    "Name": "Crimson Sea 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.58": {
+    "Name": "Crimson Sea 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.59": {
+    "Name": "FIFA 2005",
+    "Region": "PAL-E"
+  },
+  "SLES_525.60": {
+    "Name": "FIFA 2005",
+    "Region": "PAL-G"
+  },
+  "SLES_525.61": {
+    "Name": "FIFA 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.62": {
+    "Name": "FIFA 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.63": {
+    "Name": "FIFA Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.67": {
+    "Name": "Catwoman",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.68": {
+    "Name": "Crash Twinsanity",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "XgKickHack": "1 "
+  },
+  "SLES_525.69": {
+    "Name": "Spyro - A Hero's Tail",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_525.70": {
+    "Name": "Area 51",
+    "Region": "PAL-R",
+    "Compat": 5
+  },
+  "SLES_525.71": {
+    "Name": "Pacific Air Warriors 2 - Dogfight",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.72": {
+    "Name": "Operation Air Assault",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.73": {
+    "Name": "Conflict - Global Storm",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.76": {
+    "Name": "Yu-Gi-Oh! - Capsule Monster Colisee",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.79": {
+    "Name": "Legends of Wrestling - Showdown",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.81": {
+    "Name": "Madden NFL 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.84": {
+    "Name": "Burnout 3 - Takedown",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_525.85": {
+    "Name": "Burnout 3 - Takedown",
+    "Region": "PAL-F-G-I"
+  },
+  "SLES_525.87": {
+    "Name": "Army Men - Sarge's War",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_525.88": {
+    "Name": "Mercenaries",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.90": {
+    "Name": "Mercenaries",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.91": {
+    "Name": "Dynasty Warriors 4 - Empires",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.92": {
+    "Name": "Dynasty Warriors 4 - Empires",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.93": {
+    "Name": "Dynasty Warriors 4 - Empires",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.94": {
+    "Name": "U-Move SuperSports",
+    "Region": "PAL-Unk"
+  },
+  "SLES_525.98": {
+    "Name": "Dancing Stage Fusion",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_525.99": {
+    "Name": "Metal Slug 3",
+    "Region": "PAL-M5"
+  },
+  "SLES_526.00": {
+    "Name": "Harry Potter and The Prisoner of Azkaban",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.01": {
+    "Name": "Ex Zeus",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.02": {
+    "Name": "GT Racers",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_526.03": {
+    "Name": "Room Zoom - Race for Impact",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.05": {
+    "Name": "Polar Express, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.16": {
+    "Name": "Video Poker & Blackjack",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.17": {
+    "Name": "Stock Car Speedway",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.20": {
+    "Name": "Guncom 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.21": {
+    "Name": "Tony Hawk's Underground 2",
+    "Region": "PAL-Unk",
+    "vuRoundMode": "0"
+  },
+  "SLES_526.22": {
+    "Name": "Tony Hawk's Underground 2",
+    "Region": "PAL-Unk",
+    "vuRoundMode": "0"
+  },
+  "SLES_526.24": {
+    "Name": "X-Men Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.25": {
+    "Name": "X-Men Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.28": {
+    "Name": "NBA Ballers",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.30": {
+    "Name": "Conflict - Vietnam",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.31": {
+    "Name": "Digimon Rumble Arena 2",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "FpuCompareHack": 1
+  },
+  "SLES_526.36": {
+    "Name": "Colin McRae Rally 2005",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_526.37": {
+    "Name": "TOCA Racer Driver 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.38": {
+    "Name": "DTM Race Driver 2",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_526.39": {
+    "Name": "V8 Supercars 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.41": {
+    "Name": "Leisure Suit Larry - Magna Cum Laude - Uncut",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.42": {
+    "Name": "Leisure Suit Larry - Magne cum Laude",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.43": {
+    "Name": "Leisure Suit Larry - Magna Cum Laude",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.44": {
+    "Name": "Leisure Suit Larry - Magna Cum Laude",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.45": {
+    "Name": "Leisure Suit Larry - Magne cum Laude",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.46": {
+    "Name": "Tom Clancy's Ghost Recon 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.47": {
+    "Name": "Club Football - Manchester United 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.48": {
+    "Name": "BVB 09 - Club Football 2005 - Borussia Dortmund",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.49": {
+    "Name": "Om Droit au Bit - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.50": {
+    "Name": "Juventus - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.51": {
+    "Name": "FC Barcelona - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.52": {
+    "Name": "Liverpool FC - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.53": {
+    "Name": "Liverpool FC - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.54": {
+    "Name": "Club Football - Real Madri 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.55": {
+    "Name": "FC Bayern Munich - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.56": {
+    "Name": "AC Milan Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.57": {
+    "Name": "Arsenal FC - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.58": {
+    "Name": "Hamburg SV - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.59": {
+    "Name": "Paris Saint-Germain Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.60": {
+    "Name": "Inter - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.61": {
+    "Name": "Ajax Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.62": {
+    "Name": "Newcastle United - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.63": {
+    "Name": "Chelsea FC - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.64": {
+    "Name": "Rangers FC - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.65": {
+    "Name": "Celtic FC - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.66": {
+    "Name": "Tottenham Hotspur - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.67": {
+    "Name": "Birmingham City - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.68": {
+    "Name": "Aston Villa FC - Club Football 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.69": {
+    "Name": "Forgotten Realms - Demon Stone",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_526.70": {
+    "Name": "Second Sight",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_526.71": {
+    "Name": "Ghostmaster",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.73": {
+    "Name": "NHL 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.74": {
+    "Name": "Fussball Manager 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.75": {
+    "Name": "Hugo Cannon Cruise",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.78": {
+    "Name": "Viewtiful Joe",
+    "Region": "PAL-M5"
+  },
+  "SLES_526.80": {
+    "Name": "Intellivision Lives - The History of Video Gaming",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.84": {
+    "Name": "Cyclone Circus - Power Sail Racing",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_526.85": {
+    "Name": "Polar Express, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.86": {
+    "Name": "Backyard Wrestling - There Goes the Neighborhood",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.93": {
+    "Name": "LMA Manager 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_526.94": {
+    "Name": "BDFL Manager 2005",
+    "Region": "PAL-G"
+  },
+  "SLES_526.95": {
+    "Name": "Roger Lemerre - La Selection des Champions",
+    "Region": "PAL-F"
+  },
+  "SLES_526.97": {
+    "Name": "Manager de la Liga 2005",
+    "Region": "PAL-S"
+  },
+  "SLES_527.00": {
+    "Name": "Jimmy Neutron - Attack of the Twonkies",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.01": {
+    "Name": "Future Tactics - The Uprising",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.02": {
+    "Name": "Psi-Ops - The Mindgate Conspiracy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.03": {
+    "Name": "Psi-Ops - The Mindgate Conspiracy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.05": {
+    "Name": "Mortal Kombat - Deception",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.06": {
+    "Name": "Mortal Kombat - Deception",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.07": {
+    "Name": "Monster Hunter",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.09": {
+    "Name": "Ty the Tazmanian Tiger 2 - Bush Rescue",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.10": {
+    "Name": "McFarlane's Evil Prophecy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.11": {
+    "Name": "Titeuf Mega Compet",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.13": {
+    "Name": "NBA Live 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.14": {
+    "Name": "Board Games Gallery",
+    "Region": "PAL-E"
+  },
+  "SLES_527.16": {
+    "Name": "Energy Thieves, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.17": {
+    "Name": "Brian Lara Cricket 2005",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.18": {
+    "Name": "Fight Club",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.19": {
+    "Name": "Under the Skin",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.20": {
+    "Name": "Ford Racing 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.25": {
+    "Name": "Need for Speed - Underground 2",
+    "Region": "PAL-E",
+    "Compat": 4
+  },
+  "SLES_527.26": {
+    "Name": "NBA Live 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.27": {
+    "Name": "NBA Live 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.29": {
+    "Name": "Animaniacs - The Great Edgar Hunt",
+    "Region": "PAL-E",
+    "Compat": 4
+  },
+  "SLES_527.30": {
+    "Name": "DragonBall Z - Budokai 3",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.31": {
+    "Name": "One Piece - Round the Land!",
+    "Region": "PAL-M3"
+  },
+  "SLES_527.33": {
+    "Name": "Driven to Destruction",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.34": {
+    "Name": "Worms Forts - Under Siege",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.37": {
+    "Name": "Obscure",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.38": {
+    "Name": "Obscure",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.45": {
+    "Name": "Hugo - CannonCruise",
+    "Region": "PAL-M4"
+  },
+  "SLES_527.47": {
+    "Name": "Dukes of Hazzard, The - The Return of General Lee",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.49": {
+    "Name": "Habitrail - Hamster Ball",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.50": {
+    "Name": "Monster Trux Extreme",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.51": {
+    "Name": "Offroad Extreme!",
+    "Region": "PAL-E"
+  },
+  "SLES_527.52": {
+    "Name": "Playboy - The Mansion",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.53": {
+    "Name": "Flatout",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.54": {
+    "Name": "FlatOut",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.55": {
+    "Name": "Blood Will Tell",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.60": {
+    "Name": "Pro Evolution Soccer 4",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.61": {
+    "Name": "Rocky - Legends",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.66": {
+    "Name": "Godzilla - Save The Earth",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.67": {
+    "Name": "Hugo - CannonCruise",
+    "Region": "PAL-M4"
+  },
+  "SLES_527.68": {
+    "Name": "Commandos - Strike Force",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.73": {
+    "Name": "Pool Shark 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.74": {
+    "Name": "Sprint Car Challenge",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_527.76": {
+    "Name": "Junior Board Games",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_527.78": {
+    "Name": "Arcade, The",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_527.79": {
+    "Name": "Poker Masters",
+    "Region": "PAL-M6"
+  },
+  "SLES_527.81": {
+    "Name": "WWE SmackDown! vs. RAW",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.82": {
+    "Name": "Call of Duty - Finest Hour",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.83": {
+    "Name": "Call of Duty - Le Jour de Glorie",
+    "Region": "PAL-F"
+  },
+  "SLES_527.84": {
+    "Name": "Call of Duty - Finest Hour",
+    "Region": "PAL-G"
+  },
+  "SLES_527.98": {
+    "Name": "Vietcong - Purple Haze",
+    "Region": "PAL-Unk"
+  },
+  "SLES_527.99": {
+    "Name": "Vietcong - Purple Haze",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.00": {
+    "Name": "Pro Evolution Soccer 4",
+    "Region": "PAL-I"
+  },
+  "SLES_528.01": {
+    "Name": "Lord of the Rings, The - The Third Age",
+    "Region": "PAL-M5"
+  },
+  "SLES_528.02": {
+    "Name": "Lord of the Rings, The - The Third Age",
+    "Region": "PAL-F"
+  },
+  "SLES_528.03": {
+    "Name": "Lord of the Rings, The - The Third Age (Der Herr der Ringe - Das dritte Zeitalter)",
+    "Region": "PAL-G"
+  },
+  "SLES_528.04": {
+    "Name": "Lord of the Rings, The - The Third Age",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.05": {
+    "Name": "Lord of the Rings, The - The Third Age",
+    "Region": "PAL-S"
+  },
+  "SLES_528.07": {
+    "Name": "Lemony Snicket's A Series of Unfortunate Events",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.08": {
+    "Name": "Lemony Snicket's A Series of Unfortunate Events",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.09": {
+    "Name": "Lemony Snicket - Schauriger Schlamassel",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.10": {
+    "Name": "Lemony Snicket's Una Serie Disfortunati Eventi",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.11": {
+    "Name": "Get on da Mic",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.12": {
+    "Name": "Disney-Pixar's The Incredibles",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.13": {
+    "Name": "Incredibles, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.14": {
+    "Name": "Incredibles, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.15": {
+    "Name": "Disney-Pixar's The Incredibles",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.16": {
+    "Name": "Incredibles, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.20": {
+    "Name": "Incredibles, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.21": {
+    "Name": "Incredibles, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.22": {
+    "Name": "Prince of Persia - Warrior Within",
+    "Region": "PAL-M6"
+  },
+  "SLES_528.24": {
+    "Name": "Furry Tales",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.25": {
+    "Name": "Lemony Snicket's A Series of Unfortunate Events",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.31": {
+    "Name": "Syberia 2",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_528.32": {
+    "Name": "MegaMan X - Command Mission",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.34": {
+    "Name": "Sega Superstars Eyetoy Bundle",
+    "Region": "PAL-Unk",
+    "Compat": 1
+  },
+  "SLES_528.35": {
+    "Name": "Mummy, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.36": {
+    "Name": "Knight Rider 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_528.43": {
+    "Name": "Garfield",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.44": {
+    "Name": "Midway Arcade Treasures 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.45": {
+    "Name": "Gadget and the Gadgetinis",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.52": {
+    "Name": "Capcom Fighting Jam",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.53": {
+    "Name": "Miami Vice",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.54": {
+    "Name": "Capcom Fighting Jam",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_528.57": {
+    "Name": "Fairly Odd Parents, The - Shadow Showdown",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.58": {
+    "Name": "Cocoto Kart Racer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.59": {
+    "Name": "Project - Snowblind",
+    "Region": "PAL-E"
+  },
+  "SLES_528.61": {
+    "Name": "King Arthur",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.63": {
+    "Name": "Pinball Hall of Fame",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_528.64": {
+    "Name": "MX World Tour",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.67": {
+    "Name": "Spindrive Ping Pong",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.68": {
+    "Name": "Viewtiful Joe 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.72": {
+    "Name": "Constantine",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.74": {
+    "Name": "Dark Wind (with Gametrak)",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.76": {
+    "Name": "King of Fighters 2000-2001",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.77": {
+    "Name": "Haunting Ground",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_528.82": {
+    "Name": "Stolen",
+    "Region": "PAL-M5",
+    "Compat": 3
+  },
+  "SLES_528.84": {
+    "Name": "Duel Masters",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.85": {
+    "Name": "Sega Superstars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.86": {
+    "Name": "Power Rangers Dino Thunder",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.87": {
+    "Name": "Power Rangers Dino Thunder",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.88": {
+    "Name": "Brothers in Arms - Road to Hill 30",
+    "Region": "PAL-R"
+  },
+  "SLES_528.89": {
+    "Name": "Disney's Winnie the Pooh Rumbly Tumbly Adventure",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.95": {
+    "Name": "Spongebob Squarepants - The Movie",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.96": {
+    "Name": "Spongebob Squarepants - The Movie",
+    "Region": "PAL-Unk"
+  },
+  "SLES_528.98": {
+    "Name": "King of Fighters - Maximum Impact",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.00": {
+    "Name": "Rapala Pro Fishing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.02": {
+    "Name": "Arcade Classics Vol.1",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.06": {
+    "Name": "Spongebob and Friends - Movin'",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.08": {
+    "Name": "Urbz, The - Sims in the City",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_529.09": {
+    "Name": "UEFA Champions League 2004-2005",
+    "Region": "PAL-E-G"
+  },
+  "SLES_529.10": {
+    "Name": "UEFA Champions League 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.11": {
+    "Name": "UEFA Champions League 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.12": {
+    "Name": "UEFA Champions League 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.13": {
+    "Name": "Suikoden IV",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_529.15": {
+    "Name": "Shark Tale",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.17": {
+    "Name": "Scaler",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_529.18": {
+    "Name": "Scaler",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.19": {
+    "Name": "NRL Rugby League 2",
+    "Region": "PAL-E"
+  },
+  "SLES_529.21": {
+    "Name": "Rogue Trooper",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.22": {
+    "Name": "EyeToy - Disney Move",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.27": {
+    "Name": "Grand Theft Auto - San Andreas",
+    "Region": "PAL-G"
+  },
+  "SLES_529.31": {
+    "Name": "Legend of Kay",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_529.39": {
+    "Name": "Airborne Troops - Countdown to D-Day",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.40": {
+    "Name": "S.L.A.I. Steel Lancer Arena International",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.41": {
+    "Name": "Gungrave - Overdose",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.42": {
+    "Name": "Midnight Club 3 - DUB Edition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.43": {
+    "Name": "ESPN NFL 2K5",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.44": {
+    "Name": "Robotech - Invasion",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.49": {
+    "Name": "Arcade Action - 30 Games",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.50": {
+    "Name": "Shadow of Rome",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_529.51": {
+    "Name": "Phantom Brave",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_529.54": {
+    "Name": "WWII - Tank Battles",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.55": {
+    "Name": "Deadly Strike",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.56": {
+    "Name": "Action Girlz Racing",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_529.57": {
+    "Name": "Urban Extreme",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.58": {
+    "Name": "Premier Manager 2004-2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.60": {
+    "Name": "Premier Manager 2004-2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.61": {
+    "Name": "Premier Manager 2004-2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.63": {
+    "Name": "Cold Winter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.64": {
+    "Name": "NanoBreaker",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_529.65": {
+    "Name": "Outlaw Golf 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_529.66": {
+    "Name": "ESPN NHL 2K5",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.67": {
+    "Name": "Guilty Gear X2 Reloaded",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_529.68": {
+    "Name": "Burnout 2 - Point of Impact",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_529.73": {
+    "Name": "Ski Racing 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.74": {
+    "Name": "GoldenEye - Rogue Agent",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.75": {
+    "Name": "GoldenEye - Au Service du Mal",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.76": {
+    "Name": "GoldenEye - Rogue Agent",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.77": {
+    "Name": "GoldenEye - Rogue Agent",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.78": {
+    "Name": "La Pucelle Tactics",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.80": {
+    "Name": "Big Mutha Truckers 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.82": {
+    "Name": "NFL Street 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.83": {
+    "Name": "Fitness Fun",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.84": {
+    "Name": "Panzer Front Ausf B",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.85": {
+    "Name": "Spongebob Squarepants - The Movie",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.86": {
+    "Name": "Spongebob Squarepants - The Movie",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.88": {
+    "Name": "MegaMan X8",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.89": {
+    "Name": "Blowout",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.93": {
+    "Name": "TimeSplitters - Future Perfect",
+    "Region": "PAL-Unk"
+  },
+  "SLES_529.98": {
+    "Name": "Sonic Mega Collection Plus",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_529.99": {
+    "Name": "RC Toy Machines",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.00": {
+    "Name": "Crazy Golf",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.01": {
+    "Name": "NBA Street 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.02": {
+    "Name": "Samurai Warriors Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.03": {
+    "Name": "Samurai Warriors Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.04": {
+    "Name": "Samurai Warriors Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.05": {
+    "Name": "Monster Trux - Off-Road Edition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.06": {
+    "Name": "Hamster Heroes",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.07": {
+    "Name": "Tom Clancy's Splinter Cell - Chaos Theory",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_530.11": {
+    "Name": "Gallop Racer 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.12": {
+    "Name": "Tenchu - Fatal Shadows",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.13": {
+    "Name": "Tenchu - Fatal Shadows",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.14": {
+    "Name": "Tenchu - Fatal Shadows",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.15": {
+    "Name": "Tenchu - Fatal Shadows",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.16": {
+    "Name": "Tenchu - Fatal Shadows",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_530.17": {
+    "Name": "Teenage Mutant Ninja Turtles 2 - Battle Nexus",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.20": {
+    "Name": "Ghost in the Shell - Stand Alone Complex",
+    "Region": "PAL-M5"
+  },
+  "SLES_530.21": {
+    "Name": "Gunbird - Special Edition",
+    "Region": "PAL-M3",
+    "Compat": 5
+  },
+  "SLES_530.22": {
+    "Name": "ESPN NBA 2K5",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.23": {
+    "Name": "RTL Ski Jump 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.24": {
+    "Name": "Altered Beast",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SLES_530.25": {
+    "Name": "Red Ninja - End of Honor",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.26": {
+    "Name": "Red Ninja - End of Honor",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.27": {
+    "Name": "Championship Manager 5",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.28": {
+    "Name": "Hitman - Blood Money",
+    "Region": "PAL-E"
+  },
+  "SLES_530.29": {
+    "Name": "Hitman - Blood Money",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.30": {
+    "Name": "Hitman - Blood Money",
+    "Region": "PAL-G"
+  },
+  "SLES_530.31": {
+    "Name": "Hitman - Blood Money",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.32": {
+    "Name": "Hitman - Blood Money",
+    "Region": "PAL-S"
+  },
+  "SLES_530.35": {
+    "Name": "Masters of the Universe - He-Man - Defender of Greyskull",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_530.36": {
+    "Name": "Tak 2 - The Stuff of Dreams",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.37": {
+    "Name": "Super Monkey Ball Deluxe",
+    "Region": "PAL-M5",
+    "Compat": 3
+  },
+  "SLES_530.38": {
+    "Name": "Devil May Cry 3 - Dante's Awakening",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "eeRoundMode": "0"
+  },
+  "SLES_530.39": {
+    "Name": "Champions - Return to Arms",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_530.41": {
+    "Name": "RTL Ski Alpine 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.44": {
+    "Name": "Juiced",
+    "Region": "PAL-R",
+    "Compat": 5
+  },
+  "SLES_530.45": {
+    "Name": "Street Racing Syndicate",
+    "Region": "PAL-Unk",
+    "Compat": 3
+  },
+  "SLES_530.46": {
+    "Name": "CT Special Forces - Fire for Effect",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.47": {
+    "Name": "Punisher, The",
+    "Region": "PAL-M2"
+  },
+  "SLES_530.49": {
+    "Name": "Punisher, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.52": {
+    "Name": "Robots",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.58": {
+    "Name": "Ricky Ponting International Cricket",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.59": {
+    "Name": "Samurai Showdown V",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_530.60": {
+    "Name": "Asterix & Obelix XXL 2 - Mission Las Vegum",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.61": {
+    "Name": "Atari Anthology",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.62": {
+    "Name": "Yu Yu Hakuhso - Dark Tournament",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.73": {
+    "Name": "Michigan : Report from Hell",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_530.64": {
+    "Name": "FIFA Street",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_530.65": {
+    "Name": "SNK vs. Capcom - SVC Chaos",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_530.74": {
+    "Name": "Soccer Life",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.75": {
+    "Name": "Area 51",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.76": {
+    "Name": "Triggerman",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.78": {
+    "Name": "Spy vs. Spy",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_530.79": {
+    "Name": "Ys - The Ark of Napishtim",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_530.80": {
+    "Name": "Extreme Sprint 3010",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.82": {
+    "Name": "World Championship Snooker 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.84": {
+    "Name": "Fight Night Round 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.87": {
+    "Name": "TOCA Race Driver 3",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_530.88": {
+    "Name": "DTM Race Driver 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.89": {
+    "Name": "V8 Supercars 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.90": {
+    "Name": "Circuit Blasters",
+    "Region": "PAL-M5"
+  },
+  "SLES_530.91": {
+    "Name": "Predator - Concrete Jungle",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.92": {
+    "Name": "Motocross Mania 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.93": {
+    "Name": "Cold Winter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.94": {
+    "Name": "Rugby 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.95": {
+    "Name": "Rugby 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.96": {
+    "Name": "Worms 4 - Mayhem",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_530.98": {
+    "Name": "Conspiracy - Weapons of Mass Destruction",
+    "Region": "PAL-Unk"
+  },
+  "SLES_530.99": {
+    "Name": "Pilot Down - Behind Enemy Lines",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.00": {
+    "Name": "Scooby Doo! Unmasked",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.04": {
+    "Name": "Tom Clancy's Rainbow Six - Lockdown",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.06": {
+    "Name": "MX vs. ATV Unleashed",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.07": {
+    "Name": "Cabela's Big Game Hunter 2005 Adventures",
+    "Region": "PAL-E"
+  },
+  "SLES_531.08": {
+    "Name": "American Chopper",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.14": {
+    "Name": "Full Spectrum Warrior",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_531.19": {
+    "Name": "Kessen III",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.20": {
+    "Name": "Kessen III",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.21": {
+    "Name": "Kessen III",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_531.24": {
+    "Name": "Project Snowblind",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.25": {
+    "Name": "Enthusia - Professional Racing",
+    "Region": "PAL-Unk",
+    "eeClampMode": 3
+  },
+  "SLES_531.27": {
+    "Name": "Teenage Mutant Ninja Turtles - Mutant Melee",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.29": {
+    "Name": "Tak 2 - The Staff of Dreams",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.30": {
+    "Name": "World Championship Poker",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.31": {
+    "Name": "Full Spectrum Warrior",
+    "Region": "PAL-R",
+    "EETimingHack": 1
+  },
+  "SLES_531.38": {
+    "Name": "Outlaw Volleyball - Remixed",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.39": {
+    "Name": "Alien Humanoid",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_531.40": {
+    "Name": "Choro Q",
+    "Region": "PAL-E"
+  },
+  "SLES_531.41": {
+    "Name": "X-Treme Quads",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_531.42": {
+    "Name": "Doomsday Racers",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.43": {
+    "Name": "Fantastic Four",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.44": {
+    "Name": "Four Fantastiques, Les",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.45": {
+    "Name": "Fantastic Four",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.46": {
+    "Name": "I Fantastici Quattro",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.47": {
+    "Name": "Four Fantasticos, Los",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.48": {
+    "Name": "Fruitfall",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.50": {
+    "Name": "10 Pin - Champions' Alley",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.51": {
+    "Name": "Juiced",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.52": {
+    "Name": "Mashed Fully Loaded",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.54": {
+    "Name": "Bard's Tale",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.55": {
+    "Name": "Star Wars - Episode III - Revenge of the Sith",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_531.56": {
+    "Name": "Star Wars - Episode III - La Revanche des Sith",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.57": {
+    "Name": "Star Wars - Episode III - Die Rache der Sith",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.58": {
+    "Name": "Cold Fear",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SLES_531.72": {
+    "Name": "Strike Force Bowling",
+    "Region": "PAL-M5"
+  },
+  "SLES_531.74": {
+    "Name": "Golden Age of Racing",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_531.75": {
+    "Name": "Top Spin",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_531.86": {
+    "Name": "International Super Karts",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.90": {
+    "Name": "Girl Zone",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_531.91": {
+    "Name": "Kaido Racer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.92": {
+    "Name": "Nightmare Before Christmas, The - Tim Burton's",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.94": {
+    "Name": "LEGO Star Wars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.95": {
+    "Name": "Punisher, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.96": {
+    "Name": "Destroy All Humans!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.97": {
+    "Name": "Destroy All Humans!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_531.99": {
+    "Name": "25 to Life",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.00": {
+    "Name": "DragonBall Z - Budokai Tenkaichi",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_532.01": {
+    "Name": "Saint Seiya Chapter Sanctuary",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_532.03": {
+    "Name": "Punisher, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.18": {
+    "Name": "Dancing Stage MAX",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.19": {
+    "Name": "Winx Club",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.21": {
+    "Name": "l'Entraineur 5",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.22": {
+    "Name": "Scudetto 5",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.23": {
+    "Name": "Championship Manager 5",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.24": {
+    "Name": "Championship Manager 5",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.25": {
+    "Name": "Dreamworks' Madagascar",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.26": {
+    "Name": "Dreamworks' Madagascar",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_532.27": {
+    "Name": "Madagascar",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.33": {
+    "Name": "Assault Suits Valken",
+    "Region": "PAL-E"
+  },
+  "SLES_532.34": {
+    "Name": "Samurai Western",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_532.35": {
+    "Name": "Syberia II",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_532.36": {
+    "Name": "Buzzrod Fishing Fantasy",
+    "Region": "PAL-E"
+  },
+  "SLES_532.37": {
+    "Name": "Fire Heroes",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.38": {
+    "Name": "Premier Manager 2005-2006",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.42": {
+    "Name": "Madagascar",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.46": {
+    "Name": "Madagascar",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.80": {
+    "Name": "7 Sins",
+    "Region": "PAL-M3",
+    "Compat": 5
+  },
+  "SLES_532.81": {
+    "Name": "Fantastic Four",
+    "Region": "PAL-Unk"
+  },
+  "SLES_532.82": {
+    "Name": "Harvest Fishing",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_532.84": {
+    "Name": "Guilty Gear Isuka",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_532.87": {
+    "Name": "Tom Clancy's Splinter Cell - Chaos Theory",
+    "Region": "PAL-M3"
+  },
+  "SLES_532.96": {
+    "Name": "Ford Mustang - The Legend Lives",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_532.97": {
+    "Name": "7 Sins",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_532.99": {
+    "Name": "Delta Force - Black Hawk Down",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.00": {
+    "Name": "SOCOM 3 - U.S. Navy SEALs",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.01": {
+    "Name": "Bomberman Hardball",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_533.03": {
+    "Name": "Skijumping 2006",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.09": {
+    "Name": "Transformers",
+    "Region": "PAL-Unk",
+    "VIFFIFOHack": 1
+  },
+  "SLES_533.11": {
+    "Name": "Graffiti Kingdom",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.17": {
+    "Name": "Black Market Bowling",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.18": {
+    "Name": "Crazy Golf - World Tour",
+    "Region": "PAL-M6"
+  },
+  "SLES_533.19": {
+    "Name": "Resident Evil Outbreak - File #2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.20": {
+    "Name": "S.C.A.R. - Squadra Corse Alfa Romeo",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.22": {
+    "Name": "Obscure",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.32": {
+    "Name": "Medal of Honor - European Assault",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.33": {
+    "Name": "Medal of Honor - Les Faucons de Guerre",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.34": {
+    "Name": "Medal of Honor - European Assault",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.35": {
+    "Name": "Medal of Honor - European Assault",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.36": {
+    "Name": "Medal of Honor - European Assault",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.38": {
+    "Name": "Victorious Boxers 2 - Fighting Spirit",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.39": {
+    "Name": "Dynasty Warriors 5",
+    "Region": "PAL-E"
+  },
+  "SLES_533.41": {
+    "Name": "Dynasty Warriors 5",
+    "Region": "PAL-G",
+    "Compat": 5
+  },
+  "SLES_533.42": {
+    "Name": "EA Sports Cricket 2005",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.44": {
+    "Name": "Gerrilla Strike",
+    "Region": "PAL-E"
+  },
+  "SLES_533.46": {
+    "Name": "DragonBall Z - Budokai 3 [Collector's Edition]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.50": {
+    "Name": "Sonic Gems Collection",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_533.51": {
+    "Name": "SSX On Tour",
+    "Region": "PAL-E"
+  },
+  "SLES_533.54": {
+    "Name": "Superbike GP",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.56": {
+    "Name": "Colosseum - Road to Freedom",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.57": {
+    "Name": "Colosseum - Road to Freedom",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.60": {
+    "Name": "Alarm for Cobra 11 Vol.2 - Hot Pursuit",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.61": {
+    "Name": "Stealth Force - The War on Terror",
+    "Region": "PAL-E"
+  },
+  "SLES_533.62": {
+    "Name": "Alpine Skiing 2005",
+    "Region": "PAL-E"
+  },
+  "SLES_533.63": {
+    "Name": "Shin Megami Tensei - Lucifer's Call",
+    "Region": "PAL-M3"
+  },
+  "SLES_533.66": {
+    "Name": "Killer 7",
+    "Region": "PAL-M3",
+    "Compat": 5
+  },
+  "SLES_533.67": {
+    "Name": "Dodgeball",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_533.68": {
+    "Name": "Splatter Master",
+    "Region": "PAL-E"
+  },
+  "SLES_533.69": {
+    "Name": "Twenty-2 Party",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_533.70": {
+    "Name": "Real World Golf [with Gametrak]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.71": {
+    "Name": "Real World Golf [with Gametrak]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.73": {
+    "Name": "Madagascar",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.74": {
+    "Name": "X-Men Legends II - Rise of Apocalypse",
+    "Region": "PAL-M3"
+  },
+  "SLES_533.77": {
+    "Name": "X-Men Legends II - Rise of Apocalypse",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.80": {
+    "Name": "Metal Slug 4",
+    "Region": "PAL-E"
+  },
+  "SLES_533.81": {
+    "Name": "King of Fighters 2002",
+    "Region": "PAL-E"
+  },
+  "SLES_533.82": {
+    "Name": "King of Fighters 2003",
+    "Region": "PAL-E"
+  },
+  "SLES_533.83": {
+    "Name": "Metal Slug 5",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_533.86": {
+    "Name": "Charlie and the Chocolate Factory",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_533.87": {
+    "Name": "Batman Begins",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.90": {
+    "Name": "Ultimate Spider-Man",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.91": {
+    "Name": "Ultimate Spider-Man",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.93": {
+    "Name": "Spartan Total Warrior",
+    "Region": "PAL-Unk"
+  },
+  "SLES_533.98": {
+    "Name": "Zombie Zone",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_533.99": {
+    "Name": "Yakuza Fury",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.02": {
+    "Name": "Taxi Rider",
+    "Region": "PAL-E"
+  },
+  "SLES_534.03": {
+    "Name": "Demolition Girl",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_534.05": {
+    "Name": "Digimon World 4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.06": {
+    "Name": "Party Girls",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_534.07": {
+    "Name": "Street Boyz",
+    "Region": "PAL-E"
+  },
+  "SLES_534.08": {
+    "Name": "Fighting Angels",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_534.11": {
+    "Name": "Kuon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.14": {
+    "Name": "Echo Night - Beyond",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.15": {
+    "Name": "Call of Duty 2 - Big Red One",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.16": {
+    "Name": "Call of Duty 2 - Big Red One",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.17": {
+    "Name": "Call of Duty 2 - Big Red One",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.18": {
+    "Name": "Tak - The Great JuJu Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.19": {
+    "Name": "LA Rush",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.24": {
+    "Name": "Dead to Rights 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.30": {
+    "Name": "Incredible Hulk 2, The - Ultimate Destruction",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.33": {
+    "Name": "NHL '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.34": {
+    "Name": "WWI - Red Baron",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.35": {
+    "Name": "SAS Anti-Terror Force",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.36": {
+    "Name": "YetiSports Arctic Adventures",
+    "Region": "PAL-E"
+  },
+  "SLES_534.38": {
+    "Name": "Taito Legends",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_534.39": {
+    "Name": "Crash Tag Team Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.41": {
+    "Name": "Heroes of the Pacific",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.43": {
+    "Name": "Warriors, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.44": {
+    "Name": "Pro Evolution Soccer 5",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.46": {
+    "Name": "Arcade USA",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_534.52": {
+    "Name": "Trixie in Toyland",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.57": {
+    "Name": "Evil Dead - Regeneration",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.58": {
+    "Name": "Shin Megami Tensei - Digital Devil Saga",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_534.59": {
+    "Name": "Marc Ecko's Getting Up - Contents Under Pressure",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.61": {
+    "Name": "Sega Classics Collection",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_534.62": {
+    "Name": "Matrix, The - Path of Neo",
+    "Region": "PAL-M5"
+  },
+  "SLES_534.63": {
+    "Name": "NHL '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.66": {
+    "Name": "Il Grande Quiz sul Calcio Italiano",
+    "Region": "PAL-I"
+  },
+  "SLES_534.68": {
+    "Name": "Family Boardgames",
+    "Region": "PAL-M6"
+  },
+  "SLES_534.71": {
+    "Name": "LMA Manager 2006",
+    "Region": "PAL-M5"
+  },
+  "SLES_534.73": {
+    "Name": "Incredibles, The - Rise of the Underminer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.74": {
+    "Name": "Incredibles, The - Rise of the Underminer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.80": {
+    "Name": "Harvest Moon - A Wonderful Life [Special Edition]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.81": {
+    "Name": "10,000 Bullets",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_534.83": {
+    "Name": "Magne Carta",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_534.84": {
+    "Name": "Eagle Eye Golf",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.87": {
+    "Name": "Forty 4 Party",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.88": {
+    "Name": "Puzzlemaniacs",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.89": {
+    "Name": "Paparazzi",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_534.90": {
+    "Name": "Outlaw Tennis",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.92": {
+    "Name": "Total Overdose",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.94": {
+    "Name": "Spongebob Squarepants - Lights, Camera, PANTS!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_534.96": {
+    "Name": "Spongebob Squarepants - Lights, Camera, PANTS!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.01": {
+    "Name": "Star Wars - Battlefront II",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_535.02": {
+    "Name": "Star Wars - Battlefront II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.04": {
+    "Name": "Agent Hugo",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.05": {
+    "Name": "Beat Down - Fists of Vengeance",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.06": {
+    "Name": "Burnout Revenge",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_535.07": {
+    "Name": "Burnout Revenge",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_535.08": {
+    "Name": "Ultimate Pro-Pinball",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_535.09": {
+    "Name": "Hello Kitty - Roller Rescue",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.10": {
+    "Name": "Madden NFL 2006",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.18": {
+    "Name": "Castle Shikigami II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.21": {
+    "Name": "Musashi - Samurai Legend",
+    "Region": "PAL-M4"
+  },
+  "SLES_535.23": {
+    "Name": "Gun",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.24": {
+    "Name": "Mortal Kombat - Shaolin Monks",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.25": {
+    "Name": "Mortal Kombat - Shaolin Monks",
+    "Region": "PAL-G"
+  },
+  "SLES_535.27": {
+    "Name": "Suffering, The - Ties that Bind",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.28": {
+    "Name": "Suffering, The - Ties that Bind",
+    "Region": "PAL-G"
+  },
+  "SLES_535.29": {
+    "Name": "FIFA '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.30": {
+    "Name": "FIFA '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.31": {
+    "Name": "FIFA '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.32": {
+    "Name": "FIFA '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.33": {
+    "Name": "FIFA '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.34": {
+    "Name": "Tony Hawk's American Wasteland",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_535.35": {
+    "Name": "Tony Hawk's American Wasteland",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.36": {
+    "Name": "London Racer - Police Madness",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_535.39": {
+    "Name": "Fahrenheit",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_535.40": {
+    "Name": "Fahrenheit",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_535.41": {
+    "Name": "Tiger Woods PGA Tour '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.42": {
+    "Name": "Shadow the Hedgehog",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.44": {
+    "Name": "Pro Evolution Soccer 5",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_535.45": {
+    "Name": "Pro Evolution Soccer 5",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.46": {
+    "Name": "NBA Live 2006",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.47": {
+    "Name": "NBA Live '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.48": {
+    "Name": "Yokushin - Giga Wing Generations",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.51": {
+    "Name": "SSX On Tour",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.52": {
+    "Name": "SSX On Tour",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.53": {
+    "Name": "James Bond 007 - From Russia with Love",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.57": {
+    "Name": "Need for Speed - Most Wanted",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_535.58": {
+    "Name": "Need for Speed - Most Wanted",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.59": {
+    "Name": "Need for Speed - Most Wanted",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.60": {
+    "Name": "Sonic Riders",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_535.61": {
+    "Name": "Canis Canem Edit",
+    "Region": "PAL-E"
+  },
+  "SLES_535.63": {
+    "Name": "Spongebob Squarepants and Friends - Untie!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.64": {
+    "Name": "Darkwatch",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.66": {
+    "Name": "London Taxi - Rushour",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.69": {
+    "Name": "Mini Mini Desktop Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.70": {
+    "Name": "Ninjabread Man",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_535.71": {
+    "Name": "Anubis II",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_535.72": {
+    "Name": "Rig Racer 2",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_535.74": {
+    "Name": "Bratz - Rock Angelz",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.75": {
+    "Name": "Bratz - Rock Angelz",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.76": {
+    "Name": "Bratz - Rock Angelz",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.77": {
+    "Name": "Bratz - Rock Angelz",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.78": {
+    "Name": "Bratz - Rock Angelz",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.79": {
+    "Name": "One Piece - Grand Battle",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.80": {
+    "Name": "NBA Live '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.81": {
+    "Name": "NBA Live '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.82": {
+    "Name": "Bratz - Rock Angelz",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.83": {
+    "Name": "Bratz - Rock Angelz",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.85": {
+    "Name": "Marvel Nemesis - Rise of the Imperfects",
+    "Region": "PAL-Unk",
+    "Compat": 3
+  },
+  "SLES_535.87": {
+    "Name": "Garfield - Saving Arlene",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.92": {
+    "Name": "Zombie Attack",
+    "Region": "PAL-E"
+  },
+  "SLES_535.94": {
+    "Name": "Living World Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_535.95": {
+    "Name": "Wild Water Adrenaline featuring Salomon",
+    "Region": "PAL-M5"
+  },
+  "SLES_535.96": {
+    "Name": "The Ultimate Film Quiz",
+    "Region": "PAL-M6"
+  },
+  "SLES_535.99": {
+    "Name": "The Ultimate Music Quiz",
+    "Region": "PAL-M6"
+  },
+  "SLES_536.14": {
+    "Name": "Classic British Motor Racing",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_536.16": {
+    "Name": "True Crime - New York City",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.18": {
+    "Name": "True Crime - New York City",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.21": {
+    "Name": "Wallace & Grommit - The Curse of the Were Rabbit",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.23": {
+    "Name": "Spongebob Squarepants - Battle for Bikini Bottom",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.24": {
+    "Name": "Disney-Pixar's Cars",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_536.26": {
+    "Name": "Suffering, The - Ties that Bind",
+    "Region": "PAL-M2"
+  },
+  "SLES_536.35": {
+    "Name": "NASCAR '06 - Total Team Control",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.39": {
+    "Name": "Ford Street Racing",
+    "Region": "PAL-M5"
+  },
+  "SLES_536.41": {
+    "Name": "Destroy All Humans!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.45": {
+    "Name": "Knights of the Temple II",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_536.46": {
+    "Name": "World Racing 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.47": {
+    "Name": "Gun",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.51": {
+    "Name": "WWII - Soldier",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.52": {
+    "Name": "Daemon Summoner",
+    "Region": "PAL-E"
+  },
+  "SLES_536.54": {
+    "Name": "London Racer - Destruction Madness",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_536.56": {
+    "Name": "Full Spectrum Warrior - Ten Hammers",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_536.57": {
+    "Name": "Shrek - Super Slam",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.58": {
+    "Name": "Disney-Pixar's The Incredibles - Rise of the Underminer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.59": {
+    "Name": "Brothers in Arms - Earned in Blood",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.61": {
+    "Name": "Capcom Classics Collection",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.66": {
+    "Name": "Midway Arcade Treasures 3",
+    "Region": "PAL-E"
+  },
+  "SLES_536.67": {
+    "Name": "Gauntlet - Seven Sorrows",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_536.68": {
+    "Name": "Micro Machines v4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.76": {
+    "Name": "WWE SmackDown! vs. RAW 2006",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_536.77": {
+    "Name": "WWE SmackDown! vs. RAW 2006",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.82": {
+    "Name": "James Pond - Codename Robocod",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_536.85": {
+    "Name": "Codename: Kids Next Door - Operation V.I.D.E.O.G.A.M.E",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_536.86": {
+    "Name": "NHL Hockey 2K6",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.89": {
+    "Name": "World Poker Tour 2K6",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.90": {
+    "Name": "Makai Kingdon - Chronicle of the Sacred Stone",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.95": {
+    "Name": "Tak - The Great Juju Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.96": {
+    "Name": "Zathura",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_536.97": {
+    "Name": "Dora the Explorer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_536.99": {
+    "Name": "Swords of Destiny",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_537.01": {
+    "Name": "Super Monkey Ball Adventure",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_537.02": {
+    "Name": "Resident Evil 4",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_537.03": {
+    "Name": "King Kong, Peter Jackson's - The Official Game of the Movie",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SLES_537.04": {
+    "Name": "King Kong, Peter Jackson's - The Official Game of the Movie",
+    "Region": "PAL-R"
+  },
+  "SLES_537.05": {
+    "Name": "King Kong, Peter Jackson's - The Official Game of the Movie",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.06": {
+    "Name": "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_537.07": {
+    "Name": "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.08": {
+    "Name": "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.09": {
+    "Name": "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.10": {
+    "Name": "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.12": {
+    "Name": "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.13": {
+    "Name": "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.15": {
+    "Name": "Disney's The Chronicles of Narnia - The Lion, The Witch, and The Wardrobe",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.16": {
+    "Name": "Without Warning",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.17": {
+    "Name": "Midnight Club 3 - DUB Edition Remix",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.18": {
+    "Name": "Sims 2, The",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_537.22": {
+    "Name": "Call of Duty 2 - Big Red One [Collector's Edition]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.24": {
+    "Name": "World Series of Poker",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.25": {
+    "Name": "Asterix & Obelix XXL2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.26": {
+    "Name": "Harry Potter and The Goblet of Fire",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.27": {
+    "Name": "Harry Potter and The Goblet of Fire",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.28": {
+    "Name": "Harry Potter and The Goblet of Fire",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.29": {
+    "Name": "Battlefield 2 - Modern Combat",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.30": {
+    "Name": "Battlefield 2 - Modern Combat",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.34": {
+    "Name": "50cent - Bulletproof",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.36": {
+    "Name": "Billy the Wizard - Rocket Broomstick Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.38": {
+    "Name": "Disney's Chicken Little",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.39": {
+    "Name": "Disney's Chicken Little",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.40": {
+    "Name": "Disney's Chicken Little",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.41": {
+    "Name": "Disney's Chicken Little",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.43": {
+    "Name": "Disney's Chicken Little",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.44": {
+    "Name": "Disney's Chicken Little",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.46": {
+    "Name": "Superman Returns",
+    "Region": "PAL-E"
+  },
+  "SLES_537.47": {
+    "Name": "Ed, Edd, 'n Eddy - The Misadventure",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.48": {
+    "Name": "Quest for Sleeping Beauty",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.51": {
+    "Name": "Shrek Superslam",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.54": {
+    "Name": "ATV Off-Road Fury 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.55": {
+    "Name": "Castlevania - Curse of Darkness",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "vuClampMode": "0"
+  },
+  "SLES_537.56": {
+    "Name": "Resident Evil 4",
+    "Region": "PAL-M5"
+  },
+  "SLES_537.59": {
+    "Name": "Matrix, The - Path of Neo",
+    "Region": "PAL-M5"
+  },
+  "SLES_537.60": {
+    "Name": "Rugby Challenge 2006",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.61": {
+    "Name": "Friends - The One with All the Trivia",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.63": {
+    "Name": "Tom Clancy's Ghost Recon - Advanced Warfighter",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.64": {
+    "Name": "Atelier Iris - Eternal Mana",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.65": {
+    "Name": "Stella Deus - The Gate of Eternity",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.67": {
+    "Name": "Magna Carta",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.68": {
+    "Name": "Sword of Etheria, The",
+    "Region": "PAL-M5",
+    "Compat": 4
+  },
+  "SLES_537.69": {
+    "Name": "Suikoden Tactics",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.72": {
+    "Name": "Air Raid 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.75": {
+    "Name": "Reservoir Dogs",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_537.77": {
+    "Name": "Prince of Persia - The Two Thrones",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_537.78": {
+    "Name": "Jacked",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.79": {
+    "Name": "American Chopper 2 - Full Throttle",
+    "Region": "PAL-E"
+  },
+  "SLES_537.94": {
+    "Name": "Drakengard 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.96": {
+    "Name": "FIFA Street 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_537.97": {
+    "Name": "FIFA Street 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_537.99": {
+    "Name": "Matrix, The - Path of Neo",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SLES_538.00": {
+    "Name": "Rampage - Total Destruction",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.03": {
+    "Name": "Friends - Das Trivia Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.04": {
+    "Name": "Shamu's Deep Sea Adventures",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.10": {
+    "Name": "Sensible Soccer 2006",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_538.13": {
+    "Name": "Friends - Celui qui Repond a Toutes les Questions",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.19": {
+    "Name": "Armored Core - Nine Breaker",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.20": {
+    "Name": "Armored Core - Last Raven",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.24": {
+    "Name": "Trapt",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_538.25": {
+    "Name": "Project Zero 3 - The Tormented",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_538.26": {
+    "Name": "Tom Clancy's Splinter Cell - Double Agent",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_538.27": {
+    "Name": "Tom Clancy's Splinter Cell - Double Agent",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.28": {
+    "Name": "We Love Katamari",
+    "Region": "PAL-Unk",
+    "vuClampMode": 3,
+    "mvuFlagSpeedHack": "0"
+  },
+  "SLES_538.29": {
+    "Name": "Raiden III",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_538.30": {
+    "Name": "Psychonauts",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.31": {
+    "Name": "BloodRayne 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_538.32": {
+    "Name": "BloodRayne 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.46": {
+    "Name": "Soccer Life II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.47": {
+    "Name": "Street Golfer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.48": {
+    "Name": "Flow - Urban Dance Uprising",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_538.49": {
+    "Name": "Asterix & Obelix XXL2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.50": {
+    "Name": "Teenage Mutant Ninja Turtles 3 - Mutant Nightmare",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.52": {
+    "Name": "Taito Legends 2",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_538.55": {
+    "Name": "Heracles - Battle with the Gods",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.57": {
+    "Name": "Need for Speed - Most Wanted [Black Edition]",
+    "Region": "PAL-E"
+  },
+  "SLES_538.60": {
+    "Name": "Dynasty Warriors 5 - Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.61": {
+    "Name": "Dynasty Warriors 5 - Xtreme Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.62": {
+    "Name": "Dynasty Warriors 5 - Xtreme Legends",
+    "Region": "PAL-G"
+  },
+  "SLES_538.63": {
+    "Name": "Pool Paradise - International Edition",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_538.66": {
+    "Name": "Over the Hedge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.67": {
+    "Name": "Ski Alpin 2006",
+    "Region": "PAL-Unk",
+    "vuClampMode": 2
+  },
+  "SLES_538.69": {
+    "Name": "Crazy Frog Racer",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_538.70": {
+    "Name": "Devil Kings",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_538.71": {
+    "Name": "Tengai",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.72": {
+    "Name": "Samurai Aces",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.73": {
+    "Name": "Sol Divide",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_538.74": {
+    "Name": "Dragon Blaze",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.77": {
+    "Name": "Premier Manager 2006-2007",
+    "Region": "PAL-Unk"
+  },
+  "SLES_538.86": {
+    "Name": "Black",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "vuClampMode": "0"
+  },
+  "SLES_538.97": {
+    "Name": "Dreamworks Vecinos Invasores",
+    "Region": "PAL-S"
+  },
+  "SLES_538.99": {
+    "Name": "Pro Evolution Soccer Management",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.00": {
+    "Name": "Kaido Racer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.01": {
+    "Name": "Torino 2006",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "vuClampMode": 2
+  },
+  "SLES_539.02": {
+    "Name": "Leaderboard Golf",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.03": {
+    "Name": "Franklin the Turtle",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.04": {
+    "Name": "DT Racer",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.06": {
+    "Name": "50cent - Bulletproof",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.08": {
+    "Name": "Tomb Raider - Legend",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_539.09": {
+    "Name": "Full Spectrum Warrior - Ten Hammers",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_539.10": {
+    "Name": "Agent Hugo",
+    "Region": "PAL-R"
+  },
+  "SLES_539.13": {
+    "Name": "Plan, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.14": {
+    "Name": "Plan, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.15": {
+    "Name": "Space War Attack",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.17": {
+    "Name": "G1 Jockey 4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.20": {
+    "Name": "Speed Machines 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.21": {
+    "Name": "Sim Chemist",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.22": {
+    "Name": "Car Wash Tycoon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.24": {
+    "Name": "Combat Ace",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.34": {
+    "Name": "G-Force",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.35": {
+    "Name": "Dynamite",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.36": {
+    "Name": "Snow Rider",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.40": {
+    "Name": "Smarties Meltdown",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.45": {
+    "Name": "Championship Manager 2006",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.48": {
+    "Name": "Winter Sports",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.49": {
+    "Name": "Magne Carta",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.52": {
+    "Name": "Cue Academy, The (Snooker-Pool-Billiards)",
+    "Region": "PAL-M5"
+  },
+  "SLES_539.55": {
+    "Name": "Friends - The One with All the Trivia",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.56": {
+    "Name": "Aeon Flux",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_539.59": {
+    "Name": "Pac-Man World 3",
+    "Region": "PAL-Unk",
+    "EETimingHack": 1
+  },
+  "SLES_539.63": {
+    "Name": "Downhill Slalom",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.64": {
+    "Name": "Homura",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.65": {
+    "Name": "Plan, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.66": {
+    "Name": "Taito Legends",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.67": {
+    "Name": "Godfather, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.68": {
+    "Name": "Godfather, The (Le Parrain)",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.70": {
+    "Name": "Godfather, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.71": {
+    "Name": "Godfather, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.72": {
+    "Name": "Stock Car Crash",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_539.74": {
+    "Name": "Dragon Quest VIII - Journey of the Cursed King",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_539.76": {
+    "Name": "Evolution GT",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.79": {
+    "Name": "Torrente 3 - El Protector",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.82": {
+    "Name": "Fight Night Round 3",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.84": {
+    "Name": "Ice Age 2 - The Meltdown",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.87": {
+    "Name": "Over the Hedge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.88": {
+    "Name": "Over the Hedge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.89": {
+    "Name": "Over the Hedge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.91": {
+    "Name": "Urban Chaos - Riot Response",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.94": {
+    "Name": "50cent - Bulletproof",
+    "Region": "PAL-Unk"
+  },
+  "SLES_539.96": {
+    "Name": "Army Men - Major Malfunction",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_539.98": {
+    "Name": "OutRun 2006 - Coast 2 Coast",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_539.99": {
+    "Name": "King of Fighters, The - Neo Wave",
+    "Region": "PAL-E"
+  },
+  "SLES_540.02": {
+    "Name": "FlatOut 2",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_540.03": {
+    "Name": "Flatout 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.04": {
+    "Name": "Disney-Pixar's Cars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.06": {
+    "Name": "Disney-Pixar's Cars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.07": {
+    "Name": "Disney-Pixar's Cars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.10": {
+    "Name": "Disney-Pixar's Cars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.11": {
+    "Name": "Disney-Pixar's Cars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.12": {
+    "Name": "Disney-Pixar's Cars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.13": {
+    "Name": "World Snooker Championship 2007",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.15": {
+    "Name": "Disney-Pixar's Cars",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.16": {
+    "Name": "and 1 Streetball",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.21": {
+    "Name": "Ruff Trigger",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.23": {
+    "Name": "Bible Game, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.27": {
+    "Name": "Driver - Parallel Lines",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.30": {
+    "Name": "Black",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "vuClampMode": "0"
+  },
+  "SLES_540.31": {
+    "Name": "Da Vinci Code, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.33": {
+    "Name": "Search and Destroy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.60": {
+    "Name": "Fruit Machine Mania",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.61": {
+    "Name": "FIFA World Cup - Germany '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.62": {
+    "Name": "FIFA World Cup - Germany '06",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.63": {
+    "Name": "FIFA World Cup 2006",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.64": {
+    "Name": "FIFA World Cup 2006",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.66": {
+    "Name": "X-Men - The Official Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.68": {
+    "Name": "AFL Premiership 2006",
+    "Region": "PAL-E"
+  },
+  "SLES_540.74": {
+    "Name": "Speedboat GP",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.75": {
+    "Name": "ProStroke Golf - World Tour 2007",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.80": {
+    "Name": "World Super Police",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.81": {
+    "Name": "FIFA World Cup 2006",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.83": {
+    "Name": "Pirates of the Caribbean - The Legend of Jack Sparrow",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.84": {
+    "Name": "PowerShot Pinball",
+    "Region": "PAL-M6",
+    "Compat": 5
+  },
+  "SLES_540.85": {
+    "Name": "Street Fighter Alpha Anthology",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.87": {
+    "Name": "Suikoden V",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_540.89": {
+    "Name": "State of Emergency 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.93": {
+    "Name": "Guitar Hero",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.95": {
+    "Name": "Dynasty Warriors 5 - Empires",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.96": {
+    "Name": "Dynasty Warriors 5 - Empires",
+    "Region": "PAL-Unk"
+  },
+  "SLES_540.97": {
+    "Name": "Dynasty Warriors 5 - Empires",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.06": {
+    "Name": "Kidz Sports - Ice Hockey",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.07": {
+    "Name": "Kidz Sports - Basketball",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.08": {
+    "Name": "Habitrail - Hamster Ball",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.09": {
+    "Name": "Off-Road Extreme! [Special Edition]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.10": {
+    "Name": "Monster Trux Arenas [Special Edition]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.11": {
+    "Name": "PDC World Championship Darts",
+    "Region": "PAL-M6"
+  },
+  "SLES_541.12": {
+    "Name": "Myth Makers - Orbs of Doom",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.13": {
+    "Name": "Myth Makers - Super Kart GP",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.14": {
+    "Name": "Kingdom Hearts II",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_541.15": {
+    "Name": "Delta Force - Black Hawk Down - Team Sabre",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_541.16": {
+    "Name": "Operation Winback 2 - Project Poseidon",
+    "Region": "PAL-E"
+  },
+  "SLES_541.17": {
+    "Name": "Torrente 3 - El Protector",
+    "Region": "PAL-E"
+  },
+  "SLES_541.18": {
+    "Name": "Da Vinci Code, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.20": {
+    "Name": "The Snow Queen Quest",
+    "Region": "PAL-M6"
+  },
+  "SLES_541.23": {
+    "Name": "Marvel - Ultimate Alliance",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.26": {
+    "Name": "Family Guy - The Video Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.30": {
+    "Name": "Spy Hunter - Nowhere to Run",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.32": {
+    "Name": "Guitar Hero",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_541.35": {
+    "Name": "Grand Theft Auto - Liberty City Stories",
+    "Region": "PAL-M5",
+    "Compat": 4
+  },
+  "SLES_541.36": {
+    "Name": "Grand Theft Auto - Liberty City Stories",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.37": {
+    "Name": "Just Cause",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.38": {
+    "Name": "Steambot Chronicles",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.39": {
+    "Name": "Earache - Extreme Metal Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.40": {
+    "Name": "Playwize Poker & Casino",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.43": {
+    "Name": "Hard Rock Casino",
+    "Region": "PAL-M5"
+  },
+  "SLES_541.46": {
+    "Name": "Crusty Demons",
+    "Region": "PAL-M5"
+  },
+  "SLES_541.50": {
+    "Name": "Bionicle Heroes",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.51": {
+    "Name": "Let's Make a Soccer Team!",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.52": {
+    "Name": "Ant Bully, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.53": {
+    "Name": "Virtua Pro Football",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.54": {
+    "Name": "D-Unit Drift Racing",
+    "Region": "PAL-E"
+  },
+  "SLES_541.55": {
+    "Name": "Drag Racer USA",
+    "Region": "PAL-E"
+  },
+  "SLES_541.56": {
+    "Name": "Mortal Kombat - Armageddon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.58": {
+    "Name": "Hummer Badlands",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.59": {
+    "Name": "Eragon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.60": {
+    "Name": "Eragon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.61": {
+    "Name": "Super DragonBall Z",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.62": {
+    "Name": "Saint Seiya - The Hades",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_541.63": {
+    "Name": "Naruto - Ultimate Ninja",
+    "Region": "PAL-F"
+  },
+  "SLES_541.64": {
+    "Name": "DragonBall Z Budokai - Tenkaichi 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_541.65": {
+    "Name": "One Piece - Grand Adventure",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.66": {
+    "Name": "Call of Duty 3",
+    "Region": "PAL-Unk",
+    "eeClampMode": 3
+  },
+  "SLES_541.67": {
+    "Name": "Call of Duty 3",
+    "Region": "PAL-S",
+    "eeClampMode": 3
+  },
+  "SLES_541.68": {
+    "Name": "Call of Duty 3",
+    "Region": "PAL-Unk",
+    "eeClampMode": 3
+  },
+  "SLES_541.69": {
+    "Name": "Aeon Flux",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.70": {
+    "Name": "Jaws Unleashed",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.71": {
+    "Name": "Yakuza",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_541.72": {
+    "Name": "Garfield 2 - Tale of Two Kitties",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_541.74": {
+    "Name": "Zoocube",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.78": {
+    "Name": "Ant Bully, The",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.79": {
+    "Name": "Pirates of the Caribbean - At World's End",
+    "Region": "PAL-M6"
+  },
+  "SLES_541.81": {
+    "Name": "Gottlieb Pinball Classics",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_541.82": {
+    "Name": "Scarface - The World is Yours",
+    "Region": "PAL-F"
+  },
+  "SLES_541.83": {
+    "Name": "Scarface - The World is Yours",
+    "Region": "PAL-G"
+  },
+  "SLES_541.84": {
+    "Name": "Scarface - The World is Yours",
+    "Region": "PAL-R"
+  },
+  "SLES_541.85": {
+    "Name": "Dirge of Cerberus - Final Fantasy VII",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_541.86": {
+    "Name": "Devil May Cry 3 - Dante's Awakening [Special Edition]",
+    "Region": "PAL-E",
+    "eeRoundMode": "0"
+  },
+  "SLES_541.87": {
+    "Name": "Real World Golf 2007",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.88": {
+    "Name": "Nickelodeon Avatar - The Legend of Aang",
+    "Region": "PAL-M4"
+  },
+  "SLES_541.93": {
+    "Name": "Sudoku, Carol Vonderman's",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.94": {
+    "Name": "Sudoku, Carol Vonderman's",
+    "Region": "PAL-Unk"
+  },
+  "SLES_541.95": {
+    "Name": "Turbo Trucks",
+    "Region": "PAL-E"
+  },
+  "SLES_541.99": {
+    "Name": "Who Wants to be a Millionaire - Party Edition",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.00": {
+    "Name": "Just Cause",
+    "Region": "PAL-F-G"
+  },
+  "SLES_542.03": {
+    "Name": "Pro Evolution Soccer 6",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.04": {
+    "Name": "Pro Evolution Soccer 6",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.05": {
+    "Name": "WWI - Aces of the Sky",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.09": {
+    "Name": "Sopranos, The - Road to Respect",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.10": {
+    "Name": "NBA 2K7",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.11": {
+    "Name": "NHL 2K7",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.12": {
+    "Name": "Agent Hugo - RoboRumble",
+    "Region": "PAL-M11"
+  },
+  "SLES_542.13": {
+    "Name": "Black Buccaneer",
+    "Region": "PAL-M5"
+  },
+  "SLES_542.15": {
+    "Name": "Monster House",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_542.16": {
+    "Name": "Monster House",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.17": {
+    "Name": "Monster House",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.18": {
+    "Name": "Rule of Rose",
+    "Region": "PAL-F"
+  },
+  "SLES_542.21": {
+    "Name": "LEGO Star Wars II - The Original Trilogy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.22": {
+    "Name": "SuperBikes Riding Challenge",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.23": {
+    "Name": "NASCAR '07",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.24": {
+    "Name": "Australian Idol Sing",
+    "Region": "PAL-E"
+  },
+  "SLES_542.25": {
+    "Name": "LMA Manager 2007",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.30": {
+    "Name": "Brian Lara International Cricket 2007",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_542.32": {
+    "Name": "Kingdom Hearts II",
+    "Region": "PAL-F"
+  },
+  "SLES_542.33": {
+    "Name": "Kingdom Hearts II",
+    "Region": "PAL-G"
+  },
+  "SLES_542.34": {
+    "Name": "Kingdom Hearts II",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.35": {
+    "Name": "Kingdom Hearts II",
+    "Region": "PAL-S"
+  },
+  "SLES_542.37": {
+    "Name": "Pirates of the Caribbean - The Legend of Jack Sparrow",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_542.39": {
+    "Name": "Wild ARMs 4",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.40": {
+    "Name": "FIFA '07",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_542.41": {
+    "Name": "FIFA '07",
+    "Region": "PAL-F-G-I"
+  },
+  "SLES_542.43": {
+    "Name": "FIFA '07",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.44": {
+    "Name": "FIFA '07",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.45": {
+    "Name": "NHL '07",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.46": {
+    "Name": "FIFA '07",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.48": {
+    "Name": "Madden NFL '07",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.50": {
+    "Name": "NBA Live '07",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.51": {
+    "Name": "NBA Live '07",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.52": {
+    "Name": "NBA Live '07",
+    "Region": "PAL-E-G-I"
+  },
+  "SLES_542.53": {
+    "Name": "Tiger Woods PGA Tour '07",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.54": {
+    "Name": "Evolution GT",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.55": {
+    "Name": "King of Fighters, The - Maximum Impact 2",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_542.56": {
+    "Name": "WWII - Battle Over the Pacific",
+    "Region": "PAL-Unk"
+  },
+  "SLES_542.71": {
+    "Name": "Scarface - The World is Yours",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.05": {
+    "Name": "Demon Chaos",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_543.06": {
+    "Name": "Cartoon Network Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.07": {
+    "Name": "Rayman - Raving Rabbids",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_543.08": {
+    "Name": "Phantasy Star Universe",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "eeRoundMode": "0"
+  },
+  "SLES_543.09": {
+    "Name": "Strawberry Shortcake - The Sweet Dreams Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.10": {
+    "Name": "Open Season",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.11": {
+    "Name": "Noddy and The Magic Book",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.16": {
+    "Name": "Open Season - Rebelles de la Foret",
+    "Region": "PAL-F"
+  },
+  "SLES_543.17": {
+    "Name": "Ghost Rider",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.19": {
+    "Name": "Biker Mice from Mars",
+    "Region": "PAL-M5"
+  },
+  "SLES_543.20": {
+    "Name": "Championship Manager 2007",
+    "Region": "PAL-E"
+  },
+  "SLES_543.21": {
+    "Name": "Need for Speed - Carbon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.22": {
+    "Name": "Need for Speed - Carbon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.23": {
+    "Name": "Need for Speed - Carbon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.24": {
+    "Name": "Need for Speed - Carbon",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.31": {
+    "Name": "Street Dance",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.32": {
+    "Name": "Dance Fest",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.33": {
+    "Name": "Sega MegaDrive Collection",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.36": {
+    "Name": "Lumines Plus",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_543.39": {
+    "Name": "Realm of the Dead",
+    "Region": "PAL-E"
+  },
+  "SLES_543.40": {
+    "Name": "Samurai Warriors 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.41": {
+    "Name": "Dancing Stage SuperNOVA",
+    "Region": "PAL-M5"
+  },
+  "SLES_543.42": {
+    "Name": "Bratz - Forever Diamondz",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.43": {
+    "Name": "Bratz - Forever Diamondz",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.44": {
+    "Name": "Bratz - Forever Diamondz",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.46": {
+    "Name": "Heatseeker",
+    "Region": "PAL-M3"
+  },
+  "SLES_543.47": {
+    "Name": "Sims 2, The - Pets",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.50": {
+    "Name": "Superman Returns",
+    "Region": "PAL-G"
+  },
+  "SLES_543.54": {
+    "Name": "Final Fantasy XII",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_543.55": {
+    "Name": "Final Fantasy XII",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.56": {
+    "Name": "Final Fantasy XII",
+    "Region": "PAL-G"
+  },
+  "SLES_543.57": {
+    "Name": "Final Fantasy XII",
+    "Region": "PAL-I"
+  },
+  "SLES_543.58": {
+    "Name": "Final Fantasy XII",
+    "Region": "PAL-S",
+    "Compat": 5
+  },
+  "SLES_543.59": {
+    "Name": "Legend of Spyro, The - A New Beginning",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.60": {
+    "Name": "Pro Evolution Soccer 6",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.61": {
+    "Name": "Pro Evolution Soccer 6",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.62": {
+    "Name": "Pro Evolution Soccer 6",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.64": {
+    "Name": "Curious George",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.65": {
+    "Name": "AMF Xtreme bowling 2006",
+    "Region": "PAL-M6"
+  },
+  "SLES_543.66": {
+    "Name": "David Douillet Judo",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.68": {
+    "Name": "RTL Ski Jumping 2007",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.70": {
+    "Name": "Alpine Ski Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.74": {
+    "Name": "RTL Wintergames 2007",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.76": {
+    "Name": "Barnyard",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.79": {
+    "Name": "NFL Street 3",
+    "Region": "PAL-E"
+  },
+  "SLES_543.80": {
+    "Name": "Babe",
+    "Region": "PAL-M6"
+  },
+  "SLES_543.81": {
+    "Name": "Dr. Dolittle",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.82": {
+    "Name": "Jumanji",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_543.83": {
+    "Name": "Casper and The Ghostly Trio",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.84": {
+    "Name": "Destroy All Humans 2 - Make War not Love",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.85": {
+    "Name": "Atelier Iris 2 - The Azoth of Destiny",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.88": {
+    "Name": "Kim Possible - What's the Switch",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.89": {
+    "Name": "Tony Hawk's Project 8",
+    "Region": "PAL-Unk",
+    "Compat": 2
+  },
+  "SLES_543.93": {
+    "Name": "Pippa Funnell - Take the Reins",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.94": {
+    "Name": "Family Guy - The Video Game",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.95": {
+    "Name": "NeoGeo Battle Coliseum",
+    "Region": "PAL-Unk"
+  },
+  "SLES_543.96": {
+    "Name": "Cricket 07",
+    "Region": "PAL-E"
+  },
+  "SLES_544.00": {
+    "Name": "SpongeBob Squarepants - Creature from the Krusty Krab",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.02": {
+    "Name": "Need for Speed - Carbon [Collector's Edition]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.18": {
+    "Name": "Powerdrome",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.20": {
+    "Name": "Arthus & The Minimoys",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.21": {
+    "Name": "Happy Feet",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_544.23": {
+    "Name": "Justice League Heroes",
+    "Region": "PAL-M5"
+  },
+  "SLES_544.24": {
+    "Name": "Dr. Dolittle",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.26": {
+    "Name": "Casper and The Ghostly Trio",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.27": {
+    "Name": "Jumanji",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.30": {
+    "Name": "Teen Titans",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.31": {
+    "Name": "Teen Titans",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.32": {
+    "Name": "Mercury Meltdown Remix",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_544.37": {
+    "Name": "King of Fighters XI",
+    "Region": "PAL-E"
+  },
+  "SLES_544.39": {
+    "Name": "Okami",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.40": {
+    "Name": "GT-R Touring",
+    "Region": "PAL-E"
+  },
+  "SLES_544.41": {
+    "Name": "Hawk Kawasaki Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.42": {
+    "Name": "Guitar Hero II",
+    "Region": "PAL-Unk",
+    "Compat": 3
+  },
+  "SLES_544.44": {
+    "Name": "Made Man",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_544.48": {
+    "Name": "World Series of Poker - Tournament of Champions",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.49": {
+    "Name": "Chicken Little - Ace in Action",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.50": {
+    "Name": "Chicken Little - Aventures Intergalactiques",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.51": {
+    "Name": "Himmel und Huhn - Ace in Action",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.52": {
+    "Name": "Chicken Little - 'As' en Accion",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.53": {
+    "Name": "Chicken Little - Ace in Action",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.54": {
+    "Name": "Disgaea 2 - Cursed Memories",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.56": {
+    "Name": "Beverly Hills Cop",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_544.59": {
+    "Name": "All Star Fighters",
+    "Region": "PAL-E"
+  },
+  "SLES_544.60": {
+    "Name": "Dragon Sisters",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_544.61": {
+    "Name": "Zombie Hunters",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_544.62": {
+    "Name": "Zombie Virus",
+    "Region": "PAL-E"
+  },
+  "SLES_544.64": {
+    "Name": "Global Defence Force",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_544.65": {
+    "Name": "CSI 3 - Dimensions of Murder",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.66": {
+    "Name": "Test Drive Unlimited",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "VIFFIFOHack": 1
+  },
+  "SLES_544.67": {
+    "Name": "Final Armada",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.68": {
+    "Name": "Crazy Chicken X",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.69": {
+    "Name": "Home Alone",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.71": {
+    "Name": "Captain Scarlet",
+    "Region": "PAL-M6"
+  },
+  "SLES_544.73": {
+    "Name": "Flintstones, The - Bedrock Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.74": {
+    "Name": "Curious George",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.76": {
+    "Name": "Buccaneer",
+    "Region": "PAL-E"
+  },
+  "SLES_544.78": {
+    "Name": "TMNT",
+    "Region": "PAL-M5",
+    "Compat": 4
+  },
+  "SLES_544.83": {
+    "Name": "The Fast and the Furious",
+    "Region": "PAL-E"
+  },
+  "SLES_544.86": {
+    "Name": "Xiaolin Showdown",
+    "Region": "PAL-M5"
+  },
+  "SLES_544.87": {
+    "Name": "Tokobot Plus - Mysteries of the Karakuri",
+    "Region": "PAL-M5"
+  },
+  "SLES_544.88": {
+    "Name": "WWE SmackDown! vs. RAW 2007",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.89": {
+    "Name": "WWE SmackDown! vs. RAW 2007",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_544.90": {
+    "Name": "God Hand",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_544.92": {
+    "Name": "Need for Speed - Carbon [Collector's Edition]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_544.93": {
+    "Name": "Need for Speed - Carbon [Collector's Edition]",
+    "Region": "PAL-G"
+  },
+  "SLES_544.94": {
+    "Name": "Little Britain - The Video Game",
+    "Region": "PAL-E"
+  },
+  "SLES_545.10": {
+    "Name": "Disney's Meet the Robinsons",
+    "Region": "PAL-M3"
+  },
+  "SLES_545.11": {
+    "Name": "UEFA Champions League",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.12": {
+    "Name": "UEFA Champions League",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.13": {
+    "Name": "UEFA Champions League",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.18": {
+    "Name": "Clumsy Shumsy",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.21": {
+    "Name": "Nickelodeon SpongeBob and Friends - Battle for Volcano Island",
+    "Region": "PAL-M5"
+  },
+  "SLES_545.27": {
+    "Name": "Flushed Away",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.41": {
+    "Name": "Xena - Warrior Princess",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_545.42": {
+    "Name": "Xena - Warrior Princess",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.44": {
+    "Name": "Gun Club",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.45": {
+    "Name": "Maxxed Out Racing Nitro",
+    "Region": "PAL-E"
+  },
+  "SLES_545.46": {
+    "Name": "Horsez",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.48": {
+    "Name": "Cocoto Fishing Master",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.49": {
+    "Name": "Crazy Frog Racer 2",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.51": {
+    "Name": "Premier Manager 2006-2007",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.53": {
+    "Name": "Shrek - Smash 'n Crash Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.54": {
+    "Name": "Star Trek - Encounters",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.55": {
+    "Name": "Shin Megami Tensei - Digital Devil Saga 2",
+    "Region": "PAL-E",
+    "EETimingHack": 1
+  },
+  "SLES_545.60": {
+    "Name": "Alpine Ski Racing 2007",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.61": {
+    "Name": "Capcom Classics Collection Vol. 2",
+    "Region": "PAL-E"
+  },
+  "SLES_545.66": {
+    "Name": "Barbie in The 12 Dancing Princesses",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.69": {
+    "Name": "Zombie Hunters 2",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_545.79": {
+    "Name": "Flintstones, The - Bedrock Racing",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.81": {
+    "Name": "The Red Star",
+    "Region": "PAL-M5"
+  },
+  "SLES_545.82": {
+    "Name": "International Tennis Pro",
+    "Region": "PAL-E"
+  },
+  "SLES_545.83": {
+    "Name": "Surf's Up",
+    "Region": "PAL-M5"
+  },
+  "SLES_545.84": {
+    "Name": "Pac-Man Rally",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.86": {
+    "Name": "Ar Tonelico - Melody of Elemia",
+    "Region": "PAL-Unk"
+  },
+  "SLES_545.88": {
+    "Name": "Brunswick Pro Bowling",
+    "Region": "PAL-E"
+  },
+  "SLES_545.89": {
+    "Name": "Global Defense Force Tactics",
+    "Region": "PAL-E"
+  },
+  "SLES_546.04": {
+    "Name": "'Que pasa Neng! El Videojuego",
+    "Region": "PAL-S"
+  },
+  "SLES_546.06": {
+    "Name": "Harley-Davidson - Race to the Rally",
+    "Region": "PAL-Unk"
+  },
+  "SLES_546.08": {
+    "Name": "Barbie in The 12 Dancing Princesses",
+    "Region": "PAL-Unk"
+  },
+  "SLES_546.11": {
+    "Name": "TT Superbikes - Real Road Racing Championship",
+    "Region": "PAL-M5"
+  },
+  "SLES_546.15": {
+    "Name": "Code of the Samurai",
+    "Region": "PAL-Unk"
+  },
+  "SLES_546.17": {
+    "Name": "Action Man A.T.O.M. - Alpha Teens on Machines",
+    "Region": "PAL-M9"
+  },
+  "SLES_546.22": {
+    "Name": "Grand Theft Auto - Vice City Stories",
+    "Region": "PAL-M5"
+  },
+  "SLES_546.23": {
+    "Name": "Grand Theft Auto - Vice City Stories",
+    "Region": "PAL-G"
+  },
+  "SLES_546.24": {
+    "Name": "Samurai Warriors 2 - Empires",
+    "Region": "PAL-E"
+  },
+  "SLES_546.26": {
+    "Name": "An American Tail",
+    "Region": "PAL-M11"
+  },
+  "SLES_546.27": {
+    "Name": "Burnout Dominator",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_546.29": {
+    "Name": "Shin Megami Tensei - Devil Summoner",
+    "Region": "PAL-E"
+  },
+  "SLES_546.31": {
+    "Name": "Harley-Davidson - Race to the Rally",
+    "Region": "PAL-Unk"
+  },
+  "SLES_546.33": {
+    "Name": "Premier Manager 08",
+    "Region": "PAL-M4"
+  },
+  "SLES_546.34": {
+    "Name": "Top Trumps Adventures Vol. 1 - Horror & Predators",
+    "Region": "PAL-M5"
+  },
+  "SLES_546.35": {
+    "Name": "Top Trumps Adventures Vol. 2 - Dogs & Dinosaurs",
+    "Region": "PAL-M5"
+  },
+  "SLES_546.39": {
+    "Name": "AFL Premiership 2007",
+    "Region": "PAL-E"
+  },
+  "SLES_546.41": {
+    "Name": "International Cricket Captain III",
+    "Region": "PAL-E"
+  },
+  "SLES_546.44": {
+    "Name": "Valkyrie Profile 2 - Silmeria",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLES_546.45": {
+    "Name": "Valkyrie Profile 2 - Silmeria",
+    "Region": "PAL-F",
+    "VuAddSubHack": 1
+  },
+  "SLES_546.46": {
+    "Name": "Valkyrie Profile 2 - Silmeria",
+    "Region": "PAL-G",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLES_546.47": {
+    "Name": "Valkyrie Profile 2 - Silmeria",
+    "Region": "PAL-I",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLES_546.48": {
+    "Name": "Valkyrie Profile 2 - Silmeria",
+    "Region": "PAL-S",
+    "VuAddSubHack": 1
+  },
+  "SLES_546.57": {
+    "Name": "Charlotte's Web",
+    "Region": "PAL-E"
+  },
+  "SLES_546.59": {
+    "Name": "Star Wars - The Force Unleashed",
+    "Region": "PAL-M4"
+  },
+  "SLES_546.63": {
+    "Name": "Jackass - The Game",
+    "Region": "PAL-M5"
+  },
+  "SLES_546.66": {
+    "Name": "Mr. Bean",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_546.70": {
+    "Name": "Wacky Races - Mad Motors",
+    "Region": "PAL-M11"
+  },
+  "SLES_546.74": {
+    "Name": "Lara Croft Tomb Raider - Anniversary",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_546.75": {
+    "Name": "Street Warrior",
+    "Region": "PAL-E"
+  },
+  "SLES_546.77": {
+    "Name": "Metal Slug - Anthology",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_546.81": {
+    "Name": "Burnout Dominator",
+    "Region": "PAL-E"
+  },
+  "SLES_546.83": {
+    "Name": "Medal of Honor - Vanguard",
+    "Region": "PAL-M9"
+  },
+  "SLES_546.86": {
+    "Name": "Impossible Mission",
+    "Region": "PAL-E",
+    "Compat": 1
+  },
+  "SLES_546.87": {
+    "Name": "Spectral vs. Generation",
+    "Region": "PAL-E"
+  },
+  "SLES_546.95": {
+    "Name": "Azur & Asmar",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_547.05": {
+    "Name": "SBK-07 - Superbike World Championship",
+    "Region": "PAL-M5"
+  },
+  "SLES_547.11": {
+    "Name": "Shadow Hearts - From the New World",
+    "Region": "PAL-E"
+  },
+  "SLES_547.17": {
+    "Name": "Power Volleyball",
+    "Region": "PAL-E"
+  },
+  "SLES_547.19": {
+    "Name": "Charlotte's Web",
+    "Region": "PAL-11"
+  },
+  "SLES_547.23": {
+    "Name": "Spiderman 3",
+    "Region": "PAL-E",
+    "Compat": 4
+  },
+  "SLES_547.27": {
+    "Name": "Naruto - Uzumaki Chronicles",
+    "Region": "PAL-M5",
+    "OPHFLagHack": 1
+  },
+  "SLES_547.31": {
+    "Name": "King of Clubs",
+    "Region": "PAL-M5"
+  },
+  "SLES_547.33": {
+    "Name": "Disney-Pixar Ratatouille",
+    "Region": "PAL-E"
+  },
+  "SLES_547.35": {
+    "Name": "Disney-Pixar Ratatouille",
+    "Region": "PAL-G"
+  },
+  "SLES_547.47": {
+    "Name": "Disney-Pixar Ratatouille",
+    "Region": "PAL-M2"
+  },
+  "SLES_547.55": {
+    "Name": "Transformers - The Game",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_547.56": {
+    "Name": "Transformers - The Game",
+    "Region": "PAL-M2"
+  },
+  "SLES_547.70": {
+    "Name": "DreamWorks Shrek the Third",
+    "Region": "PAL-E"
+  },
+  "SLES_547.71": {
+    "Name": "DreamWorks Shrek the Third",
+    "Region": "PAL-M5"
+  },
+  "SLES_547.76": {
+    "Name": "Fantastic Four - Rise of the Silver Surfer",
+    "Region": "PAL-I"
+  },
+  "SLES_547.79": {
+    "Name": "Harry Potter and the Order of the Phoenix",
+    "Region": "PAL-M5"
+  },
+  "SLES_547.82": {
+    "Name": "Obscure 2",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_547.84": {
+    "Name": "Xyanide - Resurrection",
+    "Region": "PAL-M5"
+  },
+  "SLES_547.88": {
+    "Name": "Aqua Teen Hunger Force - Zombie Ninja Pro-Am",
+    "Region": "PAL-E"
+  },
+  "SLES_547.90": {
+    "Name": "Art of Fighting Anthology",
+    "Region": "PAL-E"
+  },
+  "SLES_547.93": {
+    "Name": "WWE SmackDown vs. Raw 2008",
+    "Region": "PAL-E"
+  },
+  "SLES_548.04": {
+    "Name": "Operation Air Assault 2",
+    "Region": "PAL-E"
+  },
+  "SLES_548.05": {
+    "Name": "Wer Wird Millionar - Party Edition",
+    "Region": "PAL-G"
+  },
+  "SLES_548.10": {
+    "Name": "Rugby 08",
+    "Region": "PAL-E"
+  },
+  "SLES_548.11": {
+    "Name": "Rugby 08",
+    "Region": "PAL-I"
+  },
+  "SLES_548.12": {
+    "Name": "Madden NFL 08",
+    "Region": "PAL-E"
+  },
+  "SLES_548.15": {
+    "Name": "Spyro - The Eternal Night",
+    "Region": "PAL-M6",
+    "Compat": 5
+  },
+  "SLES_548.19": {
+    "Name": "Manhunt 2",
+    "Region": "PAL-M5"
+  },
+  "SLES_548.20": {
+    "Name": "Stuntman Ignition",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "VIFFIFOHack": 1
+  },
+  "SLES_548.22": {
+    "Name": "Atelier Iris 3 - Grand Phantasm",
+    "Region": "PAL-Unk"
+  },
+  "SLES_548.25": {
+    "Name": "Bob the Builder",
+    "Region": "PAL-M3"
+  },
+  "SLES_548.34": {
+    "Name": "Juiced 2",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_548.36": {
+    "Name": "Disney High School Musical - Sing It!",
+    "Region": "PAL-M5"
+  },
+  "SLES_548.37": {
+    "Name": "Disney Princess - Enchanted Journey",
+    "Region": "PAL-M3"
+  },
+  "SLES_548.40": {
+    "Name": "Nickelodeon Avatar - The Legend of Aang - The Burning Earth",
+    "Region": "PAL-M4"
+  },
+  "SLES_548.41": {
+    "Name": "Crash of the Titans",
+    "Region": "PAL-M6"
+  },
+  "SLES_548.42": {
+    "Name": "Crash of the Titans",
+    "Region": "PAL-M5"
+  },
+  "SLES_548.45": {
+    "Name": "Warriors Orochi",
+    "Region": "PAL-Unk"
+  },
+  "SLES_548.59": {
+    "Name": "Guitar Hero - Rocks The 80's",
+    "Region": "PAL-E",
+    "Compat": 4
+  },
+  "SLES_548.61": {
+    "Name": "Thomas & Friends - A Day at the Races",
+    "Region": "PAL-M5"
+  },
+  "SLES_548.70": {
+    "Name": "FIFA 08",
+    "Region": "PAL-E"
+  },
+  "SLES_548.71": {
+    "Name": "FIFA 2008",
+    "Region": "PAL-F-G-I"
+  },
+  "SLES_548.72": {
+    "Name": "FIFA 08",
+    "Region": "PAL-P-S"
+  },
+  "SLES_548.73": {
+    "Name": "FIFA 2008",
+    "Region": "PAL-E-N-Sw"
+  },
+  "SLES_548.75": {
+    "Name": "Warriors Orochi",
+    "Region": "PAL-E"
+  },
+  "SLES_548.77": {
+    "Name": "Warriors Orochi",
+    "Region": "PAL-G"
+  },
+  "SLES_548.78": {
+    "Name": "Naruto - Ultimate Ninja 2",
+    "Region": "PAL-M5"
+  },
+  "SLES_548.79": {
+    "Name": "WWE SmackDown vs. Raw 2008",
+    "Region": "PAL-M5"
+  },
+  "SLES_548.80": {
+    "Name": "NBA 2K8",
+    "Region": "PAL-M5"
+  },
+  "SLES_548.84": {
+    "Name": "Alone in the Dark",
+    "Region": "PAL-E",
+    "Compat": 3
+  },
+  "SLES_548.85": {
+    "Name": "Moto X Maniac",
+    "Region": "PAL-E"
+  },
+  "SLES_548.91": {
+    "Name": "Clever Kids - Pony World",
+    "Region": "PAL-M6"
+  },
+  "SLES_548.92": {
+    "Name": "Phantasy Star Universe - Ambition of the Illuminus",
+    "Region": "PAL-M3"
+  },
+  "SLES_548.95": {
+    "Name": "NBA Live 08",
+    "Region": "PAL-M3"
+  },
+  "SLES_548.97": {
+    "Name": "GrimGrimoire",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_548.98": {
+    "Name": "Metropolismania 2",
+    "Region": "PAL-E"
+  },
+  "SLES_548.99": {
+    "Name": "Bob the Builder",
+    "Region": "PAL-M5"
+  },
+  "SLES_549.03": {
+    "Name": "The Sims 2 - Castaway",
+    "Region": "PAL-M13"
+  },
+  "SLES_549.04": {
+    "Name": "The Simpsons Game",
+    "Region": "PAL-M4",
+    "Compat": 5
+  },
+  "SLES_549.06": {
+    "Name": "The Simpsons Game",
+    "Region": "PAL-I-S"
+  },
+  "SLES_549.13": {
+    "Name": "Pro Evolution Soccer 2008",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_549.14": {
+    "Name": "Pro Evolution Soccer 2008",
+    "Region": "PAL-I-P"
+  },
+  "SLES_549.15": {
+    "Name": "Sonic Riders - Zero Gravity",
+    "Region": "PAL-M5"
+  },
+  "SLES_549.18": {
+    "Name": "Agent Hugo - Lemoon Twist",
+    "Region": "PAL-M7"
+  },
+  "SLES_549.29": {
+    "Name": "Realplay Racing",
+    "Region": "PAL-M5"
+  },
+  "SLES_549.31": {
+    "Name": "Looney Tunes - ACME Arsenal",
+    "Region": "PAL-M5"
+  },
+  "SLES_549.37": {
+    "Name": "RTL Biathon 2008",
+    "Region": "PAL-G"
+  },
+  "SLES_549.39": {
+    "Name": "RTL Winter Sports 2008 - The Ultimate Challenge",
+    "Region": "PAL-G"
+  },
+  "SLES_549.42": {
+    "Name": "Disney Princess - Enchanted Journey",
+    "Region": "PAL-D-F-I"
+  },
+  "SLES_549.45": {
+    "Name": "Dragonball Z Budokai Tenkaichi 3",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_549.46": {
+    "Name": "Sega Superstars Tennis",
+    "Region": "PAL-M5"
+  },
+  "SLES_549.49": {
+    "Name": "Catz",
+    "Region": "PAL-M6"
+  },
+  "SLES_549.52": {
+    "Name": "Ben 10 - Protector of Earth",
+    "Region": "PAL-M5"
+  },
+  "SLES_549.53": {
+    "Name": "Totally Spies! Totally Party",
+    "Region": "PAL-Unk"
+  },
+  "SLES_549.55": {
+    "Name": "Finkles World",
+    "Region": "PAL-E"
+  },
+  "SLES_549.57": {
+    "Name": "Cheggers Party Quiz",
+    "Region": "PAL-M5"
+  },
+  "SLES_549.58": {
+    "Name": "Alan Hansen's Sports Challenge",
+    "Region": "PAL-M5"
+  },
+  "SLES_549.62": {
+    "Name": "Guitar Hero III - Legends of Rock",
+    "Region": "PAL-E"
+  },
+  "SLES_549.64": {
+    "Name": "Tony Hawk's Proving Ground",
+    "Region": "PAL-M4"
+  },
+  "SLES_549.75": {
+    "Name": "George Of The Jungle",
+    "Region": "PAL-E",
+    "Compat": 4
+  },
+  "SLES_549.81": {
+    "Name": "Bob the Builder - Festival of Fun",
+    "Region": "PAL-I-F-G"
+  },
+  "SLES_549.86": {
+    "Name": "Bratz - The Movie",
+    "Region": "PAL-E-I"
+  },
+  "SLES_549.88": {
+    "Name": "Bratz - The Movie",
+    "Region": "PAL-G"
+  },
+  "SLES_549.92": {
+    "Name": "PDC World Championship Darts 2008",
+    "Region": "PAL-M6"
+  },
+  "SLES_549.94": {
+    "Name": "Pippa Funnell - Ranch Rescue",
+    "Region": "PAL-M11"
+  },
+  "SLES_549.95": {
+    "Name": "Puzzle Quest - Challenge of the Warlords",
+    "Region": "PAL-M5"
+  },
+  "SLES_549.96": {
+    "Name": "The Golden Compass",
+    "Region": "PAL-M5"
+  },
+  "SLES_549.97": {
+    "Name": "Mercenaries 2 - World in Flames",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_549.98": {
+    "Name": "Bratz - The Movie",
+    "Region": "PAL-M5"
+  },
+  "SLES_550.00": {
+    "Name": "Mercenaries 2 - World in Flames",
+    "Region": "PAL-G",
+    "EETimingHack": 1
+  },
+  "SLES_550.01": {
+    "Name": "Mercenaries 2 - World in Flames",
+    "Region": "PAL-S",
+    "EETimingHack": 1
+  },
+  "SLES_550.02": {
+    "Name": "Need for Speed - ProStreet",
+    "Region": "PAL-E"
+  },
+  "SLES_550.03": {
+    "Name": "Need for Speed - ProStreet",
+    "Region": "PAL-F-G"
+  },
+  "SLES_550.05": {
+    "Name": "Need for Speed - ProStreet",
+    "Region": "PAL-M8"
+  },
+  "SLES_550.07": {
+    "Name": "Boogie",
+    "Region": "PAL-E",
+    "Compat": 4
+  },
+  "SLES_550.13": {
+    "Name": "Iridium Runners",
+    "Region": "PAL-M5"
+  },
+  "SLES_550.16": {
+    "Name": "DreamWorks Bee Movie Game",
+    "Region": "PAL-M6"
+  },
+  "SLES_550.17": {
+    "Name": "Yu-Gi-Oh! GX - Tag Force Evolution",
+    "Region": "PAL-M5"
+  },
+  "SLES_550.18": {
+    "Name": "Shin Megami Tensei: Persona 3",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "VuClipFlagHack": 1
+  },
+  "SLES_550.19": {
+    "Name": "Ratchet & Clank - Size Matters",
+    "Region": "PAL-M13"
+  },
+  "SLES_550.20": {
+    "Name": "Die Simpsons - Das Spiel",
+    "Region": "PAL-G"
+  },
+  "SLES_550.21": {
+    "Name": "Pro Evolution Soccer 2008",
+    "Region": "PAL-F-G"
+  },
+  "SLES_550.24": {
+    "Name": "Nickelodeon SpongeBob's Atlantis SquarePantis",
+    "Region": "PAL-M4"
+  },
+  "SLES_550.32": {
+    "Name": "Off Road",
+    "Region": "PAL-M5"
+  },
+  "SLES_550.34": {
+    "Name": "Asterix at the Olympic Games",
+    "Region": "PAL-M5"
+  },
+  "SLES_550.39": {
+    "Name": "Rock Band",
+    "Region": "PAL-M5"
+  },
+  "SLES_550.50": {
+    "Name": "MX vs. ATV - Untamed",
+    "Region": "PAL-E"
+  },
+  "SLES_550.52": {
+    "Name": "Alvin and the Chipmunks",
+    "Region": "PAL-M5"
+  },
+  "SLES_550.53": {
+    "Name": "Jetix - Puzzle Buzzle",
+    "Region": "PAL-M10"
+  },
+  "SLES_550.64": {
+    "Name": "Luxor - Pharaoh's Challenge",
+    "Region": "PAL-M5"
+  },
+  "SLES_550.69": {
+    "Name": "7 Wonders of the Ancient World",
+    "Region": "PAL-M5"
+  },
+  "SLES_550.75": {
+    "Name": "Speed racer",
+    "Region": "PAL-M6",
+    "Compat": 5
+  },
+  "SLES_550.79": {
+    "Name": "CID the Dummy",
+    "Region": "PAL-M5"
+  },
+  "SLES_550.81": {
+    "Name": "Jackass - The Game",
+    "Region": "PAL-E"
+  },
+  "SLES_550.90": {
+    "Name": "Naruto - Uzumaki Chronicles 2",
+    "Region": "PAL-M5",
+    "OPHFLagHack": 1
+  },
+  "SLES_551.05": {
+    "Name": "UEFA Euro 2008 - Austria-Switzerland",
+    "Region": "PAL-M5"
+  },
+  "SLES_551.08": {
+    "Name": "Samurai Warriors 2 - Xtreme Legends",
+    "Region": "PAL-E"
+  },
+  "SLES_551.10": {
+    "Name": "Odin Sphere",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_551.23": {
+    "Name": "Legend of Sayuki",
+    "Region": "PAL-M4"
+  },
+  "SLES_551.26": {
+    "Name": "Artlist Collection - The Dog Island",
+    "Region": "PAL-M6"
+  },
+  "SLES_551.29": {
+    "Name": "Jumper - Griffin's Story",
+    "Region": "PAL-M5"
+  },
+  "SLES_551.33": {
+    "Name": "LEGO Indiana Jones - The Original Adventure",
+    "Region": "PAL-M6"
+  },
+  "SLES_551.35": {
+    "Name": "LEGO Batman - The VideoGame",
+    "Region": "PAL-M6"
+  },
+  "SLES_551.36": {
+    "Name": "Let's Ride! Silver Buckle Stables",
+    "Region": "PAL-M4"
+  },
+  "SLES_551.47": {
+    "Name": "Silent Hill Origins",
+    "Region": "PAL-M5"
+  },
+  "SLES_551.50": {
+    "Name": "TNA Impact",
+    "Region": "PAL-Unk",
+    "Compat": 5,
+    "EETimingHack": 1
+  },
+  "SLES_551.63": {
+    "Name": "The Legend of Spyro - Dawn of the Dragon",
+    "Region": "PAL-M6"
+  },
+  "SLES_551.69": {
+    "Name": "Monster Lab",
+    "Region": "PAL-M5"
+  },
+  "SLES_551.74": {
+    "Name": "NHL 08",
+    "Region": "PAL-R"
+  },
+  "SLES_551.87": {
+    "Name": "Disney-Pixar WALL-E",
+    "Region": "PAL-D-F"
+  },
+  "SLES_551.91": {
+    "Name": "Guitar Hero - Aerosmith",
+    "Region": "PAL-E"
+  },
+  "SLES_551.97": {
+    "Name": "Dancing Stage SuperNOVA 2",
+    "Region": "PAL-M5"
+  },
+  "SLES_551.98": {
+    "Name": "Iron Man",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_552.04": {
+    "Name": "Crash - Mind Over Mutant",
+    "Region": "PAL-M6"
+  },
+  "SLES_552.07": {
+    "Name": "Alone in the Dark",
+    "Region": "PAL-M4"
+  },
+  "SLES_552.08": {
+    "Name": "The Incredible Hulk",
+    "Region": "PAL-E-F-G"
+  },
+  "SLES_552.15": {
+    "Name": "Growlanser - Heritage of War",
+    "Region": "PAL-E"
+  },
+  "SLES_552.16": {
+    "Name": "Baroque",
+    "Region": "PAL-E"
+  },
+  "SLES_552.20": {
+    "Name": "Summer Athletics",
+    "Region": "PAL-M5"
+  },
+  "SLES_552.31": {
+    "Name": "Fatal Fury - Battle Archives Volume 1",
+    "Region": "PAL-E"
+  },
+  "SLES_552.32": {
+    "Name": "SNK Arcade Classics Vol. 1",
+    "Region": "PAL-E"
+  },
+  "SLES_552.33": {
+    "Name": "World Heroes Anthology",
+    "Region": "PAL-E"
+  },
+  "SLES_552.37": {
+    "Name": "Naruto - Ultimate Ninja 3",
+    "Region": "PAL-M5"
+  },
+  "SLES_552.40": {
+    "Name": "Pipe Mania",
+    "Region": "PAL-M5"
+  },
+  "SLES_552.42": {
+    "Name": "Yakuza 2",
+    "Region": "PAL-E"
+  },
+  "SLES_552.43": {
+    "Name": "FIFA 09",
+    "Region": "PAL-E"
+  },
+  "SLES_552.44": {
+    "Name": "FIFA 09",
+    "Region": "PAL-F-G"
+  },
+  "SLES_552.45": {
+    "Name": "FIFA 09",
+    "Region": "PAL-M5"
+  },
+  "SLES_552.47": {
+    "Name": "FIFA 09",
+    "Region": "PAL-M5"
+  },
+  "SLES_552.48": {
+    "Name": "Harry Potter and the Half-Blood Prince",
+    "Region": "PAL-M6"
+  },
+  "SLES_552.49": {
+    "Name": "Harry Potter and the Half-Blood Prince",
+    "Region": "PAL-Unk"
+  },
+  "SLES_552.51": {
+    "Name": "WWE SmackDown vs. Raw 2009",
+    "Region": "PAL-M5"
+  },
+  "SLES_552.53": {
+    "Name": "NBA 2K5",
+    "Region": "PAL-M5"
+  },
+  "SLES_552.63": {
+    "Name": "Nickelodeon Avatar - The Legend of Aang - Into the Inferno",
+    "Region": "PAL-M7"
+  },
+  "SLES_552.66": {
+    "Name": "MotoGP 08",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_552.74": {
+    "Name": "Diabolik - The Original Sin",
+    "Region": "PAL-M6"
+  },
+  "SLES_552.80": {
+    "Name": "King of Fighters '98 - Ultimate Match",
+    "Region": "PAL-E"
+  },
+  "SLES_552.92": {
+    "Name": "Samurai Shodown Anthology",
+    "Region": "PAL-E"
+  },
+  "SLES_553.28": {
+    "Name": "The Millenium European Paintball Series - Championship Paintball 2009",
+    "Region": "PAL-E"
+  },
+  "SLES_553.29": {
+    "Name": "Shrek's Carnival Craze",
+    "Region": "PAL-Unk"
+  },
+  "SLES_553.31": {
+    "Name": "Cabela's Dangerous Adventures",
+    "Region": "PAL-E"
+  },
+  "SLES_553.41": {
+    "Name": "Hasbro Family Game Night",
+    "Region": "PAL-G"
+  },
+  "SLES_553.42": {
+    "Name": "Hasbro Family Game Night",
+    "Region": "PAL-Unk"
+  },
+  "SLES_553.44": {
+    "Name": "Rock Band - Song Back 1",
+    "Region": "PAL-M5"
+  },
+  "SLES_553.45": {
+    "Name": "James Bond: Quantum of Solace",
+    "Region": "PAL-Unk"
+  },
+  "SLES_553.47": {
+    "Name": "Dragonball Z Infinite World",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_553.49": {
+    "Name": "Need For Speed - Undercover",
+    "Region": "PAL-Unk"
+  },
+  "SLES_553.50": {
+    "Name": "Need for Speed - Undercover",
+    "Region": "PAL-F-G"
+  },
+  "SLES_553.52": {
+    "Name": "Need For Speed - Undercover",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_553.54": {
+    "Name": "Persona 3 FES",
+    "Region": "PAL-E",
+    "VuClipFlagHack": 1
+  },
+  "SLES_553.55": {
+    "Name": "Guitar Hero - World Tour",
+    "Region": "PAL-M5"
+  },
+  "SLES_553.65": {
+    "Name": "Agent Hugo - Hula Holiday",
+    "Region": "PAL-M7"
+  },
+  "SLES_553.67": {
+    "Name": "Call of Duty - World at War - Final Fronts",
+    "Region": "PAL-M4"
+  },
+  "SLES_553.69": {
+    "Name": "Call of Duty - World at War - Final Fronts",
+    "Region": "PAL-G"
+  },
+  "SLES_553.71": {
+    "Name": "Barbie Horse Adventures - Riding Camp",
+    "Region": "PAL-M6"
+  },
+  "SLES_553.73": {
+    "Name": "The King of Fighters Collection: The Orochi Saga",
+    "Region": "PAL-Unk"
+  },
+  "SLES_553.74": {
+    "Name": "DreamWorks Madagascar 2 - Escape 2 Africa",
+    "Region": "PAL-M6"
+  },
+  "SLES_553.76": {
+    "Name": "Nickelodeon Tak and the Guardians of Gross",
+    "Region": "PAL-E-G"
+  },
+  "SLES_553.80": {
+    "Name": "Sonic Unleashed",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_553.82": {
+    "Name": "Warriors Orochi 2",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_553.84": {
+    "Name": "Warriors Orochi 2",
+    "Region": "PAL-G"
+  },
+  "SLES_553.92": {
+    "Name": "Disne Sing It!",
+    "Region": "PAL-M6"
+  },
+  "SLES_553.94": {
+    "Name": "Disney TH!NK Fast",
+    "Region": "PAL-E"
+  },
+  "SLES_553.95": {
+    "Name": "Disney TH!NK Fast",
+    "Region": "PAL-D-F-G"
+  },
+  "SLES_553.98": {
+    "Name": "Disney High School Musical 3 - Senior Year Dance!",
+    "Region": "PAL-M6"
+  },
+  "SLES_554.05": {
+    "Name": "Pro Evolution Soccer 2009",
+    "Region": "PAL-F-G"
+  },
+  "SLES_554.06": {
+    "Name": "Pro Evolution Soccer 2009",
+    "Region": "PAL-Unk"
+  },
+  "SLES_554.09": {
+    "Name": "TT SuperBikes - Legends",
+    "Region": "PAL-M5"
+  },
+  "SLES_554.30": {
+    "Name": "Disney Bolt",
+    "Region": "PAL-D-F-G"
+  },
+  "SLES_554.31": {
+    "Name": "Disney Vol't",
+    "Region": "PAL-Unk"
+  },
+  "SLES_554.40": {
+    "Name": "Ben 10 - Alien Force",
+    "Region": "PAL-M5"
+  },
+  "SLES_554.42": {
+    "Name": "Tomb Raider Underworld",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_554.43": {
+    "Name": "Mana Khemia - Alchemists of Al-Revis",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "DMABusyHack": 1
+  },
+  "SLES_554.44": {
+    "Name": "Ar tonelico II: Melody of Metafalica",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_554.48": {
+    "Name": "Indiana Jones and the Staff of Kings",
+    "Region": "PAL-M5"
+  },
+  "SLES_554.53": {
+    "Name": "Singstar Queen",
+    "Region": "PAL-E"
+  },
+  "SLES_554.57": {
+    "Name": "AC/DC LIVE: Rock Band Track Pack",
+    "Region": "PAL-Unk"
+  },
+  "SLES_554.59": {
+    "Name": "Jelly Belly: Ballistic Beans",
+    "Region": "PAL-Unk"
+  },
+  "SLES_554.67": {
+    "Name": "Trivial Pursuit",
+    "Region": "PAL-M5"
+  },
+  "SLES_554.70": {
+    "Name": "Coraline",
+    "Region": "PAL-E",
+    "Compat": 3
+  },
+  "SLES_554.72": {
+    "Name": "Guitar Hero - Metalica",
+    "Region": "PAL-M5"
+  },
+  "SLES_554.74": {
+    "Name": "Shin Megami Tensei: Persona 4",
+    "Region": "PAL-E",
+    "VuClipFlagHack": 1
+  },
+  "SLES_554.76": {
+    "Name": "Scooby-Doo! First Frights",
+    "Region": "PAL-M5"
+  },
+  "SLES_554.82": {
+    "Name": "Naruto Shipuuden - Ultimate Ninja 4",
+    "Region": "PAL-G-I-S"
+  },
+  "SLES_554.86": {
+    "Name": "DreamWorks Monsters vs. Aliens",
+    "Region": "PAL-M7"
+  },
+  "SLES_554.87": {
+    "Name": "Ice Age 3 - Dawn of the Dinosaurs",
+    "Region": "PAL-M6"
+  },
+  "SLES_554.92": {
+    "Name": "SBK 09 - Superbike World Championship",
+    "Region": "PAL-M5"
+  },
+  "SLES_554.94": {
+    "Name": "X-Men Origins - Wolverine",
+    "Region": "PAL-Unk",
+    "FpuCompareHack": 1
+  },
+  "SLES_554.95": {
+    "Name": "X-Men Origins - Wolverine",
+    "Region": "PAL-G-F-S",
+    "FpuCompareHack": 1
+  },
+  "SLES_554.96": {
+    "Name": "Secret Agent Clank",
+    "Region": "PAL-Unk"
+  },
+  "SLES_555.00": {
+    "Name": "Disney G-Force",
+    "Region": "PAL-G-I"
+  },
+  "SLES_555.09": {
+    "Name": "Music Maker - Rockstar",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_555.11": {
+    "Name": "MTV Pimp My Ride - Street Racing",
+    "Region": "PAL-M5"
+  },
+  "SLES_555.20": {
+    "Name": "Transformers - Revenge of the Fallen",
+    "Region": "PAL-M5"
+  },
+  "SLES_555.25": {
+    "Name": "Disney-Pixar Oben",
+    "Region": "PAL-G"
+  },
+  "SLES_555.33": {
+    "Name": "Guitar Hero 5",
+    "Region": "PAL-M5"
+  },
+  "SLES_555.37": {
+    "Name": "G.I. Joe - The Rise of Cobra",
+    "Region": "PAL-M8"
+  },
+  "SLES_555.42": {
+    "Name": "Disney Sing It - Pop Hits",
+    "Region": "PAL-M6"
+  },
+  "SLES_555.45": {
+    "Name": "WWE SmackDown vs. Raw 2010",
+    "Region": "PAL-M5"
+  },
+  "SLES_555.46": {
+    "Name": "The Secret Saturdays - Beasts of the 5th Sun",
+    "Region": "PAL-M5"
+  },
+  "SLES_555.65": {
+    "Name": "Teenage Mutant Ninja Turtles - Smash-Up",
+    "Region": "PAL-M5"
+  },
+  "SLES_555.69": {
+    "Name": "Silent Hill - Shattered Memories",
+    "Region": "PAL-M5"
+  },
+  "SLES_555.71": {
+    "Name": "Ghostbusters",
+    "Region": "PAL-E",
+    "Compat": 4
+  },
+  "SLES_555.72": {
+    "Name": "Marvel Super Hero Squad",
+    "Region": "PAL-M6"
+  },
+  "SLES_555.73": {
+    "Name": "MotorStorm Arctic Edge",
+    "Region": "PAL-Unk",
+    "OPHFLagHack": 1
+  },
+  "SLES_555.74": {
+    "Name": "the Lord of the Rings - Aragorn's Quest",
+    "Region": "PAL-M6"
+  },
+  "SLES_555.78": {
+    "Name": "Band Hero",
+    "Region": "PAL-M5"
+  },
+  "SLES_555.79": {
+    "Name": "Bakugan - Battle Brawlers",
+    "Region": "PAL-M7"
+  },
+  "SLES_555.82": {
+    "Name": "FIFA 10",
+    "Region": "PAL-F-G"
+  },
+  "SLES_555.84": {
+    "Name": "FIFA 10",
+    "Region": "PAL-M5"
+  },
+  "SLES_555.85": {
+    "Name": "FIFA 10",
+    "Region": "PAL-E"
+  },
+  "SLES_555.88": {
+    "Name": "Pro Evolution Soccer 2010",
+    "Region": "PAL-F-G"
+  },
+  "SLES_555.89": {
+    "Name": "Pro Evolution Soccer 2010",
+    "Region": "PAL-I-P-S"
+  },
+  "SLES_555.92": {
+    "Name": "Ben 10 - Alien Force - Vilgax Attacks",
+    "Region": "PAL-M5"
+  },
+  "SLES_555.93": {
+    "Name": "Astro Boy - The Video Game",
+    "Region": "PAL-M5"
+  },
+  "SLES_556.05": {
+    "Name": "Naruto Shipuuden - Ultimate Ninja 5",
+    "Region": "PAL-M5"
+  },
+  "SLES_556.09": {
+    "Name": "Scooby-Doo! and the Spooky Swamp",
+    "Region": "PAL-M5"
+  },
+  "SLES_556.22": {
+    "Name": "Disney-Pixar Toy Story 3",
+    "Region": "PAL-M6"
+  },
+  "SLES_556.35": {
+    "Name": "WWE SmackDown vs. Raw 2011",
+    "Region": "PAL-M4"
+  },
+  "SLES_556.36": {
+    "Name": "Pro Evolution Soccer 2011",
+    "Region": "PAL-Unk"
+  },
+  "SLES_556.37": {
+    "Name": "Pro Evolution Soccer 2011",
+    "Region": "PAL-F-G"
+  },
+  "SLES_556.38": {
+    "Name": "Pro Evolution Soccer 2011",
+    "Region": "PAL-M4"
+  },
+  "SLES_556.44": {
+    "Name": "FIFA 11",
+    "Region": "PAL-M5"
+  },
+  "SLES_556.65": {
+    "Name": "FIFA 13",
+    "Region": "PAL-Unk"
+  },
+  "SLES_556.48": {
+    "Name": "WWE All-Stars",
+    "Region": "PAL-M5",
+    "Compat": 5
+  },
+  "SLES_820.01": {
+    "Name": "Summoner",
+    "Region": "PAL-E"
+  },
+  "SLES_820.05": {
+    "Name": "Summoner",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_820.09": {
+    "Name": "Metal Gear Solid 2 - Substance",
+    "Region": "PAL-M5",
+    "Compat": 1
+  },
+  "SLES_820.10": {
+    "Name": "Metal Gear Solid 2, Document of",
+    "Region": "PAL-Unk",
+    "Compat": 4
+  },
+  "SLES_820.11": {
+    "Name": "Devil May Cry 2 [Dante Disc]",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_820.12": {
+    "Name": "Devil May Cry 2 [Lucia Disc]",
+    "Region": "PAL-E",
+    "Compat": 5
+  },
+  "SLES_820.13": {
+    "Name": "Metal Gear Solid 3 - Snake Eater",
+    "Region": "PAL-E-F",
+    "Compat": 5
+  },
+  "SLES_820.18": {
+    "Name": "Cy Girls",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.20": {
+    "Name": "Cy Girls [Disc 1]",
+    "Region": "PAL-E-G-I"
+  },
+  "SLES_820.21": {
+    "Name": "Cy Girls [Disc 2]",
+    "Region": "PAL-E-G-I"
+  },
+  "SLES_820.24": {
+    "Name": "Metal Gear Solid 3 - Snake Eater",
+    "Region": "PAL-I"
+  },
+  "SLES_820.26": {
+    "Name": "Metal Gear Solid 3 - Snake Eater",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.28": {
+    "Name": "Star Ocean 3 - Till the End of Time [Disc1of2]",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLES_820.29": {
+    "Name": "Star Ocean 3 - Till the End of Time [Disc2of2]",
+    "Region": "PAL-E",
+    "Compat": 5,
+    "VuAddSubHack": 1
+  },
+  "SLES_820.30": {
+    "Name": "Shadow Hearts - Covenant [Disc1of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.31": {
+    "Name": "Shadow Hearts - Covenant [Disc2of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.32": {
+    "Name": "Metal Gear Solid 3 - Snake Eater",
+    "Region": "PAL-G"
+  },
+  "SLES_820.34": {
+    "Name": "Xenosaga Episode II [Disc1of2]",
+    "Region": "PAL-E"
+  },
+  "SLES_820.35": {
+    "Name": "Xenosaga Episode II [Disc2of2]",
+    "Region": "PAL-E"
+  },
+  "SLES_820.36": {
+    "Name": "Armored Core - Nexus [Evolution Disc]",
+    "Region": "PAL-M5"
+  },
+  "SLES_820.37": {
+    "Name": "Armored Core - Nexus [Revolution Disc]",
+    "Region": "PAL-M5"
+  },
+  "SLES_820.38": {
+    "Name": "Onimusha - Dawn of Dreams [Disc1]",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_820.39": {
+    "Name": "Onimusha - Dawn of Dreams [Disc2]",
+    "Region": "PAL-Unk",
+    "Compat": 5
+  },
+  "SLES_820.42": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc1of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.43": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc2of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.44": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc1of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.45": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc2of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.46": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc1of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.47": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc2of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.48": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc1of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.49": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc2of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.50": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc1of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.51": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc2of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.52": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc1of2]",
+    "Region": "PAL-Unk"
+  },
+  "SLES_820.53": {
+    "Name": "Metal Gear Solid 3 - Subsistance [Disc2of2]",
+    "Region": "PAL-Unk"
+  },
+  "TCES_516.13": {
+    "Name": "This Is Football 2004 [Beta]",
+    "Region": "PAL-E-S"
+  },
+  "TCES_519.04": {
+    "Name": "SOCOM II - U.S. Navy SEALs [Beta]",
+    "Region": "PAL-M5",
+    "Compat": 5,
+    "EETimingHack": 1,
+    "VIF1StallHack": 1
+  }
+}

--- a/backend/handler/tests/cassettes/test_get_ps2_opl_rom.yaml
+++ b/backend/handler/tests/cassettes/test_get_ps2_opl_rom.yaml
@@ -1,0 +1,642 @@
+interactions:
+- request:
+    body: "\n                search \"WWE Smack\";\n                fields id, slug,
+      name, summary, screenshots;\n                where platforms=[8] ;\n            "
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Client-ID:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.igdb.com/v4/games/
+  response:
+    body:
+      string: '[]'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 7f3aed54583736cc-YYZ
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Aug 2023 21:42:04 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=2FZ8yXd6kJCZczwShE3trToMz6isxk3pRUdc56wkEYI-1691530924-0-AaqEUxKzxOgi0q16HWpEhnxkee2iScFmFmmwLDzJ7V8+Lm65RvQWP9+x+2SsA08kOrB4y76l/LHK/K17sx8OwhQ=;
+        path=/; expires=Tue, 08-Aug-23 22:12:04 GMT; domain=.igdb.com; HttpOnly; Secure;
+        SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 0cf68108b8820db4a096a661da0108ba.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - yWhkDdhd8nwU3D_xJgnuyJJT0ZozkSB-Fzb_Kv24Iy3_KAqMa81ATw==
+      X-Amz-Cf-Pop:
+      - YUL62-C2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Count:
+      - '0'
+      alt-svc:
+      - h3=":443"; ma=86400
+      x-amz-apigw-id:
+      - JXF69GAEvHcFSFw=
+      x-amzn-Remapped-Content-Length:
+      - '2'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Aug 2023 21:42:04 GMT
+      x-amzn-RequestId:
+      - f89b0a7e-0132-468a-9765-e860db9af0e5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "\n                search \"WWE Smack\";\n                fields id, slug,
+      name, summary, screenshots;\n                where platforms=[8] & category=10;\n
+      \           "
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Client-ID:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '161'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.igdb.com/v4/games/
+  response:
+    body:
+      string: '[]'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 7f3aed55b93fa1e4-YYZ
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Aug 2023 21:42:04 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=Puva_j5o1yiq.tnKDbNcV9pRuJbwrDYniBPvgoCQRXY-1691530924-0-ARyofbQZWmGWeXv8t7ZyqA9cLRh4bt44QD551g2b/4ovRPGCxYEce8NyjxvhPQoeZwdzuWtPOX4XhuRF0cj0dFc=;
+        path=/; expires=Tue, 08-Aug-23 22:12:04 GMT; domain=.igdb.com; HttpOnly; Secure;
+        SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 17eb4ce9c34597b3328325a19f8138fe.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - LlXMW-vJq3MPlx4V-D3RBkS_BeLRWZP6EnqmwClehjo-DKCuMEYqBQ==
+      X-Amz-Cf-Pop:
+      - JFK50-P6
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Count:
+      - '0'
+      alt-svc:
+      - h3=":443"; ma=86400
+      x-amz-apigw-id:
+      - JXF6_HRsPHcFfQg=
+      x-amzn-Remapped-Content-Length:
+      - '2'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Aug 2023 21:42:04 GMT
+      x-amzn-RequestId:
+      - 738c513a-5c6d-4b7c-b10d-0eb712ade4e5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "\n                search \"WWE Smack\";\n                fields id, slug,
+      name, summary, screenshots;\n                where platforms=[8] ;\n            "
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Client-ID:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.igdb.com/v4/games/
+  response:
+    body:
+      string: '[]'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 7f3aed575c81a226-YYZ
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Aug 2023 21:42:04 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=jlhBpkzNgFQ60YxJyjPoZQeFRys3Boz2kkiA0GzSM4E-1691530924-0-ARN2bowq/YOIbetCAuqjH8574ysfCvbCuUSI3sSC9HBViMCrAeK+BQMkCe6DAParzXuxnB8omL4Dkonp5Q+j1q0=;
+        path=/; expires=Tue, 08-Aug-23 22:12:04 GMT; domain=.igdb.com; HttpOnly; Secure;
+        SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 6e810acc9d798bdf126180508d1b511e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - UeAJtI52TSI8rQ7RlwlHc6jftX4OvgNz3Gw2IfioYp_ZNqV14aku7Q==
+      X-Amz-Cf-Pop:
+      - JFK50-P6
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Count:
+      - '0'
+      alt-svc:
+      - h3=":443"; ma=86400
+      x-amz-apigw-id:
+      - JXF7DFU_vHcFQJQ=
+      x-amzn-Remapped-Content-Length:
+      - '2'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Aug 2023 21:42:04 GMT
+      x-amzn-RequestId:
+      - 0f819ab1-564f-422e-925d-5cd09471dfb6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: fields url; where game=0;
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Client-ID:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '25'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.igdb.com/v4/covers/
+  response:
+    body:
+      string: '[]'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 7f3aed59ddaea250-YYZ
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Aug 2023 21:42:05 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=5hfxta3kbDkpYYMbi4pWqTE4TCxYZTOLNpZZFnLi3BY-1691530925-0-AXngRGKN3b+A560jM6xfcJC8ybSeSrB84RN5cVumXhBcW7x4aeWkFMsvETU9eL0uuUqRx8EHCa+f2Imgohg76+o=;
+        path=/; expires=Tue, 08-Aug-23 22:12:05 GMT; domain=.igdb.com; HttpOnly; Secure;
+        SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 0252b483f7b420504a413a83f987b080.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - lFMJmVctmUi1nCqdc39Ou5-RXXPbx-OlBzhX8HZzWZSYVbOv6GMTOA==
+      X-Amz-Cf-Pop:
+      - JFK50-P6
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Count:
+      - '0'
+      alt-svc:
+      - h3=":443"; ma=86400
+      x-amz-apigw-id:
+      - JXF7GGvlPHcFkfg=
+      x-amzn-Remapped-Content-Length:
+      - '2'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Aug 2023 21:42:05 GMT
+      x-amzn-RequestId:
+      - 2d66b17c-39e7-48c4-ad47-471ad90fecc4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: fields url; where game=0; limit 5;
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Client-ID:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.igdb.com/v4/screenshots/
+  response:
+    body:
+      string: '[]'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 7f3aed5b3f3439e7-YYZ
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Aug 2023 21:42:05 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=xQhaAjFgeVf91imq1V7u_fKbBT.2iuPS0fOuXwyjaY0-1691530925-0-AYwl6RE7yyGBd7ZHNqOtw8YOSkuqle6edPWbN2C/FPRjSMLARxkSSGyajCWulxpJYGkoC33IvmlvXhE/Dux7KFk=;
+        path=/; expires=Tue, 08-Aug-23 22:12:05 GMT; domain=.igdb.com; HttpOnly; Secure;
+        SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 0cf68108b8820db4a096a661da0108ba.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - oCOyIQwsjsGRFEH-VmwCpuhNE_QdXBNxeyPcz1uWsBE52WoKHmUyKg==
+      X-Amz-Cf-Pop:
+      - YUL62-C2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Count:
+      - '0'
+      alt-svc:
+      - h3=":443"; ma=86400
+      x-amz-apigw-id:
+      - JXF7JHGPvHcFjyw=
+      x-amzn-Remapped-Content-Length:
+      - '2'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Aug 2023 21:42:05 GMT
+      x-amzn-RequestId:
+      - 9b979995-d6e6-46d8-afb8-e93c06120852
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "\n                search \"WWE SmackDown! vs. RAW\";\n                fields
+      id, slug, name, summary, screenshots;\n                where platforms=[8] ;\n
+      \           "
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Client-ID:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '161'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.igdb.com/v4/games/
+  response:
+    body:
+      string: "[\n  {\n    \"id\": 80852,\n    \"name\": \"WWE Smackdown! vs. Raw\",\n
+        \   \"screenshots\": [\n      337102,\n      337103,\n      337104,\n      337105,\n
+        \     337106,\n      337107,\n      337108\n    ],\n    \"slug\": \"wwe-smackdown-vs-raw\",\n
+        \   \"summary\": \"WWE SmackDown! vs. Raw brings two of wrestling\\u0027s
+        most popular game series together on the PS2. The game re-creates WWE programming
+        with voice-overs and commentary throughout the season mode. During matches,
+        you can learn a host of new gameplay moves, such as stare-downs, chop battles,
+        and submission reversals. You can also try out situational challenges or create
+        your own championship. Play as your favorite wrestler, including legends and
+        Divas, and prove to the world that you have what it takes to be the WWE champion.\"\n
+        \ },\n  {\n    \"id\": 2265,\n    \"name\": \"WWE SmackDown vs. Raw 2011\",\n
+        \   \"screenshots\": [\n      25356,\n      25357,\n      25358,\n      25359,\n
+        \     25360\n    ],\n    \"slug\": \"wwe-smackdown-vs-raw-2011\",\n    \"summary\":
+        \"WWE SmackDown vs. Raw 2011 will empower players more than ever to define
+        their destiny and gameplay experiences in a dynamic and ever-changing WWE.
+        Along the way, your decisions will decide gameplay scenarios, allowing for
+        more spontaneous WWE action in and out of the ring. Enjoy a greater level
+        of interactivity that allows you to customize your WWE experience and control
+        your destinies in all-new Road to WrestleMania story-driven campaigns.\\n\\nYou\\u0027ve
+        seen the Superstars\\u0027 greatest moments on WWE programming. You\u2019ve
+        shared them and lived through them on television, on the web, and at the arenas.
+        Now, it\\u0027s time for you to define your ultimate WWE moment, in the most
+        interactive experience in the WWE Universe. This is your moment.\"\n  },\n
+        \ {\n    \"id\": 5300,\n    \"name\": \"WWE SmackDown vs. Raw 2010\",\n    \"screenshots\":
+        [\n      27682\n    ],\n    \"slug\": \"wwe-smackdown-vs-raw-2010\",\n    \"summary\":
+        \"The best-selling fighting videogame franchise returns to the virtual ring
+        with the most authentic, entertaining and compelling simulation of WWE programming
+        to date. Featuring unparalleled creation tools, a robust Superstar roster,
+        key franchise improvements and a few surprises, WWE SmackDown vs. Raw 2010
+        delivers the empowering freedom to create, customize and share gameplay experiences.
+        It\\u0027s your world now.\"\n  },\n  {\n    \"id\": 5299,\n    \"name\":
+        \"WWE SmackDown vs. Raw 2009\",\n    \"screenshots\": [\n      27080\n    ],\n
+        \   \"slug\": \"wwe-smackdown-vs-raw-2009\",\n    \"summary\": \"WWE SmackDown
+        vs. Raw 2009 for the Wii builds upon its inaugural offering by significantly
+        expanding its match type options, giving players more ways to enjoy the platform\\u0027s
+        unique pick-up-and-play experience. The game also takes full combat sports
+        entertainment to the next level by giving players more superstar control with
+        interactive entrances and victory scenes.\"\n  },\n  {\n    \"id\": 18323,\n
+        \   \"name\": \"WWE SmackDown! vs. Raw 2006\",\n    \"screenshots\": [\n      337109,\n
+        \     337110,\n      337111,\n      337112\n    ],\n    \"slug\": \"wwe-smackdown-vs-raw-2006\",\n
+        \   \"summary\": \"The debut PlayStation Portable offering of THQ and Yuke\\u0027s
+        long-running 3D wrestling series. WWE SmackDown! vs. RAW 2006 expands on THQ\\u0027s
+        popular multi-million unit-selling franchise with a number of key new features.
+        The Buried Alive Casket match, two new wrestler attributes (Stamina and Hardcore),
+        and a realistic momentum system all combine to turn the series away from its
+        arcade roots and towards that of a simulation. The PSP version follows closely
+        on the heels of its PS2 tag-teammate in terms of features and wrestler rosters,
+        with exclusive extras including additional characters and other features for
+        the PSP version, plus USB system link to connect the two versions together.\"\n
+        \ },\n  {\n    \"id\": 7252,\n    \"name\": \"WWE SmackDown vs. Raw 2007\",\n
+        \   \"screenshots\": [\n      27298\n    ],\n    \"slug\": \"wwe-smackdown-vs-raw-2007\",\n
+        \   \"summary\": \"A brand new Analog Control System makes fighting more realistic
+        than ever with intuitive movement and new elements of control. An enhanced
+        Season Mode provides multiple branching storylines and unprecedented levels
+        of player choice. In and out of the ring, dozens of user-controlled environmental
+        hotspots let players take advantage of anything at their disposal to inflict
+        damage on opponents in new and unique ways. Additionally, new high impact
+        combination moves let players take the power of WWE Superstars into their
+        own hands. Experience the intensity of WWE fans in a brand new, fully loaded
+        interactive fighting area. Players can take advantage of multiple weapons,
+        environmental damage and grabbing signs and weapons from the crowd. WWE SmackDown
+        vs. RAW 2007 offers multiple enhancements, including incredible high definition
+        graphics, updated rosters for both RAW and SmackDown, an expanded General
+        Manager Mode, online multiplayer game play with voice chat support and more.\"\n
+        \ },\n  {\n    \"id\": 5298,\n    \"name\": \"WWE SmackDown vs. Raw 2008\",\n
+        \   \"screenshots\": [\n      26973,\n      178914,\n      178915,\n      178916,\n
+        \     178917,\n      178918,\n      178919,\n      178920,\n      178921,\n
+        \     178922,\n      178923,\n      178924\n    ],\n    \"slug\": \"wwe-smackdown-vs-raw-2008\",\n
+        \   \"summary\": \"The 2008 edition in the Smackdown vs. Raw series holds
+        new features to the WWE game franchise. This is the first in the series to
+        include the extremists of ECW, including The Sandman, Marcus Cor Von and CM
+        Punk.\\n\\nThe game also features a new struggle submission system, new weapon
+        choices including guitars, and eight superstar fighting styles, including
+        Showman, Powerhouse, High-Flyer and more. Each player can now choose a primary
+        and a secondary fighting style. It continues the legend trend and new arenas,
+        such as Wrestlemania 23, Unforgiven and Summerslam as well as the classic
+        superstars like Undertaker, Shawn Michaels and Ric Flair. The roster largely
+        depends on the platform, and some versions include wrestlers not available
+        in the other ones.\"\n  }\n]"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 7f3aed5dd96ba216-YYZ
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2424'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Aug 2023 21:42:05 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=lFnWxIux8YDNP5ICYrRJNZN30Jxkv2T1QzKICAHLqOM-1691530925-0-AZHMsgCTbsWbvEU3UIsf90t5Ef/i7SGyz4Z4TwsBDzvH2+0mANJkeHp53rWNzYfkN4Mz1wJAgFz8tfKtoydRRow=;
+        path=/; expires=Tue, 08-Aug-23 22:12:05 GMT; domain=.igdb.com; HttpOnly; Secure;
+        SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 0252b483f7b420504a413a83f987b080.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - qMI0thyxNG4YqxaWxxTBgXkpeDOXi8Bs0zUkoQsOxxTo_XrbvaVCyg==
+      X-Amz-Cf-Pop:
+      - JFK50-P6
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Count:
+      - '7'
+      alt-svc:
+      - h3=":443"; ma=86400
+      x-amz-apigw-id:
+      - JXF7MF6bPHcFZ_w=
+      x-amzn-Remapped-Content-Length:
+      - '2424'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Aug 2023 21:42:05 GMT
+      x-amzn-RequestId:
+      - 401f41a8-2a6b-4964-920b-eb774319cfda
+    status:
+      code: 200
+      message: OK
+- request:
+    body: fields url; where game=80852;
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Client-ID:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '29'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.igdb.com/v4/covers/
+  response:
+    body:
+      string: "[\n  {\n    \"id\": 209154,\n    \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/co4hdu.jpg\"\n
+        \ }\n]"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 7f3aed5f2ddd36bf-YYZ
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Aug 2023 21:42:06 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=NBzU8tnnDPzzbIAUPFzzHf10sB1qjmrChgr4Ut46Ox4-1691530926-0-AdGbP+m+iP2Llc9wZ0uUxmpsDceQbzmnbkQ4M7VXQz85LhsD6qkxyqkdlu6iWeq+0Yir4PaVw3gfSMjnzHcT0X0=;
+        path=/; expires=Tue, 08-Aug-23 22:12:06 GMT; domain=.igdb.com; HttpOnly; Secure;
+        SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 0cf68108b8820db4a096a661da0108ba.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - o_MYoqRnT-DeRtef1fxWHzCYrIqFijaFAWrmcj15zvdCq0rXCY4UNw==
+      X-Amz-Cf-Pop:
+      - YUL62-C2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Count:
+      - '1'
+      alt-svc:
+      - h3=":443"; ma=86400
+      x-amz-apigw-id:
+      - JXF7QHazPHcFcww=
+      x-amzn-Remapped-Content-Length:
+      - '97'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Aug 2023 21:42:06 GMT
+      x-amzn-RequestId:
+      - a71761ba-563f-47a0-8a38-2154eec2f4ce
+    status:
+      code: 200
+      message: OK
+- request:
+    body: fields url; where game=80852; limit 5;
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Client-ID:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.igdb.com/v4/screenshots/
+  response:
+    body:
+      string: "[\n  {\n    \"id\": 337103,\n    \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/sc783z.jpg\"\n
+        \ },\n  {\n    \"id\": 337104,\n    \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/sc7840.jpg\"\n
+        \ },\n  {\n    \"id\": 337105,\n    \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/sc7841.jpg\"\n
+        \ },\n  {\n    \"id\": 337102,\n    \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/sc783y.jpg\"\n
+        \ },\n  {\n    \"id\": 337107,\n    \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/sc7843.jpg\"\n
+        \ }\n]"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 7f3aed623f323703-YYZ
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Aug 2023 21:42:06 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=zB0ETxnaV0kJzmyVyhhM2ZwIFSuA0eNxJ2FvRuPgG9s-1691530926-0-AQLXHBSsCwuXuiOXkg86hSIKr1UR1ihHIGDIrlfZ+zv0MVziB/rpH6H+EknfKKjcJMyFjIjACi8tggV87C83JS0=;
+        path=/; expires=Tue, 08-Aug-23 22:12:06 GMT; domain=.igdb.com; HttpOnly; Secure;
+        SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 fe2c65104051140806cad998f531e478.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - QfT8ouLqo-_tJw0mOCqRGudg1z4R5KlILNRHYGG4ehbuHDse4k4OWQ==
+      X-Amz-Cf-Pop:
+      - YUL62-C2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Count:
+      - '7'
+      alt-svc:
+      - h3=":443"; ma=86400
+      x-amz-apigw-id:
+      - JXF7VFzivHcFS_w=
+      x-amzn-Remapped-Content-Length:
+      - '477'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Aug 2023 21:42:06 GMT
+      x-amzn-RequestId:
+      - 54fb9c00-2b9c-4a62-9efd-89e44f768f66
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/backend/handler/tests/test_igdb_handler.py
+++ b/backend/handler/tests/test_igdb_handler.py
@@ -28,14 +28,31 @@ def test_get_rom():
     assert urlparse(rom["url_screenshots"][0]).hostname == "images.igdb.com"
 
     rom = igdbh.get_rom("Not a real game title", 4)
-    assert rom == {
-        "r_igdb_id": 0,
-        "r_slug": "",
-        "r_name": "Not a real game title",
-        "summary": "",
-        "url_cover": "",
-        "url_screenshots": [],
-    }
+    assert rom["r_igdb_id"] == 0
+    assert rom["r_slug"] == ""
+    assert rom["r_name"] == "Not a real game title"
+    assert not rom["summary"]
+    assert not rom["url_cover"]
+    assert not rom["url_screenshots"]
+
+
+@pytest.mark.vcr()
+def test_get_ps2_opl_rom():
+    rom = igdbh.get_rom("WWE Smack.iso", 8)
+    assert rom["r_igdb_id"] == 0
+    assert rom["r_slug"] == ""
+    assert rom["r_name"] == "WWE Smack"
+    assert not rom["summary"]
+    assert not rom["url_cover"]
+    assert not rom["url_screenshots"]
+
+    rom = igdbh.get_rom("SLUS_210.60.WWE Smack.iso", 8)
+    assert rom["r_igdb_id"] == 80852
+    assert rom["r_slug"] == "wwe-smackdown-vs-raw"
+    assert rom["r_name"] == "WWE Smackdown! vs. Raw"
+    assert rom["summary"]
+    assert urlparse(rom["url_cover"]).hostname == "images.igdb.com"
+    assert urlparse(rom["url_screenshots"][0]).hostname == "images.igdb.com"
 
 
 @pytest.mark.vcr()

--- a/frontend/src/views/library/Scan.vue
+++ b/frontend/src/views/library/Scan.vue
@@ -152,7 +152,7 @@ async function scan() {
       </v-avatar>
       <span class="text-body-2 ml-5"> {{ platform.name }}</span>
       <v-list-item v-for="rom in platform.roms" class="text-body-2" disabled>
-        <span v-if="rom.r_name" class="ml-10">
+        <span v-if="rom.r_igdb_id" class="ml-10">
           • Identified <b>{{ rom.r_name }} 👾</b>
         </span>
         <span v-else class="ml-10">


### PR DESCRIPTION
Patches in support for the [OPL](https://github.com/ps2homebrew/Open-PS2-Loader) file naming convention. In the case where the filename start with a value matching the OPL serial regex (XXXX_000.00), use the name from the index to search IGDB. This also has the added benefit of using that name over the filename when the IGDB lookup fails.

Note: I chose to implement the index as an in-memory python dict due to it's relatively small size (1.1MB), and not having to load it in from a fixture file (JSON, YAML). In the future, objects like these can be stored in Redis to offload that memory footprint, while allowing for fast-ish access. Since you can't view it in github, here's the structure of that index:

```python
opl_index = {
  "SLES_556.71": {
    "Name": "Fifa '14",
    "Region": "PAL"
  },
  "SLES_556.72": {
    "Name": "Fifa '14",
    "Region": "PAL"
  },
 ...
}
```

* Also fixes a small bug with scan result reporting in client

cc @binarygeek119 if you want to have a look

Closes #324 

<img width="312" alt="Screenshot 2023-08-08 at 5 34 17 PM" src="https://github.com/zurdi15/romm/assets/3247106/d6587d09-b426-4927-a7da-8ac743dc4567">
