### PR TITLE
[HOTFIX] Add route in nginx for assets that 404s

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -67,6 +67,11 @@ http {
                 add_header Access-Control-Allow-Headers *;
             }
 
+            # Static files
+            location /assets {
+                try_files $uri $uri/ =404;
+            }
+
             # OpenAPI for swagger and redoc
             location /openapi.json {
                 proxy_pass http://uvicorn;


### PR DESCRIPTION
When fetching static files (`/assets`), not found assets should 404 (and not return `index.html`). This will allow emulatorjs to fetch the right cores from the CDN.