### PR TITLE
general docker image optimization

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN npm install
 RUN npm run build
 
 # Setup frontend
-FROM ubuntu/nginx:1.18-22.04_edge as production-stage
+FROM nginx:1.24-alpine3.17 as production-stage
 ARG WEBSERVER_FOLDER=/var/www/html
 COPY --from=front-build-stage /front/dist ${WEBSERVER_FOLDER}
 COPY ./frontend/assets/default_avatar.png ${WEBSERVER_FOLDER}/assets/
@@ -16,18 +16,8 @@ RUN mkdir -p ${WEBSERVER_FOLDER}/assets/romm && \
     ln -s /romm/resources ${WEBSERVER_FOLDER}/assets/romm/resources
 
 # Setup backend
-RUN apt update && \
-    apt install -y --no-install-recommends ca-certificates curl gnupg && \
-      # add deadsnakes ppa for Python versions
-      echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main" > /etc/apt/sources.list.d/deadsnakes-ubuntu-ppa-jammy.list && \
-      apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776 && \
-    apt update && \
-    apt install -y --no-install-recommends \
-      gcc netcat \
-      libmariadb3 libmariadb-dev \
-      python3.10 python3.10-dev python3-pip && \
-    apt autoremove && \
-    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apk update
+RUN apk add bash curl gnupg gcc musl-dev netcat-openbsd mariadb-connector-c mariadb-connector-c-dev python3 python3-dev py3-pip
 WORKDIR /back
 COPY ./pyproject.toml ./poetry.lock ./
 RUN pip install --no-cache --upgrade pip && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,19 @@ RUN mkdir -p ${WEBSERVER_FOLDER}/assets/romm && \
     ln -s /romm/resources ${WEBSERVER_FOLDER}/assets/romm/resources
 
 # Setup backend
-RUN apk update
-RUN apk add bash curl gnupg gcc musl-dev netcat-openbsd mariadb-connector-c mariadb-connector-c-dev python3 python3-dev py3-pip
+RUN apk update && \
+    apk add \
+        bash \
+        curl \
+        gcc \
+        musl-dev \
+        netcat-openbsd \
+        mariadb-connector-c \
+        mariadb-connector-c-dev \
+        python3 \
+        python3-dev \
+        py3-pip
+
 WORKDIR /back
 COPY ./pyproject.toml ./poetry.lock ./
 RUN pip install --no-cache --upgrade pip && \
