### PR TITLE
[ROMM-501] Fix scan with folder overrides

### DIFF
--- a/backend/handler/db_handler.py
+++ b/backend/handler/db_handler.py
@@ -50,7 +50,7 @@ class DBHandler:
     def purge_platforms(self, platforms: list[str], session: Session = None):
         return session.execute(
             delete(Platform)
-            .where(or_(Platform.slug.not_in(platforms), Platform.slug.is_(None)))
+            .where(or_(Platform.fs_slug.not_in(platforms), Platform.slug.is_(None)))
             .execution_options(synchronize_session="evaluate")
         )
 

--- a/frontend/src/views/Library/Scan/Base.vue
+++ b/frontend/src/views/Library/Scan/Base.vue
@@ -74,7 +74,7 @@ async function onScan() {
   if (!socket.connected) socket.connect();
 
   socket.emit("scan", {
-    platforms: platformsToScan.value.map((p) => p.slug),
+    platforms: platformsToScan.value.map((p) => p.fs_slug),
     rescan: completeRescan.value,
   });
 }


### PR DESCRIPTION
The scan backend expects `fs_slug`, so pass that in when scanning in the `Scan` view.