### PR TITLE
[ROMM-520] Fix downloading multi-file roms which filenames include comma characters

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import json
-from typing import Optional
+from typing import Optional, Annotated
 from typing_extensions import TypedDict
 from fastapi import (
     APIRouter,
@@ -10,6 +10,7 @@ from fastapi import (
     File,
     UploadFile,
 )
+from fastapi import Query
 from fastapi_pagination.ext.sqlalchemy import paginate
 from fastapi_pagination.cursor import CursorPage, CursorParams
 from fastapi.responses import FileResponse
@@ -142,7 +143,7 @@ def upload_roms(
 
 
 @protected_route(router.get, "/roms/{id}/download", ["roms.read"])
-def download_rom(request: Request, id: int, files: str):
+def download_rom(request: Request, id: int, files: Annotated[list[str] | None, Query()] = None):
     """Downloads a rom or a zip file with multiple roms"""
     rom = dbh.get_rom(id)
     rom_path = f"{LIBRARY_BASE_PATH}/{rom.full_path}"
@@ -150,18 +151,19 @@ def download_rom(request: Request, id: int, files: str):
     if not rom.multi:
         return FileResponse(path=rom_path, filename=rom.file_name)
 
-    file_list = files.split(",") if files else rom.files
-
     # Builds a generator of tuples for each member file
     def local_files():
         def contents(file_name):
-            with open(f"{rom_path}/{file_name}", "rb") as f:
-                while chunk := f.read(65536):
-                    yield chunk
+            try:
+                with open(f"{rom_path}/{file_name}", "rb") as f:
+                    while chunk := f.read(65536):
+                        yield chunk
+            except FileNotFoundError:
+                log.error(f"File {rom_path}/{file_name} not found!")
 
         return [
             (file_name, datetime.now(), S_IFREG | 0o600, ZIP_64, contents(file_name))
-            for file_name in file_list
+            for file_name in files
         ]
 
     zipped_chunks = stream_zip(local_files())

--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -341,7 +341,7 @@ class IGDBHandler:
                 igdb_id=rom["id"],
                 slug=rom["slug"],
                 name=rom["name"],
-                summary=rom["summary"],
+                summary=rom.get("summary", ""),
                 url_cover=self._search_cover(rom["id"]).replace(
                     "t_thumb", "t_cover_big"
                 ),

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -52,12 +52,17 @@ socket.on("download:complete", clearRomFromDownloads);
 // Used only for multi-file downloads
 async function downloadRom({ rom, files = [] }) {
   // Force download of all multirom-parts when no part is selected
-  if (files != undefined && files.length == 0) {
-    files = undefined;
+  if (files.length == 0) {
+    files = rom.files;
   }
 
+  var files_params = ""
+  files.forEach((file) => {
+    files_params += `files=${file}&`
+  })
+
   const a = document.createElement("a");
-  a.href = `/api/roms/${rom.id}/download?files=${files}`;
+  a.href = `/api/roms/${rom.id}/download?${files_params}`;
   a.download = `${rom.name}.zip`;
   a.click();
 


### PR DESCRIPTION
Downloading ``multi-part`` games breaks the download feature when any of the parts contains a ``comma`` in the name.

This is because the ``files`` parameter is a parsed string that is splitted. Changing that to an actual list parameter fixes this issue.

Aditionally, this PR fixes an error caused when a matched rom, searched manually into IGDB, doesn't have summary.

Closes #520 