### PR TITLE
[ROMM-396] Hide platforms with no roms in dashboard and drawer

### DIFF
--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -40,9 +40,9 @@ services:
     restart: "unless-stopped"
 
   # [Optional] Only required if using MariaDB as the database
-  mariadb:
+  romm_db:
     image: mariadb:latest
-    container_name: mariadb
+    container_name: romm_db
     environment:
       - MYSQL_ROOT_PASSWORD=<root password>
       - MYSQL_DATABASE=romm

--- a/frontend/src/components/Drawer/Base.vue
+++ b/frontend/src/components/Drawer/Base.vue
@@ -50,7 +50,7 @@ emitter.on("toggleDrawerRail", () => {
           </v-list-item>
         </template>
         <platform-list-item
-          v-for="platform in platforms.value"
+          v-for="platform in platforms.filledPlatforms"
           :platform="platform"
           :rail="rail"
           :key="platform.slug"

--- a/frontend/src/stores/platforms.js
+++ b/frontend/src/stores/platforms.js
@@ -8,6 +8,7 @@ export default defineStore("platforms", {
   },
   getters: {
     totalGames: ({ value }) => value.reduce((count, p) => count + p.n_roms, 0),
+    filledPlatforms: ({ value }) => value.filter((p) => p.n_roms > 0),
   },
   actions: {
     set(platforms) {

--- a/frontend/src/views/Dashboard/Platforms.vue
+++ b/frontend/src/views/Dashboard/Platforms.vue
@@ -17,7 +17,7 @@ const platforms = storePlatforms();
     <v-card-text>
       <v-row>
         <v-col
-          v-for="platform in platforms.value"
+          v-for="platform in platforms.filledPlatforms"
           class="pa-1"
           :key="platform.slug"
           :cols="views[0]['size-cols']"

--- a/frontend/src/views/Dashboard/Summary.vue
+++ b/frontend/src/views/Dashboard/Summary.vue
@@ -10,7 +10,7 @@ const platforms = storePlatforms();
       <v-chip-group>
         <v-chip class="text-overline" variant="text" label>
           <v-icon class="mr-2">mdi-controller</v-icon
-          >{{ platforms.value.length }} Platforms
+          >{{ platforms.filledPlatforms.length }} Platforms
         </v-chip>
         <v-chip class="text-overline" variant="text" label>
           <v-icon class="mr-2">mdi-disc</v-icon>{{ platforms.totalGames }} Games


### PR DESCRIPTION
Platforms without roms now will be hidden in the drawer and the dashboard.

Closes #396  