### PR TITLE
Remove file hash from mame file url

### DIFF
--- a/backend/tasks/update_mame_xml.py
+++ b/backend/tasks/update_mame_xml.py
@@ -18,7 +18,7 @@ class UpdateMAMEXMLTask(RemoteFilePullTask):
             description="mame xml update",
             enabled=ENABLE_SCHEDULED_UPDATE_MAME_XML,
             cron_string=SCHEDULED_UPDATE_MAME_XML_CRON,
-            url="https://gist.githubusercontent.com/gantoine/0e2b9e25962bfd661ad2fe0ba0e72766/raw/59133cc98fa4c58992e4a789db394a85953b24df/gistfile1.txt",
+            url="https://gist.githubusercontent.com/gantoine/0e2b9e25962bfd661ad2fe0ba0e72766/raw/gistfile1.txt",
             file_path=FIXTURE_FILE_PATH,
         )
 


### PR DESCRIPTION
Removing the hash means we can update the file without changing the URL in the code