### PR TITLE
Set scan task timeout to 4 hours

### DIFF
--- a/backend/endpoints/scan.py
+++ b/backend/endpoints/scan.py
@@ -91,7 +91,11 @@ async def scan_handler(_sid: str, options: dict):
     # Run in worker if redis is available
     if ENABLE_EXPERIMENTAL_REDIS:
         return scan_queue.enqueue(
-            scan_platforms, platform_slugs, complete_rescan, selected_roms
+            scan_platforms,
+            platform_slugs,
+            complete_rescan,
+            selected_roms,
+            job_timeout=14400,  # Timeout after 4 hours
         )
     else:
         await scan_platforms(platform_slugs, complete_rescan, selected_roms)


### PR DESCRIPTION
Long scans were timing out since the default timeout is 5 minutes, extend it to 4 hours.