### PR TITLE
Use pinia to store roms and users

### DIFF
--- a/frontend/src/components/Dialog/Rom/DeleteRom.vue
+++ b/frontend/src/components/Dialog/Rom/DeleteRom.vue
@@ -3,12 +3,12 @@ import { ref, inject } from "vue";
 import { useRouter } from "vue-router";
 import { useDisplay } from "vuetify";
 import { deleteRomsApi } from "@/services/api";
-import romsStore from "@/stores/roms";
+import storeRoms from "@/stores/roms";
 
 const { xs, mdAndDown, lgAndUp } = useDisplay();
 const router = useRouter();
 const show = ref(false);
-const storeRoms = romsStore();
+const romsStore = storeRoms();
 const roms = ref();
 const deleteFromFs = ref(false);
 
@@ -26,7 +26,7 @@ async function deleteRoms() {
         icon: "mdi-check-bold",
         color: "green",
       });
-      storeRoms.reset();
+      romsStore.resetSelection();
     })
     .catch((error) => {
       console.log(error);
@@ -37,11 +37,13 @@ async function deleteRoms() {
       });
       return;
     });
+
   await router.push({
     name: "platform",
     params: { platform: roms.value[0].p_slug },
   });
-  emitter.emit("refreshView");
+
+  romsStore.remove(roms.value);
   emitter.emit("refreshDrawer");
   show.value = false;
 }

--- a/frontend/src/components/Dialog/Rom/EditRom.vue
+++ b/frontend/src/components/Dialog/Rom/EditRom.vue
@@ -2,10 +2,12 @@
 import { ref, inject } from "vue";
 import { useDisplay } from "vuetify";
 import { updateRomApi } from "@/services/api";
+import storeRoms from "@/stores/roms";
 
 const { xs, mdAndDown, lgAndUp } = useDisplay();
 const show = ref(false);
 const rom = ref();
