### PR TITLE
Rename rom with slash

### DIFF
--- a/frontend/src/components/Dialog/EditRom.vue
+++ b/frontend/src/components/Dialog/EditRom.vue
@@ -7,7 +7,7 @@ const { xs, mdAndDown, lgAndUp } = useDisplay();
 const show = ref(false);
 const rom = ref();
 const renameAsIGDB = ref(false);
-const inputRules = {
+const fileNameInputRules = {
   required: (value) => !!value || "Required.",
   newFileName: (value) => !value.includes("/") || "Invalid characters",
 };
@@ -19,16 +19,22 @@ emitter.on("showEditDialog", (romToEdit) => {
 });
 
 async function updateRom(updatedData = { ...rom.value }) {
-  
   if (updatedData.file_name.includes("/")) {
     emitter.emit("snackbarShow", {
       msg: "Couldn't edit rom: invalid file name characters",
       icon: "mdi-close-circle",
       color: "red",
     });
-    return; 
+    return;
+  } else if (!updatedData.file_name) {
+    emitter.emit("snackbarShow", {
+      msg: "Couldn't edit rom: file name required",
+      icon: "mdi-close-circle",
+      color: "red",
+    });
+    return;
   }
-  
+
   show.value = false;
   emitter.emit("showLoadingDialog", { loading: true, scrim: true });
 
@@ -107,7 +113,10 @@ async function updateRom(updatedData = { ...rom.value }) {
           <v-text-field
             @keyup.enter="updateRom()"
             v-model="rom.file_name"
-            :rules="[inputRules.newFileName, inputRules.required]"
+            :rules="[
+              fileNameInputRules.newFileName,
+              fileNameInputRules.required,
+            ]"
             label="File name"
             variant="outlined"
             required

--- a/frontend/src/components/Dialog/EditRom.vue
+++ b/frontend/src/components/Dialog/EditRom.vue
@@ -7,6 +7,10 @@ const { xs, mdAndDown, lgAndUp } = useDisplay();
 const show = ref(false);
 const rom = ref();
 const renameAsIGDB = ref(false);
+const inputRules = {
+  required: (value) => !!value || "Required.",
+  newFileName: (value) => !value.includes("/") || "Invalid characters",
+};
 
 const emitter = inject("emitter");
 emitter.on("showEditDialog", (romToEdit) => {
@@ -15,6 +19,16 @@ emitter.on("showEditDialog", (romToEdit) => {
 });
 
 async function updateRom(updatedData = { ...rom.value }) {
+  
+  if (updatedData.file_name.includes("/")) {
+    emitter.emit("snackbarShow", {
+      msg: "Couldn't edit rom: invalid file name characters",
+      icon: "mdi-close-circle",
+      color: "red",
+    });
+    return; 
+  }
+  
   show.value = false;
   emitter.emit("showLoadingDialog", { loading: true, scrim: true });
 
@@ -93,6 +107,7 @@ async function updateRom(updatedData = { ...rom.value }) {
           <v-text-field
             @keyup.enter="updateRom()"
             v-model="rom.file_name"
+            :rules="[inputRules.newFileName, inputRules.required]"
             label="File name"
             variant="outlined"
             required
@@ -122,11 +137,7 @@ async function updateRom(updatedData = { ...rom.value }) {
         </v-row>
         <v-row class="justify-center pa-2" no-gutters>
           <v-btn @click="show = false">Cancel</v-btn>
-          <v-btn
-            @click="updateRom()"
-            class="text-rommGreen ml-5"
-            >Apply</v-btn
-          >
+          <v-btn @click="updateRom()" class="text-rommGreen ml-5">Apply</v-btn>
         </v-row>
       </v-card-text>
     </v-card>


### PR DESCRIPTION
After researching if a file name with slash character ('/') is possible in linux, it is not worth it the effort to make it possible, so this PR will introduce input rules when editing a rom file name:

 - slash character is not allowed when renaming a rom
 - file name is required qhen editing a rom, not updating it if the field is empty

Closes #348 