### PR TITLE
Nginx logformat touchup

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -24,7 +24,20 @@ http {
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
         ssl_prefer_server_ciphers on;
 
-        access_log /dev/stdout;
+        map $time_iso8601 $date {
+            ~([^+]+)T $1;
+        }
+        map $time_iso8601 $time {
+            ~T([0-9:]+)\+ $1;
+        }
+
+        #INFO:	  [nginx][2023-11-14 09:20:29]	127.0.0.1 - -"GET / HTTP/1.1" 500 177 "-" "Mozilla/5.0 (X11; Linux x86_64)"rt=0.000 uct="-" uht="-" urt="-"
+        log_format romm_log 'INFO:	  [nginx][$date $time]	$remote_addr - $remote_user '
+                                        '"$request" $status $body_bytes_sent '
+                                        '"$http_referer" "$http_user_agent" '
+                                        'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
+
+        access_log /dev/stdout romm_log;
         error_log /dev/stderr;
 
         gzip on;


### PR DESCRIPTION
bring nginx's accesslog in line with the overall romm log format
