### PR TITLE
Change IGDB ID/SECRET variables to working names

### DIFF
--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -14,8 +14,8 @@ services:
       - DB_NAME=romm # Should match the MYSQL_DATABASE value in the mariadb container
       - DB_PASSWD=<database password>
       # [Optional] Used to fetch metadata from IGDB
-      - IGDB_CLIENT_ID=<IGDB client id>
-      - IGDB_CLIENT_SECRET=<IGDB client secret>
+      - CLIENT_ID=<IGDB client id>
+      - CLIENT_SECRET=<IGDB client secret>
       # [Optional] Use SteamGridDB as a source for covers
       - STEAMGRIDDB_API_KEY=<SteamGridDB api key>
       # [Optional] Will enable user management and require authentication to access the interface (default to false)


### PR DESCRIPTION
Current variables do not work, as mentioned here: https://github.com/zurdi15/romm/issues/394#issuecomment-1751814068

As you say, the keys will work on dev-latest. But the example file doesn't pull dev-latest, so it'd make more sense for new users if the example file used the same conventions as the release it currently pulls for the time being.