### PR TITLE
Update Undraid romm.xml

### DIFF
--- a/unraid_template/romm.xml
+++ b/unraid_template/romm.xml
@@ -13,7 +13,7 @@
    <Beta>False</Beta>
    <Category>MediaApp:Other</Category>
    <Date>2023-08-06</Date>
-   <WebUI>http://[IP]:[PORT:8091]</WebUI>
+   <WebUI>http://[IP]:[PORT:8080]</WebUI>
    <TemplateURL/>
    <Icon>https://raw.githubusercontent.com/zurdi15/romm/master/.github/resources/romm.png</Icon>
    <ExtraParams/>
@@ -27,9 +27,8 @@
    <Screenshot>https://raw.githubusercontent.com/zurdi15/romm/master/.github/resources/screenshots/gallery.png</Screenshot>
    <Screenshot>https://raw.githubusercontent.com/zurdi15/romm/master/.github/resources/screenshots/details.png</Screenshot>
    <Screenshot>https://raw.githubusercontent.com/zurdi15/romm/master/.github/resources/screenshots/search.png</Screenshot>
-   <Config Name="Port" Target="80" Default="80" Mode="tcp" Description="" Type="Port" Display="always" Required="false" Mask="false">8091</Config>
+   <Config Name="Port" Target="8080" Default="8080" Mode="tcp" Description="" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
    <Config Name="Library" Target="/romm/library/" Default="/romm/library" Mode="rw" Description="Game files" Type="Path" Display="always" Required="true" Mask="false"/>
-   <Config Name="Config file" Target="/romm/config.yml" Default="" Mode="rw" Description="Config YAML file" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/romm/config.yml</Config>
    <Config Name="Resources" Target="/romm/resources/" Default="" Mode="rw" Description="Metadata storage (covers, screenshots, etc.)" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/romm/resources</Config>
    <Config Name="Logs" Target="/romm/logs" Default="" Mode="rw" Description="Log file storage" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/romm/logs</Config>
    <Config Name="Database" Target="/romm/database" Default="" Mode="rw" Description="Only needed if using SQLite" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/romm/database</Config>


### PR DESCRIPTION
- ports changed to 8080 instead of 80. As the Docker application runs on 8080

- The config.yml file has been deleted, as you need to specify a path and not a file, which leads to the error message "config.yml is a directory".