### PR TITLE
Attempt to force refresh twitch auth token if 401

### DIFF
--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -49,9 +49,23 @@ class IGDBHandler:
         try:
             res = requests.post(url, data, headers=self.headers, timeout=timeout)
             res.raise_for_status()
+            return res.json()
         except (HTTPError, Timeout) as err:
+            if err.response.status_code != 401:
+                log.error(err)
+                return []  # All requests to the IGDB API return a list
+
+        # Attempt to force a token refresh if the token is invalid
+        log.warning("Twitch token invalid: fetching a new one...")
+        token = self.twitch_auth._update_twitch_token()
+        self.headers["Authorization"] = f"Bearer {token}"
+
+        try:
+            res = requests.post(url, data, headers=self.headers, timeout=timeout)
+            res.raise_for_status()
+        except (HTTPError, Timeout) as err:
+            # Log the error and return an empty list if the request fails again
             log.error(err)
-            # All requests to the IGDB API return a list
             return []
 
         return res.json()


### PR DESCRIPTION
For some reason an auth token I had stored in Redis expired, even though twitch says it should still be good for another ~40 days (expiry is ~60 days), which was causing requests to fail. This PR adds a 1-time catch to requests that will force-refresh the token if IGDB returns a [401 Unauthorized error](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401).

Also see https://dev.twitch.tv/docs/authentication/#tokens-dont-last-forever