### PR TITLE
[ROMM-450][ROMM-449] Improve rom sort order

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -59,6 +59,7 @@ class RomSchema(BaseModel):
     name: Optional[str]
     slug: Optional[str]
     summary: Optional[str]
+    sort_comparator: str
 
     path_cover_s: str
     path_cover_l: str

--- a/backend/handler/db_handler.py
+++ b/backend/handler/db_handler.py
@@ -63,7 +63,7 @@ class DBHandler:
         return (
             select(Rom)
             .filter_by(platform_slug=platform_slug)
-            .order_by(Rom.file_name.asc())
+            .order_by(func.lower(Rom.name).asc())
         )
 
     @begin_session

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -89,14 +89,15 @@ class Rom(BaseModel):
 
     @cached_property
     def sort_comparator(self) -> str:
-        if self.name:
-            return (
-                re.sub(SORT_COMPARE_REGEX, "", self.name, flags=re.MULTILINE)
-                .strip()
-                .lower()
+        return (
+            re.sub(
+                SORT_COMPARE_REGEX,
+                "",
+                self.name or self.file_name_no_tags,
             )
-
-        return self.file_name_no_tags.strip().lower()
+            .strip()
+            .lower()
+        )
 
     def __repr__(self) -> str:
         return self.file_name

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -1,3 +1,4 @@
+import re
 from sqlalchemy import Integer, Column, String, Text, Boolean, Float, JSON, ForeignKey
 from sqlalchemy.orm import relationship, Mapped
 from functools import cached_property
@@ -8,11 +9,14 @@ from .base import BaseModel
 SIZE_UNIT_TO_BYTES = {
     "B": 1,
     "KB": 1024,
-    "MB": 1024^2,
-    "GB": 1024^3,
-    "TB": 1024^4,
-    "PB": 1024^5,
+    "MB": 1024 ^ 2,
+    "GB": 1024 ^ 3,
+    "TB": 1024 ^ 4,
+    "PB": 1024 ^ 5,
 }
+
+SORT_COMPARE_REGEX = r"^([Tt]he|[Aa]|[Aa]nd)\s"
+
 
 class Rom(BaseModel):
     from .platform import Platform
@@ -71,10 +75,10 @@ class Rom(BaseModel):
     @cached_property
     def download_path(self) -> str:
         return f"{FRONT_LIBRARY_PATH}/{self.full_path}"
-    
+
     @property
     def file_size_bytes(self) -> int:
-        return int(self.file_size * SIZE_UNIT_TO_BYTES[self.file_size_units or 'B'])
+        return int(self.file_size * SIZE_UNIT_TO_BYTES[self.file_size_units or "B"])
 
     @property
     def has_cover(self) -> bool:
@@ -82,6 +86,17 @@ class Rom(BaseModel):
             self.path_cover_s != DEFAULT_PATH_COVER_S
             or self.path_cover_l != DEFAULT_PATH_COVER_L
         )
+
+    @cached_property
+    def sort_comparator(self) -> str:
+        if self.name:
+            return (
+                re.sub(SORT_COMPARE_REGEX, "", self.name, flags=re.MULTILINE)
+                .strip()
+                .lower()
+            )
+
+        return self.file_name_no_tags.strip().lower()
 
     def __repr__(self) -> str:
         return self.file_name

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -9,7 +9,7 @@ const mediaMatch = window.matchMedia("(prefers-color-scheme: dark)");
 function getTheme() {
   const storedTheme = parseInt(localStorage.getItem("settings.theme"));
 
-  if (storedTheme && storedTheme !== autoThemeKey) {
+  if (storedTheme !== null && storedTheme !== autoThemeKey) {
     return themes[storedTheme];
   }
 

--- a/frontend/src/stores/roms.js
+++ b/frontend/src/stores/roms.js
@@ -28,11 +28,11 @@ export default defineStore("roms", {
 
   actions: {
     _reorder() {
-      // Sort roms by name and remove duplicates
+      // Sort roms by comparator string
       this._all = uniqBy(
-        this._all.sort((a, b) =>
-          a.file_name_no_tags.localeCompare(b.file_name_no_tags)
-        ),
+        this._all.sort((a, b) => {
+          return a.sort_comparator.localeCompare(b.sort_comparator);
+        }),
         "id"
       );
     },


### PR DESCRIPTION
This PR adds a new property to `Rom` that builds the string we use to compare games when sorting them. It'll remove leading The/A/And, strip white space, and make it lowercase. We're also now using the name to compare, falling back to the filename without tags.

Closes #450 
Closes #449 