### PR TITLE
[ROMM-519] Added rescan unidentified games only feature

### DIFF
--- a/backend/endpoints/scan.py
+++ b/backend/endpoints/scan.py
@@ -16,6 +16,7 @@ from config import ENABLE_EXPERIMENTAL_REDIS
 async def scan_platforms(
     platform_slugs: list[str],
     complete_rescan: bool = False,
+    rescan_unidentified: bool = False,
     selected_roms: list[str] = (),
 ):
     # Connect to external socketio server
@@ -59,7 +60,7 @@ async def scan_platforms(
 
         for fs_rom in fs_roms:
             rom = dbh.get_rom_by_filename(scanned_platform.slug, fs_rom["file_name"])
-            if rom and rom.id not in selected_roms and not complete_rescan:
+            if (rom and rom.id not in selected_roms and not complete_rescan) and not (rescan_unidentified and rom and not rom.igdb_id):
                 continue
 
             scanned_rom = await scan_rom(scanned_platform, fs_rom)
@@ -93,7 +94,8 @@ async def scan_handler(_sid: str, options: dict):
     store_default_resources()
 
     platform_slugs = options.get("platforms", [])
-    complete_rescan = options.get("rescan", False)
+    complete_rescan = options.get("completeRescan", False)
+    rescan_unidentified = options.get("rescanUnidentified", False)
     selected_roms = options.get("roms", [])
 
     # Run in worker if redis is available
@@ -102,8 +104,9 @@ async def scan_handler(_sid: str, options: dict):
             scan_platforms,
             platform_slugs,
             complete_rescan,
+            rescan_unidentified,
             selected_roms,
             job_timeout=14400,  # Timeout after 4 hours
         )
     else:
-        await scan_platforms(platform_slugs, complete_rescan, selected_roms)
+        await scan_platforms(platform_slugs, complete_rescan, rescan_unidentified, selected_roms)

--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -291,8 +291,8 @@ class IGDBHandler:
             slug=slug,
             name=name,
             summary=summary,
-            url_cover=self._search_cover(igdb_id),
-            url_screenshots=self._search_screenshots(igdb_id),
+            url_cover=self._search_cover(igdb_id) if igdb_id else "",
+            url_screenshots=self._search_screenshots(igdb_id) if igdb_id else [],
         )
 
     @check_twitch_token
@@ -308,8 +308,8 @@ class IGDBHandler:
             "slug": rom.get("slug", ""),
             "name": rom.get("name", ""),
             "summary": rom.get("summary", ""),
-            "url_cover": self._search_cover(igdb_id),
-            "url_screenshots": self._search_screenshots(igdb_id),
+            "url_cover": self._search_cover(igdb_id) if igdb_id else "",
+            "url_screenshots": self._search_screenshots(igdb_id) if igdb_id else [],
         }
 
     @check_twitch_token
@@ -344,8 +344,8 @@ class IGDBHandler:
                 summary=rom["summary"],
                 url_cover=self._search_cover(rom["id"]).replace(
                     "t_thumb", "t_cover_big"
-                ),
-                url_screenshots=self._search_screenshots(rom["id"]),
+                ) if rom["id"] else "",
+                url_screenshots=self._search_screenshots(rom["id"]) if rom["id"] else [],
             )
             for rom in matched_roms
         ]

--- a/backend/handler/igdb_handler.py
+++ b/backend/handler/igdb_handler.py
@@ -291,8 +291,8 @@ class IGDBHandler:
             slug=slug,
             name=name,
             summary=summary,
-            url_cover=self._search_cover(igdb_id) if igdb_id else "",
-            url_screenshots=self._search_screenshots(igdb_id) if igdb_id else [],
+            url_cover=self._search_cover(igdb_id),
+            url_screenshots=self._search_screenshots(igdb_id),
         )
 
     @check_twitch_token
@@ -308,8 +308,8 @@ class IGDBHandler:
             "slug": rom.get("slug", ""),
             "name": rom.get("name", ""),
             "summary": rom.get("summary", ""),
-            "url_cover": self._search_cover(igdb_id) if igdb_id else "",
-            "url_screenshots": self._search_screenshots(igdb_id) if igdb_id else [],
+            "url_cover": self._search_cover(igdb_id),
+            "url_screenshots": self._search_screenshots(igdb_id),
         }
 
     @check_twitch_token
@@ -344,8 +344,8 @@ class IGDBHandler:
                 summary=rom["summary"],
                 url_cover=self._search_cover(rom["id"]).replace(
                     "t_thumb", "t_cover_big"
-                ) if rom["id"] else "",
-                url_screenshots=self._search_screenshots(rom["id"]) if rom["id"] else [],
+                ),
+                url_screenshots=self._search_screenshots(rom["id"]),
             )
             for rom in matched_roms
         ]

--- a/frontend/src/views/Library/Scan/Base.vue
+++ b/frontend/src/views/Library/Scan/Base.vue
@@ -11,6 +11,7 @@ const platformsToScan = ref([]);
 const scanning = storeScanning();
 const scannedPlatforms = ref([]);
 const completeRescan = ref(false);
+const rescanUnidentified = ref(false);
 
 // Event listeners bus
 const emitter = inject("emitter");
@@ -75,7 +76,8 @@ async function onScan() {
 
   socket.emit("scan", {
     platforms: platformsToScan.value.map((p) => p.fs_slug),
-    rescan: completeRescan.value,
+    completeRescan: completeRescan.value,
+    rescanUnidentified: rescanUnidentified.value
   });
 }
 
@@ -106,15 +108,28 @@ onBeforeUnmount(() => {
     />
   </v-row>
 
-  <!-- Complete rescan option -->
   <v-row class="pa-4" no-gutters>
-    <v-checkbox
-      v-model="completeRescan"
-      label="Complete Rescan"
-      prepend-icon="mdi-cached"
-      hint="Rescan every rom, including already scanned roms"
-      persistent-hint
-    />
+    <!-- Complete rescan option -->
+    <v-col cols="12" xs="12" sm="6" md="4" lg="4" xl="4">
+      <v-checkbox
+        v-model="completeRescan"
+        label="Complete Rescan"
+        prepend-icon="mdi-cached"
+        hint="Rescan every rom, including already scanned roms"
+        persistent-hint
+      />
+    </v-col>
+  
+    <!-- Rescan unidentified option -->
+    <v-col cols="12" xs="12" sm="6" md="4" lg="4" xl="4">
+      <v-checkbox
+        v-model="rescanUnidentified"
+        label="Rescan Unidentified"
+        prepend-icon="mdi-file-search-outline"
+        hint="Rescan only unidentified games by IGDB"
+        persistent-hint
+      />
+    </v-col>
   </v-row>
 
   <!-- Scan button -->


### PR DESCRIPTION
Now users can ``rescan`` only those games that weren't identified by ``IGDB`` after some time to check if those games were added to ``IGDB``.