### PR TITLE
[ROMM-486] Titleize slug as name when scanning platform

### DIFF
--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -171,7 +171,7 @@ class IGDBHandler:
 
         platform = pydash.get(platforms, "[0]", None)
         if not platform:
-            return IGDBPlatformType(igdb_id=None, name=slug)
+            return IGDBPlatformType(igdb_id=None, name=slug.replace("-", " ").title())
 
         return IGDBPlatformType(
             igdb_id=platform["id"],


### PR DESCRIPTION
If the platform isn't found in IGDB, set the name as a titleized form of the slug (`pocket-challenge-v2` -> `Pocket Challenge V2`)

@zurdi15 This will only work for new platforms going forward as it needs a full rescan. Also does this change make it confusing about which platforms were not found in IGDB?

Closes #486 

<img width="268" alt="Screenshot 2023-12-05 at 5 52 51 PM" src="https://github.com/zurdi15/romm/assets/3247106/0696a66e-2835-466a-b568-87a8beddb810">
