### PR TITLE
Disable the pwa service worker

### DIFF
--- a/backend/config/config_loader.py
+++ b/backend/config/config_loader.py
@@ -79,6 +79,7 @@ class ConfigLoader:
             self._raw_config = {}
         finally:
             self._parse_config()
+            self._validate_config()
 
     @staticmethod
     def get_db_engine() -> str:
@@ -142,6 +143,90 @@ class ConfigLoader:
                 self._raw_config, "filesystem.screenshots_folder", "screenshots"
             ),
         )
+
+    def _validate_config(self):
+        """Validates the config.yml file"""
+        if not isinstance(self.config.EXCLUDED_PLATFORMS, list):
+            log.critical("Invalid config.yml: exclude.platforms must be a list")
+            sys.exit(3)
+
+        if not isinstance(self.config.EXCLUDED_SINGLE_EXT, list):
+            log.critical(
+                "Invalid config.yml: exclude.roms.single_file.extensions must be a list"
+            )
+            sys.exit(3)
+
+        if not isinstance(self.config.EXCLUDED_SINGLE_FILES, list):
+            log.critical(
+                "Invalid config.yml: exclude.roms.single_file.names must be a list"
+            )
+            sys.exit(3)
+
+        if not isinstance(self.config.EXCLUDED_MULTI_FILES, list):
+            log.critical(
+                "Invalid config.yml: exclude.roms.multi_file.names must be a list"
+            )
+            sys.exit(3)
+
+        if not isinstance(self.config.EXCLUDED_MULTI_PARTS_EXT, list):
+            log.critical(
+                "Invalid config.yml: exclude.roms.multi_file.parts.extensions must be a list"
+            )
+            sys.exit(3)
+
+        if not isinstance(self.config.EXCLUDED_MULTI_PARTS_FILES, list):
+            log.critical(
+                "Invalid config.yml: exclude.roms.multi_file.parts.names must be a list"
+            )
+            sys.exit(3)
+
+        if not isinstance(self.config.PLATFORMS_BINDING, dict):
+            log.critical("Invalid config.yml: system.platforms must be a dictionary")
+            sys.exit(3)
+
+        if not isinstance(self.config.ROMS_FOLDER_NAME, str):
+            log.critical("Invalid config.yml: filesystem.roms_folder must be a string")
+            sys.exit(3)
+
+        if self.config.ROMS_FOLDER_NAME == "":
+            log.critical(
+                "Invalid config.yml: filesystem.roms_folder cannot be an empty string"
+            )
+            sys.exit(3)
+
+        if not isinstance(self.config.SAVES_FOLDER_NAME, str):
+            log.critical("Invalid config.yml: filesystem.saves_folder must be a string")
+            sys.exit(3)
+
+        if self.config.SAVES_FOLDER_NAME == "":
+            log.critical(
+                "Invalid config.yml: filesystem.saves_folder cannot be an empty string"
+            )
+            sys.exit(3)
+
+        if not isinstance(self.config.STATES_FOLDER_NAME, str):
+            log.critical(
+                "Invalid config.yml: filesystem.states_folder must be a string"
+            )
+            sys.exit(3)
+
+        if self.config.STATES_FOLDER_NAME == "":
+            log.critical(
+                "Invalid config.yml: filesystem.states_folder cannot be an empty string"
+            )
+            sys.exit(3)
+
+        if not isinstance(self.config.SCREENSHOTS_FOLDER_NAME, str):
+            log.critical(
+                "Invalid config.yml: filesystem.screenshots_folder must be a string"
+            )
+            sys.exit(3)
+
+        if self.config.SCREENSHOTS_FOLDER_NAME == "":
+            log.critical(
+                "Invalid config.yml: filesystem.screenshots_folder cannot be an empty string"
+            )
+            sys.exit(3)
 
 
 config = ConfigLoader().config

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -101,7 +101,7 @@ class Rom(BaseModel):
     def file_size_bytes(self) -> int:
         return int(self.file_size * SIZE_UNIT_TO_BYTES[self.file_size_units or "B"])
 
-    @property
+    @cached_property
     def has_cover(self) -> bool:
         return (
             self.path_cover_s != DEFAULT_PATH_COVER_S

--- a/frontend/src/components/Details/Cover.vue
+++ b/frontend/src/components/Details/Cover.vue
@@ -11,7 +11,12 @@ defineProps<{ rom: Rom }>();
     :loading="downloadStore.value.includes(rom.id) ? 'romm-accent-1' : false"
   >
     <v-img
-      :src="`/assets/romm/resources/${rom.path_cover_l || rom.merged_screenshots[0]}`"
+      :cover="!rom.has_cover"
+      :src="
+        !rom.has_cover && rom.merged_screenshots.length > 0
+          ? rom.merged_screenshots[0]
+          : `/assets/romm/resources/${rom.path_cover_l}`
+      "
       :lazy-src="`/assets/romm/resources/${rom.path_cover_s}`"
       :aspect-ratio="3 / 4"
     >

--- a/frontend/src/components/Game/Card/Cover.vue
+++ b/frontend/src/components/Game/Card/Cover.vue
@@ -73,12 +73,15 @@ function onTouchEnd() {
     />
     <v-hover v-slot="{ isHovering, props }" open-delay="800">
       <v-img
+        :cover="!rom.has_cover"
         :value="rom.id"
         :key="rom.id"
         v-bind="props"
-        :src="`/assets/romm/resources/${
-          rom.path_cover_l || rom.merged_screenshots[0]
-        }`"
+        :src="
+          !rom.has_cover && rom.merged_screenshots.length > 0
+            ? rom.merged_screenshots[0]
+            : `/assets/romm/resources/${rom.path_cover_l}`
+        "
         :lazy-src="`/assets/romm/resources/${rom.path_cover_s}`"
         :aspect-ratio="3 / 4"
       >

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -30,6 +30,7 @@ export default defineConfig(({ mode }) => {
         },
       }),
       VitePWA({
+        injectRegister: null,
         manifest: {
           icons: [
             {
@@ -40,15 +41,8 @@ export default defineConfig(({ mode }) => {
             },
           ],
         },
-        workbox: {
-          globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
-          navigateFallbackDenylist: [
-            /\/assets\/romm\/library/,
-            /\/api\/platforms\/.*\/roms\/.*\/download/,
-          ],
-        },
         devOptions: {
-          enabled: false,
+          enabled: true,
           type: "module",
         },
       }),


### PR DESCRIPTION
This PR stops injecting the service worker into the app, which should stop those download issues.

Also fixed cover fallback and adds validation for config.yml when mounted.