### PR TITLE
Return exact match first when searching roms

### DIFF
--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -81,7 +81,14 @@ class IGDBHandler:
             """,
         )
 
-        return pydash.get(roms, "[0]", {})
+        exact_matches = [
+            rom
+            for rom in roms
+            if rom["name"].lower() == search_term.lower()
+            or rom["slug"].lower() == search_term.lower()
+        ]
+
+        return pydash.get(exact_matches or roms, "[0]", {})
 
     @staticmethod
     def _normalize_cover_url(url: str) -> str:


### PR DESCRIPTION
When the list of results is returned from IGDB search, we should prioritize results where the name (or slug) matches the search term exactly.

Related: https://github.com/zurdi15/romm/issues/285#issuecomment-1703891357