### PR TITLE
[ROMM-378] Fixes to search and pinia store

### DIFF
--- a/frontend/src/stores/roms.js
+++ b/frontend/src/stores/roms.js
@@ -1,3 +1,4 @@
+import { uniqBy } from "lodash";
 import { defineStore } from "pinia";
 
 export default defineStore("roms", {
@@ -23,20 +24,27 @@ export default defineStore("roms", {
   },
 
   actions: {
+    _reorder() {
+      // Sort roms by name and remove duplicates
+      this._all = uniqBy(
+        this._all.sort((a, b) =>
+          a.file_name_no_tags.localeCompare(b.file_name_no_tags)
+        ),
+        "id"
+      );
+    },
     // All roms
     set(roms) {
       this._all = roms;
+      this._reorder();
     },
     add(roms) {
       this._all = this._all.concat(roms);
+      this._reorder();
     },
     update(rom) {
-      this._all = this._all.map((value) => {
-        if (value.id === rom.id) {
-          return rom;
-        }
-        return value;
-      });
+      this._all = this._all.map((value) => (value.id === rom.id ? rom : value));
+      this._reorder();
     },
     remove(roms) {
       this._all = this._all.filter((value) => {

--- a/frontend/src/views/Gallery/Base.vue
+++ b/frontend/src/views/Gallery/Base.vue
@@ -64,14 +64,19 @@ async function fetchRoms(platform) {
     searchTerm: normalizeString(galleryFilter.filter),
   })
     .then((response) => {
+      // Add any new roms to the store
+      const allRomsSet = [...allRoms.value, ...response.data.items];
+      romsStore.set(allRomsSet);
+      romsStore.setFiltered(allRomsSet);
+
       if (isFiltered) {
         searchCursor.value = response.data.next_page;
-        romsStore.setSearch([...searchRoms.value, ...response.data.items]);
-        romsStore.setFiltered(searchRoms.value);
+        
+        const serchedRomsSet = [...searchRoms.value, ...response.data.items];
+        romsStore.setSearch(serchedRomsSet);
+        romsStore.setFiltered(serchedRomsSet);
       } else {
         cursor.value = response.data.next_page;
-        romsStore.set([...allRoms.value, ...response.data.items]);
-        romsStore.setFiltered(allRoms.value);
       }
     })
     .catch((error) => {


### PR DESCRIPTION
So this is a little cleanup to the way we deal with the pinia store for roms. Essentially, anytime a change is made to the `_all` rom list, we reorder the list and remove any duplicates. This is just to make sure the list is in a healthy state in all cases.

The real fix here is adding any search results to the `_all` roms list. This way, when we set the list of filtered IDs in the `romStore`, we have the results to pull from.

Fixed #378 