### PR TITLE
Clear rom store when un-mounting gallery

### DIFF
--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -154,7 +154,7 @@ class IGDBHandler:
             or self._search_rom(uc(search_term), p_igdb_id)
         )
 
-        r_igdb_id = res.get("id", 0)
+        r_igdb_id = res.get("id", "")
         r_slug = res.get("slug", "")
         r_name = res.get("name", search_term)
         summary = res.get("summary", "")

--- a/backend/handler/tests/test_igdb_handler.py
+++ b/backend/handler/tests/test_igdb_handler.py
@@ -28,7 +28,7 @@ def test_get_rom():
     assert urlparse(rom["url_screenshots"][0]).hostname == "images.igdb.com"
 
     rom = igdbh.get_rom("Not a real game title", 4)
-    assert rom["r_igdb_id"] == 0
+    assert rom["r_igdb_id"] == ""
     assert rom["r_slug"] == ""
     assert rom["r_name"] == "Not a real game title"
     assert not rom["summary"]
@@ -39,7 +39,7 @@ def test_get_rom():
 @pytest.mark.vcr()
 def test_get_ps2_opl_rom():
     rom = igdbh.get_rom("WWE Smack.iso", 8)
-    assert rom["r_igdb_id"] == 0
+    assert rom["r_igdb_id"] == ""
     assert rom["r_slug"] == ""
     assert rom["r_name"] == "WWE Smack"
     assert not rom["summary"]

--- a/frontend/src/plugins/router.js
+++ b/frontend/src/plugins/router.js
@@ -51,8 +51,4 @@ const router = createRouter({
   routes,
 });
 
-router.beforeEach((to, from) => {
-  //TODO: check if authenticated/session expired
-})
-
 export default router;

--- a/frontend/src/views/Gallery/Base.vue
+++ b/frontend/src/views/Gallery/Base.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, inject, onMounted, onBeforeUnmount } from "vue";
-import { onBeforeRouteUpdate, useRoute } from "vue-router";
+import { onBeforeRouteUpdate, onBeforeRouteLeave, useRoute } from "vue-router";
 import { storeToRefs } from "pinia";
 import { fetchRomsApi } from "@/services/api";
 import { views, normalizeString } from "@/utils/utils";
@@ -138,7 +138,7 @@ function selectRom({ event, index, selected }) {
   }
 }
 
-onMounted(async () => {
+onMounted(() => {
   if (filteredRoms.value.length == 0) {
     fetchRoms(route.params.platform);
   }
@@ -148,7 +148,22 @@ onBeforeUnmount(() => {
   romsStore.resetSelection();
 });
 
-onBeforeRouteUpdate(async (to, _) => {
+onBeforeRouteLeave((to, from, next) => {
+  // Only reset selection if platform is the same
+  if (to.fullPath.includes(from.path)) {
+    romsStore.resetSelection();
+  // Otherwise reset store
+  } else {
+    cursor.value = "";
+    searchCursor.value = "";
+    romsStore.reset();
+  }
+
+  next();
+});
+
+onBeforeRouteUpdate((to, _) => {
+  // Reset store if switching to another platform
   cursor.value = "";
   searchCursor.value = "";
   romsStore.reset();


### PR DESCRIPTION
When you navigate out of the gallery (like to the homepage) the rom store is not reset, which leads to the wrong roms being displayed when navigating to another platform gallery. This PR adds `onBeforeRouteLeave` which will a) reset the store if leaving the gallery but b) keep it and only reset selection if navigating to game details of the same platform.

Also adds another fix that stores the igdb id as an empty string when not found, instead of the string "0".