### PR TITLE
feat(pipeline): every branch's docker image is now built

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build romm image
 
 on:
+
+  push:
+  pull_request:
+
   workflow_dispatch:
     inputs:
       version:
@@ -16,25 +20,32 @@ jobs:
       contents: write
       packages: write
     steps:
-      - name: Checkout code
+
+      - name: Checkout repository
         uses: actions/checkout@v3
+
       - name: Set environment variables
         run: echo "GIT_BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate Docker metadata
         id: meta
         uses: docker/metadata-action@v4
@@ -43,13 +54,14 @@ jobs:
             name=zurdi15/romm
             name=ghcr.io/zurdi15/romm
           flavor: |
-            # latest on release branch, prefix dev on other branches
+            # latest on release branch, prefix dev-branchname on other branches
             latest=true
-            prefix=${{ github.ref != format('refs/heads/{0}', 'release') && 'dev-' || '' }},onlatest=true
+            prefix=${{ github.ref != format('refs/heads/{0}', 'release') && format('dev-{0}-', github.ref_name) || '' }},onlatest=true
           tags: |
             type=raw,value=${{ inputs.version }}
           labels: |
             org.opencontainers.image.version=${{ inputs.version }}
+
       - name: Build image
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
Every branch now produces an image tagged `dev-branchname` on PR and push.

If this is accepted we have to check how the images appears on the registry, evenutally fix the tags if we don't like it and decide how to clean up the older builds or simply replace them with the new one.