### PR TITLE
Add check for productID in file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ frontend/dev-dist
 
 # outside data
 switch_titledb.json
+switch_product_ids.json
 mame.xml

--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -171,7 +171,7 @@ class IGDBHandler:
         search_term = get_search_term(file_name)
 
         # Support for PS2 OPL flename format
-        match = re.match(PS2_OPL_REGEX, search_term)
+        match = re.match(PS2_OPL_REGEX, file_name)
         if p_igdb_id == PS2_IGDB_ID and match:
             serial_code = match.group(1)
 

--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -225,11 +225,7 @@ class IGDBHandler:
             finally:
                 index_entry = product_id_index.get(product_id, None)
                 if index_entry:
-                    with open(SWITCH_TITLEDB_INDEX_FILE, "r") as index_json:
-                        titledb_index = json.loads(index_json.read())
-                        index_entry = titledb_index.get(index_entry, None)
-                        if index_entry:
-                            search_term = index_entry["name"]  # type: ignore
+                    search_term = index_entry["name"]  # type: ignore
 
         # Support for MAME arcade filename format
         if p_igdb_id == ARCADE_IGDB_ID:

--- a/backend/tasks/update_switch_titledb.py
+++ b/backend/tasks/update_switch_titledb.py
@@ -41,8 +41,8 @@ class UpdateSwitchTitleDBTask(RemoteFilePullTask):
             return
 
         index_json = json.loads(content)
-        product_ids = dict((v['id'],k) for k,v in index_json.items())
-        
+        product_ids = dict((v["id"], v) for _k, v in index_json.items())
+
         with open(SWITCH_PRODUCT_ID_FILE_PATH, "wb") as fixture:
             fixture.write(json.dumps(product_ids).encode())
 

--- a/backend/tasks/update_switch_titledb.py
+++ b/backend/tasks/update_switch_titledb.py
@@ -1,4 +1,5 @@
 import os
+import json
 from pathlib import Path
 
 from typing import Final
@@ -15,6 +16,13 @@ FIXTURE_FILE_PATH: Final = (
     / "switch_titledb.json"
 )
 
+SWITCH_PRODUCT_ID_FILE_PATH: Final = (
+    Path(os.path.dirname(__file__)).parent
+    / "handler"
+    / "fixtures"
+    / "switch_product_ids.json"
+)
+
 
 class UpdateSwitchTitleDBTask(RemoteFilePullTask):
     def __init__(self):
@@ -26,6 +34,17 @@ class UpdateSwitchTitleDBTask(RemoteFilePullTask):
             url="https://raw.githubusercontent.com/blawar/titledb/master/US.en.json",
             file_path=FIXTURE_FILE_PATH,
         )
+
+    async def run(self, force: bool = False):
+        content = await super().run(force)
+        if content is None:
+            return
+
+        index_json = json.loads(content)
+        product_ids = dict((v['id'],k) for k,v in index_json.items())
+        
+        with open(SWITCH_PRODUCT_ID_FILE_PATH, "wb") as fixture:
+            fixture.write(json.dumps(product_ids).encode())
 
 
 update_switch_titledb_task = UpdateSwitchTitleDBTask()

--- a/backend/tasks/utils.py
+++ b/backend/tasks/utils.py
@@ -83,11 +83,11 @@ class RemoteFilePullTask(PeriodicTask):
         self.url = url
         self.file_path = file_path
 
-    async def run(self, force: bool = False):
+    async def run(self, force: bool = False) -> bytes | None:
         if not self.enabled and not force:
             log.info(f"Scheduled {self.description} not enabled, unscheduling...")
             self.unschedule()
-            return
+            return None
 
         log.info(f"Scheduled {self.description} started...")
 
@@ -99,6 +99,8 @@ class RemoteFilePullTask(PeriodicTask):
                 fixture.write(response.content)
 
             log.info(f"Scheduled {self.description} done")
+            return response.content
         except requests.exceptions.RequestException as e:
             log.error(f"Scheduled {self.description} failed", exc_info=True)
             log.error(e)
+            return None

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -59,7 +59,7 @@ REGIONS_BY_SHORTCODE = {region[0].lower(): region[1] for region in REGIONS}
 REGIONS_NAME_KEYS = [region[1].lower() for region in REGIONS]
 
 TAG_REGEX = r"\(([^)]+)\)|\[([^]]+)\]"
-EXTENSION_REGEX = r"\.([a-z]+(\.\w+)*)$"
+EXTENSION_REGEX = r"\.(([a-z]+\.)*\w+)$"
 
 
 def parse_tags(file_name: str) -> tuple:

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -59,7 +59,7 @@ REGIONS_BY_SHORTCODE = {region[0].lower(): region[1] for region in REGIONS}
 REGIONS_NAME_KEYS = [region[1].lower() for region in REGIONS]
 
 TAG_REGEX = r"\(([^)]+)\)|\[([^]]+)\]"
-EXTENSION_REGEX = r"\.(\w+(\.\w+)*)$"
+EXTENSION_REGEX = r"\.([a-z]+(\.\w+)*)$"
 
 
 def parse_tags(file_name: str) -> tuple:

--- a/backend/utils/tests/test_utils.py
+++ b/backend/utils/tests/test_utils.py
@@ -58,7 +58,7 @@ def test_get_file_name_with_no_tags():
 
     # This is expected behavior, since the regex is aggressive
     file_name = "Battle Stadium D.O.N.zip"
-    assert gfnwt(file_name) == "Battle Stadium D"
+    assert gfnwt(file_name) == "Battle Stadium D.O.N"
 
 
 def test_get_file_extension():


### PR DESCRIPTION
In #350 it was clarified that sometimes the filename will contain the `productID`, and not the `titleID`. 

* Map the `productID` to the `titleID` during async task and save result to JSON file
* Match against product ID format during scan/rescan
* Less aggressive check for multiple file extensions