### PR TITLE
Aggressive removal of file extensions and tags

### DIFF
--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -95,9 +95,20 @@ def parse_tags(file_name: str) -> tuple:
 
 
 def get_file_name_with_no_tags(file_name: str) -> str:
-    # Use .rsplit to remove only the file extension
-    return re.sub(r"[\(\[].*?[\)\]]", "", file_name.rsplit(".", 1)[0]).strip()
+    # \[[^\]]+\]: Matches tags enclosed in square brackets, e.g., [rel-1]
+    # \([^)]+\): Matches tags enclosed in parentheses, e.g., (USA)
+    # (\.\w+)+$: Matches one or more file extensions, e.g., .zip or .nkit.iso
+    tags_extension_regex = r"(\s*\[[^\]]+\]\s*|\s*\([^)]+\)\s*)*(\.\w+)+$"
+
+    # The regex is aggressive and may remove some of the title,
+    # but that's prefered over leaving tags/extensions in the title
+    return re.sub(tags_extension_regex, "", file_name).strip()
 
 
 def get_file_extension(rom: dict) -> str:
-    return rom["file_name"].split(".")[-1] if not rom["multi"] else ""
+    extension_regex = r"(\.\w+)+$"
+    return (
+        re.search(extension_regex, rom["file_name"]).group(0)
+        if not rom["multi"]
+        else ""
+    )

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -58,14 +58,19 @@ REGIONS = [
 REGIONS_BY_SHORTCODE = {region[0].lower(): region[1] for region in REGIONS}
 REGIONS_NAME_KEYS = [region[1].lower() for region in REGIONS]
 
+TAG_REGEX = r"\(([^)]+)\)|\[([^]]+)\]"
+EXTENSION_REGEX = r"\.(\w+(\.\w+)*)$"
+
 
 def parse_tags(file_name: str) -> tuple:
     reg = ""
     rev = ""
     other_tags = []
-    tags = re.findall(r"\(([^)]+)", file_name)
+    tags = re.findall(TAG_REGEX, file_name)
 
-    for tag in tags:
+    for p_tag, s_tag in tags:
+        tag = p_tag or s_tag
+
         if tag.lower() in REGIONS_BY_SHORTCODE.keys():
             reg = REGIONS_BY_SHORTCODE[tag.lower()]
             continue
@@ -95,20 +100,13 @@ def parse_tags(file_name: str) -> tuple:
 
 
 def get_file_name_with_no_tags(file_name: str) -> str:
-    # \[[^\]]+\]: Matches tags enclosed in square brackets, e.g., [rel-1]
-    # \([^)]+\): Matches tags enclosed in parentheses, e.g., (USA)
-    # (\.\w+)+$: Matches one or more file extensions, e.g., .zip or .nkit.iso
-    tags_extension_regex = r"(?:\s*(?:\[[^\]]+\]|\([^)]+\))\s*)*(?:\.\w+)+$"
-
-    # The regex is aggressive and may remove some of the title,
-    # but that's prefered over leaving tags/extensions in the title
-    return re.sub(tags_extension_regex, "", file_name).strip()
+    file_name_no_extension = re.sub(EXTENSION_REGEX, "", file_name).strip()
+    return re.sub(TAG_REGEX, "", file_name_no_extension).strip()
 
 
 def get_file_extension(rom: dict) -> str:
-    extension_regex = r"\.((\.?\w+)+)$"
     return (
-        re.search(extension_regex, rom["file_name"]).group(1)
+        re.search(EXTENSION_REGEX, rom["file_name"]).group(1)
         if not rom["multi"]
         else ""
     )

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -98,7 +98,7 @@ def get_file_name_with_no_tags(file_name: str) -> str:
     # \[[^\]]+\]: Matches tags enclosed in square brackets, e.g., [rel-1]
     # \([^)]+\): Matches tags enclosed in parentheses, e.g., (USA)
     # (\.\w+)+$: Matches one or more file extensions, e.g., .zip or .nkit.iso
-    tags_extension_regex = r"(\s*\[[^\]]+\]\s*|\s*\([^)]+\)\s*)*(\.\w+)+$"
+    tags_extension_regex = r"(?:\s*(?:\[[^\]]+\]|\([^)]+\))\s*)*(?:\.\w+)+$"
 
     # The regex is aggressive and may remove some of the title,
     # but that's prefered over leaving tags/extensions in the title
@@ -106,9 +106,9 @@ def get_file_name_with_no_tags(file_name: str) -> str:
 
 
 def get_file_extension(rom: dict) -> str:
-    extension_regex = r"(\.\w+)+$"
+    extension_regex = r"\.((\.?\w+)+)$"
     return (
-        re.search(extension_regex, rom["file_name"]).group(0)
+        re.search(extension_regex, rom["file_name"]).group(1)
         if not rom["multi"]
         else ""
     )

--- a/backend/utils/tests/conftest.py
+++ b/backend/utils/tests/conftest.py
@@ -1,1 +1,1 @@
-from handler.tests.conftest import setup_database, clear_database, admin_user, editor_user, viewer_user, clear_database  # noqa
+from handler.tests.conftest import setup_database, clear_database, admin_user, editor_user, viewer_user  # noqa

--- a/backend/utils/tests/test_utils.py
+++ b/backend/utils/tests/test_utils.py
@@ -19,7 +19,7 @@ def test_parse_tags():
     assert parse_tags(file_name) == ("USA", "", ["Beta"])
 
     file_name = "Super Mario Bros. (CH) [!].nes"
-    assert parse_tags(file_name) == ("China", "", [])
+    assert parse_tags(file_name) == ("China", "", ["!"])
 
     file_name = "Super Mario Bros. (reg-T) (rev-1.2).nes"
     assert parse_tags(file_name) == ("Taiwan", "1.2", [])

--- a/backend/utils/tests/test_utils.py
+++ b/backend/utils/tests/test_utils.py
@@ -50,6 +50,16 @@ def test_get_file_name_with_no_tags():
     file_name = "Super Mario Bros. (Reg S) (Rev A).nes"
     assert gfnwt(file_name) == "Super Mario Bros."
 
+    file_name = "007 - Agent Under Fire.nkit.iso"
+    assert gfnwt(file_name) == "007 - Agent Under Fire"
+
+    file_name = "Jimmy Houston's Bass Tournament U.S.A..zip"
+    assert gfnwt(file_name) == "Jimmy Houston's Bass Tournament U.S.A."
+
+    # This is expected behavior, since the regex is aggressive
+    file_name = "Battle Stadium D.O.N.zip"
+    assert gfnwt(file_name) == "Battle Stadium D"
+
 
 def test_get_file_extension():
     rom = {"file_name": "Super Mario Bros. (World).nes", "multi": False}
@@ -57,3 +67,6 @@ def test_get_file_extension():
 
     rom = {"file_name": "Super Mario Bros. (World).nes", "multi": True}
     assert gfe(rom) == ""
+
+    rom = {"file_name": "007 - Agent Under Fire.nkit.iso", "multi": False}
+    assert gfe(rom) == "nkit.iso"


### PR DESCRIPTION
This new regex will strip out any tags in the filename, as well as 1 (or more) file extensions. The regex is fairly aggressive, so in rare cases it will remove parts of the filename. I think this is preferred over leaving parts of the extension in the name, as manual search should still work with a shorter name, but I'd like your thoughts on the change!

You can test it on [regex101.com](https://regex101.com) with the following examples:

```
007 - Agent Under Fire.zip
007 - Agent Under Fire.nkit.iso
007 - Agent Under Fire (USA).zip
007 - Agent Under Fire [rev-1].zip
007 - Agent Under Fire [rel-3] (USA).zip
Jimmy Houston's Bass Tournament U.S.A..zip
Battle Stadium D.O.N.zip
```