### PR TITLE
Fix sort roms by size + scan fixes

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -48,6 +48,7 @@ class RomSchema(BaseModel):
     file_path: str
     file_size: float
     file_size_units: str
+    file_size_bytes: int
 
     r_name: str
     r_slug: str
@@ -89,7 +90,7 @@ def upload_roms(request: Request, p_slug: str, roms: list[UploadFile] = File(...
     log.info(f"Uploading files to: {platform_fs_slug}")
     if roms is not None:
         roms_path = build_upload_roms_path(platform_fs_slug)
-        for rom in roms: #TODO: Refactor code to avoid double loop
+        for rom in roms:  # TODO: Refactor code to avoid double loop
             if _rom_exists(p_slug, rom.filename):
                 error = f"{rom.filename} already exists"
                 log.error(error)
@@ -99,10 +100,11 @@ def upload_roms(request: Request, p_slug: str, roms: list[UploadFile] = File(...
         for rom in roms:
             log.info(f" - Uploading {rom.filename}")
             file_location = f"{roms_path}/{rom.filename}"
-            f = open(file_location, 'wb+')
+            f = open(file_location, "wb+")
             while True:
-                chunk = rom.file.read(1024)  
-                if not chunk: break
+                chunk = rom.file.read(1024)
+                if not chunk:
+                    break
                 f.write(chunk)
             f.close()
         dbh.update_n_roms(p_slug)

--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -185,15 +185,18 @@ class IGDBHandler:
                 log.warning("Fetching the Switch titleDB index file...")
                 await update_switch_titledb_task.run(force=True)
 
-                with open(SWITCH_TITLEDB_INDEX_FILE, "r") as index_json:
-                    titledb_index = json.loads(index_json.read())
+                try:
+                    with open(SWITCH_TITLEDB_INDEX_FILE, "r") as index_json:
+                        titledb_index = json.loads(index_json.read())
+                except FileNotFoundError:
+                    log.error("Could not fetch the Switch titleDB index file")
             finally:
                 index_entry = titledb_index.get(title_id, None)
                 if index_entry:
                     search_term = index_entry["name"]  # type: ignore
 
         if p_igdb_id == ARCADE_IGDB_ID:
-            mame_index = {}
+            mame_index = { "menu": { "game": [] } }
 
             try:
                 with open(MAME_XML_FILE, "r") as index_xml:
@@ -202,8 +205,11 @@ class IGDBHandler:
                 log.warning("Fetching the MAME XML file from HyperspinFE...")
                 await update_mame_xml_task.run(force=True)
 
-                with open(MAME_XML_FILE, "r") as index_xml:
-                    mame_index = xmltodict.parse(index_xml.read())
+                try:
+                    with open(MAME_XML_FILE, "r") as index_xml:
+                        mame_index = xmltodict.parse(index_xml.read())
+                except FileNotFoundError:
+                    log.error("Could not fetch the MAME XML file from HyperspinFE")
             finally:
                 index_entry = [
                     game

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -3,6 +3,15 @@ from sqlalchemy import Integer, Column, String, Text, Boolean, Float, JSON
 from config import DEFAULT_PATH_COVER_S, DEFAULT_PATH_COVER_L, FRONT_LIBRARY_PATH
 from .base import BaseModel
 
+SIZE_UNIT_TO_BYTES = {
+    "B": 1,
+    "KB": 1024,
+    "MB": 1024^2,
+    "GB": 1024^3,
+    "TB": 1024^4,
+    "PB": 1024^5,
+}
+
 class Rom(BaseModel):
     __tablename__ = "roms"
     id = Column(Integer(), primary_key=True, autoincrement=True)
@@ -49,6 +58,10 @@ class Rom(BaseModel):
     @property
     def download_path(self) -> str:
         return f"{FRONT_LIBRARY_PATH}/{self.full_path}"
+    
+    @property
+    def file_size_bytes(self) -> int:
+        return int(self.file_size * SIZE_UNIT_TO_BYTES[self.file_size_units])
 
     def __repr__(self) -> str:
         return self.file_name

--- a/backend/utils/fastapi.py
+++ b/backend/utils/fastapi.py
@@ -57,7 +57,7 @@ async def scan_rom(
             log.info(f"\t\t · {file}")
 
     # Update properties that don't require IGDB
-    file_size, file_size_units = fs.get_rom_size(
+    file_size, file_size_units = fs.get_rom_file_size(
         multi=rom_attrs["multi"],
         file_name=rom_attrs["file_name"],
         multi_files=rom_attrs["files"],

--- a/backend/utils/fs.py
+++ b/backend/utils/fs.py
@@ -254,7 +254,7 @@ def get_roms(p_slug: str):
     ]
 
 
-def get_rom_size(roms_path: str, file_name: str, multi: bool, multi_files: list = []):
+def get_rom_file_size(roms_path: str, file_name: str, multi: bool, multi_files: list = []):
     files = (
         [f"{LIBRARY_BASE_PATH}/{roms_path}/{file_name}"]
         if not multi

--- a/backend/utils/tests/test_fs.py
+++ b/backend/utils/tests/test_fs.py
@@ -5,7 +5,7 @@ from ..fs import (
     get_platforms,
     get_roms_structure,
     get_roms,
-    get_rom_size,
+    get_rom_file_size,
     # get_rom_files,  # TODO: write test
     # rename_rom,  # TODO: write test
     # remove_rom,  # TODO: write test
@@ -112,7 +112,7 @@ def test_get_roms():
 
 
 def test_rom_size():
-    rom_size = get_rom_size(
+    rom_size = get_rom_file_size(
         roms_path=get_roms_structure(p_slug="n64"),
         file_name="Paper Mario (USA).z64",
         multi=False,
@@ -120,7 +120,7 @@ def test_rom_size():
 
     assert rom_size == (1.0, "KB")
 
-    rom_size = get_rom_size(
+    rom_size = get_rom_file_size(
         roms_path=get_roms_structure(p_slug="n64"),
         file_name="Super Mario 64 (J) (Rev A)",
         multi=True,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "romm",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@mdi/font": "7.0.96",
         "axios": "^1.3.4",

--- a/frontend/src/components/Game/DataTable/Base.vue
+++ b/frontend/src/components/Game/DataTable/Base.vue
@@ -30,7 +30,7 @@ const HEADERS = [
     title: "Size",
     align: "start",
     sortable: true,
-    key: "file_size",
+    key: "file_size_bytes",
   },
   {
     title: "Reg",
@@ -73,12 +73,12 @@ function rowClick(_, row) {
     :items-per-page-options="PER_PAGE_OPTIONS"
     items-per-page-text=""
     :headers="HEADERS"
-    :item-value="item => item.id"
+    :item-value="(item) => item.id"
     :items="romsStore.filteredRoms"
     @click:row="rowClick"
     show-select
     v-model="romsStore._selectedIDs"
-    >
+  >
     <template v-slot:item.path_cover_s="{ item }">
       <v-avatar :rounded="0">
         <v-progress-linear
@@ -94,11 +94,11 @@ function rowClick(_, row) {
         />
       </v-avatar>
     </template>
-    <template v-slot:item.file_size="{ item }">
-      <span
-        >{{ item.selectable.file_size }}
-        {{ item.selectable.file_size_units }}</span
-      >
+    <template v-slot:item.file_size_bytes="{ item }">
+      <span>
+        {{ item.selectable.file_size }}
+        {{ item.selectable.file_size_units }}
+      </span>
     </template>
     <template v-slot:item.actions="{ item }">
       <template v-if="item.selectable.multi">


### PR DESCRIPTION
* Send new property `file_size_bytes` to client
 * Computed property based on `file_size * file_size_unit`
* Catch FNF errors on second read of index files

|Before|After|
|---|---|
|<img width="1574" alt="Screenshot 2023-10-31 at 11 12 25 AM" src="https://github.com/zurdi15/romm/assets/3247106/3e0a0c59-1c7c-42fc-aa6c-2cad30b6c048">|<img width="1577" alt="Screenshot 2023-10-31 at 11 07 19 AM" src="https://github.com/zurdi15/romm/assets/3247106/2eb2328b-fa8e-48b5-832a-c5e02c0df8e2">|