### PR TITLE
Redis worker hotfix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,8 @@ RUN apt update && \
     apt install -y --no-install-recommends \
       libmariadb3 libmariadb-dev gcc \
       python3.10 python3.10-dev python3-pip && \
+    apt install -y --no-install-recommends \
+      netcat && \
     apt autoremove && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 WORKDIR /back

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -7,7 +7,7 @@
 /init_front &
 
 # Start rq worker
-/init_worker &
+# /init_worker &
 
 # Wait for any process to exit
 wait -n

--- a/docker/init_scripts/init_worker
+++ b/docker/init_scripts/init_worker
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd /back
-rq worker high default low --logging_level WARN
+nc -z ${REDIS_HOST:-localhost} ${REDIS_PORT:-6379} && rq worker high default low --logging_level WARN


### PR DESCRIPTION
Disable redis worker (and redis in general) for futures releases and adds netcat to base image