+const romsStore = storeRoms();
 const renameAsIGDB = ref(false);
 const fileNameInputRules = {
   required: (value) => !!value || "Required.",
@@ -39,13 +41,13 @@ async function updateRom(updatedData = { ...rom.value }) {
   emitter.emit("showLoadingDialog", { loading: true, scrim: true });
 
   await updateRomApi(rom.value, updatedData, renameAsIGDB.value)
-    .then((response) => {
+    .then(({ data }) => {
       emitter.emit("snackbarShow", {
-        msg: response.data.msg,
+        msg: data.msg,
         icon: "mdi-check-bold",
         color: "green",
       });
-      emitter.emit("refreshView");
+      romsStore.update(data.rom);
     })
     .catch((error) => {
       emitter.emit("snackbarShow", {

--- a/frontend/src/components/Dialog/Rom/SearchRom.vue
+++ b/frontend/src/components/Dialog/Rom/SearchRom.vue
@@ -2,10 +2,12 @@
 import { ref, inject, onBeforeUnmount } from "vue";
 import { useDisplay } from "vuetify";
 import { updateRomApi, searchRomIGDBApi } from "@/services/api";
+import storeRoms from "@/stores/roms";
 
 const { xs, mdAndDown, lgAndUp } = useDisplay();
 const show = ref(false);
 const rom = ref();
+const romsStore = storeRoms();
 const renameAsIGDB = ref(false);
 const searching = ref(false);
 const searchTerm = ref("");
@@ -48,7 +50,7 @@ async function updateRom(updatedData = { ...rom.value }) {
         icon: "mdi-check-bold",
         color: "green",
       });
-      emitter.emit("refreshView");
+      romsStore.update(data.rom);
     })
     .catch((error) => {
       emitter.emit("snackbarShow", {

--- a/frontend/src/components/Dialog/User/CreateUser.vue
+++ b/frontend/src/components/Dialog/User/CreateUser.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, inject } from "vue";
-
 import { createUserApi } from "@/services/api";
+import storeUsers from "@/stores/users";
 
 const user = ref({
   username: "",
@@ -9,6 +9,7 @@ const user = ref({
   role: "viewer",
 });
 const show = ref(false);
+const usersStore = storeUsers();
 
 const emitter = inject("emitter");
 emitter.on("showCreateUserDialog", () => {
@@ -16,17 +17,20 @@ emitter.on("showCreateUserDialog", () => {
 });
 
 async function createUser() {
-  await createUserApi(user.value).catch(({ response, message }) => {
-    emitter.emit("snackbarShow", {
-      msg: `Unable to create user: ${
-        response?.data?.detail || response?.statusText || message
-      }`,
-      icon: "mdi-close-circle",
-      color: "red",
+  await createUserApi(user.value)
+    .then(({ data }) => {
+      usersStore.add(data);
+    })
+    .catch(({ response, message }) => {
+      emitter.emit("snackbarShow", {
+        msg: `Unable to create user: ${
+          response?.data?.detail || response?.statusText || message
+        }`,
+        icon: "mdi-close-circle",
+        color: "red",
+      });
     });
-  });
   show.value = false;
-  emitter.emit("refreshView");
 }
 </script>
 <template>

--- a/frontend/src/components/Dialog/User/DeleteUser.vue
+++ b/frontend/src/components/Dialog/User/DeleteUser.vue
@@ -1,10 +1,11 @@
 <script setup>
 import { ref, inject } from "vue";
-
 import { deleteUserApi } from "@/services/api";
+import storeUsers from "@/stores/users";
 
 const user = ref();
 const show = ref(false);
+const usersStore = storeUsers();
 
 const emitter = inject("emitter");
 emitter.on("showDeleteUserDialog", (userToDelete) => {
@@ -13,17 +14,21 @@ emitter.on("showDeleteUserDialog", (userToDelete) => {
 });
 
 async function deleteUser() {
-  await deleteUserApi(user.value).catch(({ response, message }) => {
-    emitter.emit("snackbarShow", {
-      msg: `Unable to delete user: ${
-        response?.data?.detail || response?.statusText || message
-      }`,
-      icon: "mdi-close-circle",
-      color: "red",
+  await deleteUserApi(user.value)
+    .then(() => {
+      usersStore.remove(user.value);
+    })
+    .catch(({ response, message }) => {
+      emitter.emit("snackbarShow", {
+        msg: `Unable to delete user: ${
+          response?.data?.detail || response?.statusText || message
+        }`,
+        icon: "mdi-close-circle",
+        color: "red",
+      });
     });
-  });
+
   show.value = false;
-  emitter.emit("refreshView");
 }
 </script>
 <template>

--- a/frontend/src/components/Dialog/User/EditUser.vue
+++ b/frontend/src/components/Dialog/User/EditUser.vue
@@ -2,10 +2,11 @@
 import { ref, inject } from "vue";
 import { updateUserApi } from "@/services/api";
 import { defaultAvatarPath } from "@/utils/utils"
+import storeUsers from "@/stores/users";
 
 const user = ref();
 const show = ref(false);
-const avatarFile = ref();
+const usersStore = storeUsers();
 
 const emitter = inject("emitter");
 emitter.on("showEditUserDialog", (userToEdit) => {
@@ -15,13 +16,14 @@ emitter.on("showEditUserDialog", (userToEdit) => {
 
 function editUser() {
   updateUserApi(user.value)
-    .then((response) => {
+    .then(({ data }) => {
       emitter.emit("snackbarShow", {
-        msg: `User ${response.data.username} updated successfully`,
+        msg: `User ${data.username} updated successfully`,
         icon: "mdi-check-bold",
         color: "green",
         timeout: 5000
       });
+      usersStore.update(data);
     })
     .catch(({ response, message }) => {
       emitter.emit("snackbarShow", {
@@ -33,8 +35,8 @@ function editUser() {
         timeout: 5000
       });
     });
+
   show.value = false;
-  emitter.emit("refreshView");
   emitter.emit("refreshDrawer");
 }
 </script>

--- a/frontend/src/components/FabMenu/Base.vue
+++ b/frontend/src/components/FabMenu/Base.vue
@@ -19,7 +19,7 @@ const route = useRoute();
 
 socket.on("scan:scanning_rom", ({ id }) => {
   const rom = romsStore.selected.find((r) => r.id === id);
-  romsStore.removeSelectedRoms(rom);
+  romsStore.removeFromSelection(rom);
 });
 
 socket.on("scan:done", () => {
@@ -60,12 +60,11 @@ async function onScan() {
 
 function selectAllRoms() {
   if (props.filteredRoms.length === romsStore.selected.length) {
-    romsStore.reset();
+    romsStore.resetSelection();
     emitter.emit("openFabMenu", false);
   } else {
-    romsStore.updateSelectedRoms(props.filteredRoms);
+    romsStore.setSelection(props.filteredRoms);
   }
-  emitter.emit("refreshSelected");
 }
 
 function onDownload() {

--- a/frontend/src/components/FabMenu/Base.vue
+++ b/frontend/src/components/FabMenu/Base.vue
@@ -18,7 +18,7 @@ const scanning = storeScanning();
 const route = useRoute();
 
 socket.on("scan:scanning_rom", ({ id }) => {
-  const rom = romsStore.selected.find((r) => r.id === id);
+  const rom = romsStore.selectedRoms.find((r) => r.id === id);
   romsStore.removeFromSelection(rom);
 });
 
@@ -59,7 +59,7 @@ async function onScan() {
 }
 
 function selectAllRoms() {
-  if (props.filteredRoms.length === romsStore.selected.length) {
+  if (props.filteredRoms.length === romsStore.selectedRoms.length) {
     romsStore.resetSelection();
     emitter.emit("openFabMenu", false);
   } else {
@@ -68,7 +68,7 @@ function selectAllRoms() {
 }
 
 function onDownload() {
-  romsStore.selected.forEach((rom) => {
+  romsStore.selectedRoms.forEach((rom) => {
     downloadRomApi(rom);
   });
 }
@@ -79,7 +79,7 @@ function onDownload() {
     color="terciary"
     elevation="8"
     :icon="
-      filteredRoms.length === romsStore.selected.length
+      filteredRoms.length === romsStore.selectedRoms.length
         ? 'mdi-select'
         : 'mdi-select-all'
     "
@@ -114,7 +114,7 @@ function onDownload() {
     elevation="8"
     icon
     class="mb-3 ml-1"
-    @click="emitter.emit('showDeleteRomDialog', romsStore.selected)"
+    @click="emitter.emit('showDeleteRomDialog', romsStore.selectedRoms)"
   >
     <v-icon color="romm-red">mdi-delete</v-icon>
   </v-btn>

--- a/frontend/src/components/FabMenu/Base.vue
+++ b/frontend/src/components/FabMenu/Base.vue
@@ -11,7 +11,6 @@ import { downloadRomApi } from "@/services/api";
 const emitter = inject("emitter");
 
 // Props
-const props = defineProps(["filteredRoms"]);
 const auth = storeAuth();
 const romsStore = storeRoms();
 const scanning = storeScanning();
@@ -59,11 +58,11 @@ async function onScan() {
 }
 
 function selectAllRoms() {
-  if (props.filteredRoms.length === romsStore.selectedRoms.length) {
+  if (romsStore.filteredRoms.length === romsStore.selectedRoms.length) {
     romsStore.resetSelection();
     emitter.emit("openFabMenu", false);
   } else {
-    romsStore.setSelection(props.filteredRoms);
+    romsStore.setSelection(romsStore.filteredRoms);
   }
 }
 
@@ -79,7 +78,7 @@ function onDownload() {
     color="terciary"
     elevation="8"
     :icon="
-      filteredRoms.length === romsStore.selectedRoms.length
+      romsStore.filteredRoms.length === romsStore.selectedRoms.length
         ? 'mdi-select'
         : 'mdi-select-all'
     "

--- a/frontend/src/components/GalleryAppBar/FilterBar.vue
+++ b/frontend/src/components/GalleryAppBar/FilterBar.vue
@@ -10,7 +10,7 @@ const filterValue = ref("");
 // Event listeners bus
 const emitter = inject("emitter");
 onMounted(() => {
-  filterValue.value = galleryFilter.value;
+  filterValue.value = galleryFilter.filter;
 });
 
 function clearFilter() {

--- a/frontend/src/components/GalleryAppBar/GalleryViewBtn.vue
+++ b/frontend/src/components/GalleryAppBar/GalleryViewBtn.vue
@@ -12,7 +12,7 @@ const galleryView = storeGalleryView();
     rounded="0"
     variant="text"
     class="mr-0"
-    :icon="views[galleryView.value]['icon']"
+    :icon="views[galleryView.current]['icon']"
   >
   </v-btn>
 </template>

--- a/frontend/src/components/Game/Card/Base.vue
+++ b/frontend/src/components/Game/Card/Base.vue
@@ -1,32 +1,22 @@
 <script setup>
-import { ref, inject } from "vue";
-import useRomsStore from "@/stores/roms.js";
+import storeRoms from "@/stores/roms.js";
 import ActionBar from "@/components/Game/Card/ActionBar.vue";
 import Cover from "@/components/Game/Card/Cover.vue";
 
 // Props
-const props = defineProps(["rom", "index"]);
+const props = defineProps(["rom", "index", "selected"]);
 const emit = defineEmits(["selectRom"]);
-const romsStore = useRomsStore();
-const selected = ref();
+const romsStore = storeRoms();
 
 // Functions
 function selectRom(event) {
-  selected.value = !selected.value;
-  if (selected.value) {
-    romsStore.addSelectedRoms(props.rom);
+  if (!props.selected) {
+    romsStore.addToSelection(props.rom);
   } else {
-    romsStore.removeSelectedRoms(props.rom);
+    romsStore.removeFromSelection(props.rom);
   }
-  emit("selectRom", { event, index: props.index, selected: selected.value });
+  emit("selectRom", { event, index: props.index, selected: !props.selected });
 }
-
-const emitter = inject("emitter");
-emitter.on("refreshSelected", () => {
-  selected.value = romsStore.selected
-    .map((rom) => rom.id)
-    .includes(props.rom.id);
-});
 </script>
 
 <template>

--- a/frontend/src/components/Game/Card/Cover.vue
+++ b/frontend/src/components/Game/Card/Cover.vue
@@ -30,7 +30,7 @@ function onNavigate(event) {
   <router-link
     style="text-decoration: none; color: inherit"
     :to="
-      romsStore.length > 0
+      romsStore.selectedRoms.length > 0
         ? `#`
         : `/platform/${$route.params.platform}/${rom.id}`
     "
@@ -66,7 +66,7 @@ function onNavigate(event) {
             v-if="isHovering || !rom.has_cover"
             class="rom-title d-flex transition-fast-in-fast-out bg-tooltip text-caption"
           >
-            <v-list-item>{{ rom.file_name }}</v-list-item>
+            <v-list-item>{{ rom.r_name || rom.file_name }}</v-list-item>
           </div>
         </v-expand-transition>
         <v-chip-group class="pl-1 pt-0">

--- a/frontend/src/components/Game/DataTable/Base.vue
+++ b/frontend/src/components/Game/DataTable/Base.vue
@@ -76,7 +76,7 @@ function rowClick(_, row) {
     :items="filteredRoms"
     @click:row="rowClick"
     show-select
-    v-model="romsStore.selected"
+    v-model="romsStore.selectedRoms"
   >
     <template v-slot:item.path_cover_s="{ item }">
       <v-avatar :rounded="0">

--- a/frontend/src/components/Game/DataTable/Base.vue
+++ b/frontend/src/components/Game/DataTable/Base.vue
@@ -7,15 +7,6 @@ import storeRoms from "@/stores/roms";
 import { VDataTable } from "vuetify/labs/VDataTable";
 import AdminMenu from "@/components/AdminMenu/Base.vue";
 
-// Props
-const emitter = inject("emitter");
-const props = defineProps(["filteredRoms"]);
-const location = window.location.origin;
-const router = useRouter();
-const downloadStore = storeDownload();
-const romsStore = storeRoms();
-const saveFiles = ref(false);
-const romsPerPage = ref(-1);
 const HEADERS = [
   {
     title: "",
@@ -59,6 +50,16 @@ const PER_PAGE_OPTIONS = [
   { value: -1, title: "$vuetify.dataFooter.itemsPerPageAll" },
 ];
 
+// Props
+const location = window.location.origin;
+const props = defineProps(["filteredRoms"]);
+const router = useRouter();
+const downloadStore = storeDownload();
+const romsStore = storeRoms();
+const saveFiles = ref(false);
+const romsPerPage = ref(-1);
+
+// Functions
 function rowClick(_, row) {
   router.push(
     `/platform/${row.item.selectable.p_slug}/${row.item.selectable.id}`
@@ -76,7 +77,7 @@ function rowClick(_, row) {
     :items="filteredRoms"
     @click:row="rowClick"
     show-select
-    v-model="romsStore.selectedRoms"
+    v-model="romsStore._selectedIDs"
   >
     <template v-slot:item.path_cover_s="{ item }">
       <v-avatar :rounded="0">

--- a/frontend/src/components/Game/DataTable/Base.vue
+++ b/frontend/src/components/Game/DataTable/Base.vue
@@ -3,7 +3,7 @@ import { ref, inject } from "vue";
 import { useRouter } from "vue-router";
 import { downloadRomApi } from "@/services/api";
 import storeDownload from "@/stores/download";
-import useRomsStore from "@/stores/roms";
+import storeRoms from "@/stores/roms";
 import { VDataTable } from "vuetify/labs/VDataTable";
 import AdminMenu from "@/components/AdminMenu/Base.vue";
 
@@ -13,7 +13,7 @@ const props = defineProps(["filteredRoms"]);
 const location = window.location.origin;
 const router = useRouter();
 const downloadStore = storeDownload();
-const romsStore = useRomsStore();
+const romsStore = storeRoms();
 const saveFiles = ref(false);
 const romsPerPage = ref(-1);
 const HEADERS = [
@@ -77,7 +77,6 @@ function rowClick(_, row) {
     @click:row="rowClick"
     show-select
     v-model="romsStore.selected"
-    @update:model-value="emitter.emit('refreshSelected')"
   >
     <template v-slot:item.path_cover_s="{ item }">
       <v-avatar :rounded="0">

--- a/frontend/src/components/Game/DataTable/Base.vue
+++ b/frontend/src/components/Game/DataTable/Base.vue
@@ -52,12 +52,12 @@ const PER_PAGE_OPTIONS = [
 
 // Props
 const location = window.location.origin;
-const props = defineProps(["filteredRoms"]);
 const router = useRouter();
 const downloadStore = storeDownload();
 const romsStore = storeRoms();
 const saveFiles = ref(false);
 const romsPerPage = ref(-1);
+const emitter = inject("emitter");
 
 // Functions
 function rowClick(_, row) {
@@ -73,12 +73,12 @@ function rowClick(_, row) {
     :items-per-page-options="PER_PAGE_OPTIONS"
     items-per-page-text=""
     :headers="HEADERS"
-    :item-value="item => item"
-    :items="filteredRoms"
+    :item-value="item => item.id"
+    :items="romsStore.filteredRoms"
     @click:row="rowClick"
     show-select
     v-model="romsStore._selectedIDs"
-  >
+    >
     <template v-slot:item.path_cover_s="{ item }">
       <v-avatar :rounded="0">
         <v-progress-linear

--- a/frontend/src/stores/galleryFilter.js
+++ b/frontend/src/stores/galleryFilter.js
@@ -2,11 +2,11 @@ import { defineStore } from "pinia";
 import { normalizeString } from "@/utils/utils";
 
 export default defineStore("galleryFilter", {
-  state: () => ({ value: "" }),
+  state: () => ({ filter: "" }),
 
   actions: {
     set(filter) {
-      this.value = normalizeString(filter);
+      this.filter = normalizeString(filter);
     },
   },
 });

--- a/frontend/src/stores/galleryView.js
+++ b/frontend/src/stores/galleryView.js
@@ -2,19 +2,19 @@ import { defineStore } from "pinia";
 
 export default defineStore("galleryView", {
   state: () => ({
-    value: JSON.parse(localStorage.getItem("currentView")) || 0,
+    current: JSON.parse(localStorage.getItem("currentView")) || 0,
   }),
 
   actions: {
     set(view) {
-      this.value = view;
-      localStorage.setItem("currentView", this.value);
+      this.current = view;
+      localStorage.setItem("currentView", this.current);
     },
     next() {
-      if (this.value == 2) {
+      if (this.current == 2) {
         this.set(0);
       } else {
-        this.set(this.value + 1);
+        this.set(this.current + 1);
       }
     },
   },

--- a/frontend/src/stores/roms.js
+++ b/frontend/src/stores/roms.js
@@ -10,10 +10,10 @@ export default defineStore("roms", {
   }),
 
   getters: {
-    all: (state) => state._all,
-    filtered: (state) => state._all.filter((rom) => state._filteredIDs.includes(rom.id)),
-    search: (state) => state._all.filter((rom) => state._searchIDs.includes(rom.id)),
-    selected: (state) =>  state._all.filter((rom) => state._selectedIDs.includes(rom.id)),
+    allRoms: (state) => state._all,
+    filteredRoms: (state) => state._all.filter((rom) => state._filteredIDs.includes(rom.id)),
+    searchRoms: (state) => state._all.filter((rom) => state._searchIDs.includes(rom.id)),
+    selectedRoms: (state) =>  state._all.filter((rom) => state._selectedIDs.includes(rom.id)),
   },
 
   actions: {

--- a/frontend/src/stores/roms.js
+++ b/frontend/src/stores/roms.js
@@ -1,26 +1,80 @@
 import { defineStore } from "pinia";
 
 export default defineStore("roms", {
-  state: () => ({ selected: [], lastSelectedIndex: -1 }),
+  state: () => ({
+    _all: [],
+    _filteredIDs: [],
+    _searchIDs: [],
+    _selectedIDs: [],
+    lastSelectedIndex: -1,
+  }),
+
+  getters: {
+    all: (state) => state._all,
+    filtered: (state) => state._all.filter((rom) => state._filteredIDs.includes(rom.id)),
+    search: (state) => state._all.filter((rom) => state._searchIDs.includes(rom.id)),
+    selected: (state) =>  state._all.filter((rom) => state._selectedIDs.includes(rom.id)),
+  },
 
   actions: {
-    updateSelectedRoms(roms) {
-      this.selected = roms;
+    // All roms
+    set(roms) {
+      this._all = roms;
     },
-    addSelectedRoms(rom) {
-      this.selected.push(rom);
+    add(roms) {
+      this._all = this._all.concat(roms);
     },
-    removeSelectedRoms(rom) {
-      this.selected = this.selected.filter(function (value) {
-        return value.id != rom.id;
+    update(rom) {
+      this._all = this._all.map((value) => {
+        if (value.id === rom.id) {
+          return rom;
+        }
+        return value;
       });
     },
-    updateLastSelectedRom(index) {
+    remove(roms) {
+      this._all = this._all.filter((value) => {
+        return !roms.find((rom) => {
+          return rom.id === value.id;
+        });
+      });
+    },
+    reset() {
+      this._all = [];
+      this._filteredIDs = [];
+      this._searchIDs = [];
+      this._selectedIDs = [];
+      this.lastSelectedIndex = -1;
+    },
+
+    // Filtered roms
+    setFiltered(roms) {
+      this._filteredIDs = roms.map((rom) => rom.id);
+    },
+
+    // Search roms
+    setSearch(roms) {
+      this._searchIDs = roms.map((rom) => rom.id);
+    },
+
+    // Selected roms
+    setSelection(roms) {
+      this._selectedIDs =  roms.map((rom) => rom.id);
+    },
+    addToSelection(rom) {
+      this._selectedIDs.push(rom.id);
+    },
+    removeFromSelection(rom) {
+      this._selectedIDs = this._selectedIDs.filter((id) => {
+        return id !== rom.id;
+      });
+    },
+    updateLastSelected(index) {
       this.lastSelectedIndex = index;
     },
-    reset(){
-      this.selected = [];
+    resetSelection() {
+      this._selectedIDs = [];
       this.lastSelectedIndex = -1;
-    }
+    },
   },
 });

--- a/frontend/src/stores/users.js
+++ b/frontend/src/stores/users.js
@@ -6,7 +6,7 @@ export default defineStore("users", {
     }),
 
     getters: {
-        admins: (state) => state.all.filter((user) => user.role === "ADMIN"),
+        admins: (state) => state.all.filter((user) => user.role === "admin"),
     },
 
     actions: {

--- a/frontend/src/stores/users.js
+++ b/frontend/src/stores/users.js
@@ -1,0 +1,36 @@
+import { defineStore } from "pinia";
+
+export default defineStore("users", {
+    state: () => ({
+        all: [],
+    }),
+
+    getters: {
+        admins: (state) => state.all.filter((user) => user.role === "ADMIN"),
+    },
+
+    actions: {
+        set(users) {
+            this.all = users;
+        },
+        add(user) {
+            this.all = this.all.concat(user);
+        },
+        update(user) {
+            this.all = this.all.map((value) => {
+                if (value.id === user.id) {
+                    return user;
+                }
+                return value;
+            })
+        },
+        remove(user) {
+            this.all = this.all.filter((value) => {
+                return value.id !== user.id;
+            })
+        },
+        reset() {
+            this.all = [];
+        }
+    }
+});

--- a/frontend/src/views/Gallery/Base.vue
+++ b/frontend/src/views/Gallery/Base.vue
@@ -281,13 +281,13 @@ onBeforeRouteUpdate(async (to, _) => {
         <template v-slot:activator="{ props }">
           <v-fab-transition>
             <v-btn
-              v-show="selectedRoms.length > 0"
+              v-show="romsStore._selectedIDs.length > 0"
               color="romm-accent-1"
               v-bind="props"
               elevation="8"
               icon
               size="large"
-              >{{ selectedRoms.length }}</v-btn
+              >{{ romsStore._selectedIDs.length }}</v-btn
             >
           </v-fab-transition>
         </template>

--- a/frontend/src/views/Gallery/Base.vue
+++ b/frontend/src/views/Gallery/Base.vue
@@ -179,7 +179,9 @@ function selectRom({ event, index, selected }) {
 }
 
 onMounted(async () => {
-  fetchRoms(route.params.platform);
+  if(filteredRoms.value.length == 0){
+    fetchRoms(route.params.platform);
+  }
 });
 
 onBeforeUnmount(() => {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -13,14 +13,10 @@ const { mdAndDown } = useDisplay();
 const platforms = storePlatforms();
 const scanning = storeScanning();
 const auth = storeAuth();
-const refreshView = ref(false);
 const refreshDrawer = ref(false);
 
 // Event listeners bus
 const emitter = inject("emitter");
-emitter.on("refreshView", () => {
-  refreshView.value = !refreshView.value;
-});
 emitter.on("refreshDrawer", () => {
   refreshDrawer.value = !refreshDrawer.value;
 });
@@ -54,7 +50,7 @@ onMounted(async () => {
   <app-bar v-if="mdAndDown" />
 
   <v-container class="pa-1" fluid>
-    <router-view :key="refreshView" />
+    <router-view />
   </v-container>
 </template>
 

--- a/frontend/src/views/Library/Scan.vue
+++ b/frontend/src/views/Library/Scan.vue
@@ -40,15 +40,14 @@ socket.on("scan:scanning_rom", ({ p_slug, p_name, ...rom }) => {
 
 socket.on("scan:done", () => {
   scanning.set(false);
+  socket.disconnect();
 
   emitter.emit("refreshDrawer");
-  emitter.emit("refreshView");
   emitter.emit("snackbarShow", {
     msg: "Scan completed successfully!",
     icon: "mdi-check-bold",
     color: "green",
   });
-  socket.disconnect();
 });
 
 socket.on("scan:done_ko", (msg) => {

--- a/frontend/src/views/Settings/Users/Users.vue
+++ b/frontend/src/views/Settings/Users/Users.vue
@@ -9,7 +9,6 @@ import CreateUserDialog from "@/components/Dialog/User/CreateUser.vue";
 import EditUserDialog from "@/components/Dialog/User/EditUser.vue";
 import DeleteUserDialog from "@/components/Dialog/User/DeleteUser.vue";
 
-const auth = storeAuth();
 const HEADERS = [
   {
     title: "",
@@ -48,6 +47,7 @@ const PER_PAGE_OPTIONS = [
 
 // Props
 const emitter = inject("emitter");
+const auth = storeAuth();
 const usersStore = storeUsers();
 const usersPerPage = ref(5);
 const userSearch = ref("");

--- a/frontend/src/views/Settings/Users/Users.vue
+++ b/frontend/src/views/Settings/Users/Users.vue
@@ -3,6 +3,7 @@ import { ref, inject, onMounted } from "vue";
 import { VDataTable } from "vuetify/labs/VDataTable";
 import { fetchUsersApi, updateUserApi } from "@/services/api";
 import storeAuth from "@/stores/auth";
+import storeUsers from "@/stores/users";
 import { defaultAvatarPath } from "@/utils/utils";
 import CreateUserDialog from "@/components/Dialog/User/CreateUser.vue";
 import EditUserDialog from "@/components/Dialog/User/EditUser.vue";
@@ -47,7 +48,7 @@ const PER_PAGE_OPTIONS = [
 
 // Props
 const emitter = inject("emitter");
-const users = ref([]);
+const usersStore = storeUsers();
 const usersPerPage = ref(5);
 const userSearch = ref("");
 
@@ -67,7 +68,7 @@ function disableUser(user) {
 onMounted(() => {
   fetchUsersApi()
     .then(({ data }) => {
-      users.value = data;
+      usersStore.set(data)
     })
     .catch((error) => {
       console.log(error);
@@ -109,7 +110,7 @@ onMounted(() => {
         v-model:items-per-page="usersPerPage"
         :search="userSearch"
         :headers="HEADERS"
-        :items="users"
+        :items="usersStore.all"
         :sort-by="[{ key: 'username', order: 'asc' }]"
       >
         <template v-slot:item.avatar_path="{ item }">


### PR DESCRIPTION
This PR leverages pinia as a better way to store the state of roms (in the gallery) and users in the frontend. This allows us to remove `refreshView`, as a full-app refresh is no longer necessary to update the client state.

### ROMs

A store for roms was added to hold the collection of ROMs visible in the gallery, and the sub-state of that collection. When a rom is edited or deleted, we update `romsStore` to reflect that change.

The list of filteredRoms, searchRoms and selectedRoms was also moved to the store. Internally, the store maintains those lists as IDs (and not full objects), and filters against `_all` in the getters. This way, when we update the `_all` list, those sub-lists will also be updated, as they're simply filtering against `_all`.

### Users

The users list now uses `/stores/users`, which holds the list of all users. When a user is created, edited, or removed, we update the `usersStore` to reflect that change.