@@ -29,6 +40,17 @@ COPY ./backend .
 # Setup init script and config files
 COPY ./docker/init_scripts/* /
 COPY ./docker/nginx/default.conf /etc/nginx/nginx.conf
+
+# cleanup build deps
+RUN apk del \
+        gcc \
+        musl-dev \
+        mariadb-connector-c-dev \
+        python3-dev \
+        py3-pip
+
+FROM scratch
+COPY --from=production-stage / /
 
 # Expose ports and start
 EXPOSE 8080

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,8 @@ COPY ./pyproject.toml ./poetry.lock ./
 RUN pip install --no-cache --upgrade pip && \
     pip install --no-cache poetry && \
     poetry config virtualenvs.create false && \
-    poetry install --no-interaction --no-ansi --only main
+    poetry install --no-interaction --no-ansi --only main && \
+    poetry cache clear --all .
 COPY ./backend .
 
 # Setup init script and config files

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN npm install
 RUN npm run build
 
 # Setup frontend
-FROM nginx:1.24-alpine3.17 as production-stage
+FROM nginx:1.24-alpine3.17-slim as production-stage
 ARG WEBSERVER_FOLDER=/var/www/html
 COPY --from=front-build-stage /front/dist ${WEBSERVER_FOLDER}
 COPY ./frontend/assets/default_avatar.png ${WEBSERVER_FOLDER}/assets/
@@ -31,6 +31,6 @@ COPY ./docker/init_scripts/* /
 COPY ./docker/nginx/default.conf /etc/nginx/nginx.conf
 
 # Expose ports and start
-EXPOSE 80
+EXPOSE 8080
 WORKDIR /romm
 CMD ["/init"]

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Run migrations and start uvicorn
-/init_back &
+#/init_back &
  
 # Start nginx
 /init_front &
 
 # Start rq worker
-/init_worker &
+#/init_worker &
 
 # Wait for any process to exit
 wait -n

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Run migrations and start uvicorn
-#/init_back &
+/init_back &
  
 # Start nginx
 /init_front &
 
 # Start rq worker
-#/init_worker &
+/init_worker &
 
 # Wait for any process to exit
 wait -n

--- a/docker/init_scripts/init_back
+++ b/docker/init_scripts/init_back
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd /back
-alembic upgrade head && uvicorn main:app --proxy-headers --host 0.0.0.0 --port 5000 --workers 2
+alembic upgrade head && uvicorn main:app --proxy-headers --host 0.0.0.0 --port 5000 --uds /tmp/uvicorn.sock --workers 2

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -8,6 +8,11 @@ events {
 }
 
 http {
+        client_body_temp_path /tmp/client_body 1 2;                                                                          
+        fastcgi_temp_path /tmp/fastcgi 1 2;                                                                                  
+        proxy_temp_path /tmp/proxy;                                                                                          
+        uwsgi_temp_path /tmp/uwsgi;                                                                                          
+        scgi_temp_path /tmp/scgi; 
 
         sendfile on;
         tcp_nopush on;
@@ -19,8 +24,8 @@ http {
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
         ssl_prefer_server_ciphers on;
 
-        access_log /var/log/nginx/access.log;
-        error_log /var/log/nginx/error.log;
+        access_log stdout;
+        error_log stderr;
 
         gzip on;
 

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,6 +1,6 @@
 user www-data;
 worker_processes auto;
-pid /run/nginx.pid;
+pid /tmp/nginx.pid;
 
 events {
         worker_connections 768;
@@ -24,8 +24,8 @@ http {
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
         ssl_prefer_server_ciphers on;
 
-        access_log stdout;
-        error_log stderr;
+        access_log /dev/stdout;
+        error_log /dev/stderr;
 
         gzip on;
 
@@ -34,7 +34,7 @@ http {
 
         server {
             root /var/www/html;
-            listen 80;
+            listen 8080;
             server_name localhost;
 
             proxy_set_header Host $host;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -32,6 +32,10 @@ http {
         # include /etc/nginx/conf.d/*.conf;
         # include /etc/nginx/sites-enabled/*;
 
+        upstream uvicorn {
+            server unix:/tmp/uvicorn.sock;
+        }
+
         server {
             root /var/www/html;
             listen 8080;
@@ -49,16 +53,16 @@ http {
 
             # OpenAPI for swagger and redoc
             location /openapi.json {
-                proxy_pass http://localhost:5000;
+                proxy_pass http://uvicorn;
             }
 
             # Backend api calls
             location /api {
                 rewrite /api/(.*) /$1 break;
-                proxy_pass http://localhost:5000;
+                proxy_pass http://uvicorn;
             }
             location /ws {
-                proxy_pass http://localhost:5000;
+                proxy_pass http://uvicorn;
                 proxy_http_version 1.1;
                 proxy_set_header Upgrade $http_upgrade;
                 proxy_set_header Connection "upgrade";

--- a/poetry.lock
+++ b/poetry.lock
@@ -1014,7 +1014,7 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "23.1"
+version = "21.3"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.7"
@@ -1431,11 +1431,12 @@ client = ["requests (>=2.21.0)", "websocket-client (>=0.54.0)"]
 
 [[package]]
 name = "pyyaml"
-version = "6.0"
+version = "6.0.1"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.6"
 files = [
+    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ websockets = "11.0.3"
 python-socketio = "5.8.0"
 SQLAlchemy = {extras = ["mypy"], version = "^2.0.19"}
 alembic = "1.10.4"
-PyYAML = "6.0"
+PyYAML = "6.0.1"
 Unidecode = "1.3.6"
 emoji = "2.2.0"
 python-dotenv = "1.0.0"


### PR DESCRIPTION
for kubernetes deployments and security minded folks its prefered to run containers with a readonly rootfs.
this patch changes nginx configuration in a way that it is possible to run it on such readonly instances.
(mounted volumes are by design exempt from this)

other things i changed are:
- the default listen port for nginx to not be port 80 (since that port can not be bound without root permissions)
- the connection between uvicorn and nginx was switched from using TCP to unix domain socket
- alpine base image instead of ubuntu to shave a few mb from the docker container size
- added cache cleaning for poetry
- squashed docker layers down to one as last build step to reduce final image size ( 112.32MiB   from  260.36MiB in the beginning )