### PR TITLE
[HOTFIX] Use params when running sqlite -> maria migration

### DIFF
--- a/backend/alembic/versions/0014_asset_files.py
+++ b/backend/alembic/versions/0014_asset_files.py
@@ -5,6 +5,7 @@ Revises: 0013_upgrade_file_extension
 Create Date: 2024-02-08 15:03:26.338964
 
 """
+
 import os
 from alembic import op
 import sqlalchemy as sa
@@ -56,33 +57,18 @@ def migrate_to_mysql() -> None:
             ).fetchall()
             for table_name in tables:
                 table_name = table_name[0]
+
+                # Skip migration for the 'alembic_version' table
                 if table_name == "alembic_version":
                     continue
 
-                table_data = sqlite_conn.execute(
-                    text(f"SELECT * FROM {table_name}")
-                ).fetchall()
-
+                table_data = sqlite_conn.execute(text(f"SELECT * FROM {table_name}")).fetchall()
+                
                 # Insert data into MariaDB table
-                if table_name == "roms":
-                    for row in table_data:
-                        summary = tuple(row)[15].replace('"', '\\"').replace("'", "\\'")
-                        maria_conn.execute(
-                            text(
-                                f'INSERT INTO {table_name} (id, igdb_id, p_igdb_id, sgdb_id, p_sgdb_id, platform_slug, p_name, file_name, file_name_no_tags, file_extension, file_path, file_size, file_size_units, name, slug, summary, path_cover_s, path_cover_l, revision, tags, multi, files, url_cover, url_screenshots, path_screenshots, regions, languages) VALUES ({tuple(row)[0]}, {tuple(row)[1]}, "{tuple(row)[2]}", {tuple(row)[3]}, "{tuple(row)[4]}", "{tuple(row)[5]}", "{tuple(row)[6]}", "{tuple(row)[7]}", "{tuple(row)[8]}", "{tuple(row)[9]}", "{tuple(row)[10]}", {tuple(row)[11]}, "{tuple(row)[12]}", "{tuple(row)[13]}", "{tuple(row)[14]}", "{summary}", "{tuple(row)[16]}", "{tuple(row)[17]}", "{tuple(row)[18]}", \'{tuple(row)[19]}\', {tuple(row)[20]}, \'{tuple(row)[21]}\', "{tuple(row)[22]}", \'{tuple(row)[23]}\', \'{tuple(row)[24]}\', \'{tuple(row)[25]}\', \'{tuple(row)[26]}\')'.replace(
-                                    "None,", "null,"
-                                )
-                            )
-                        )
-                else:
-                    for row in table_data:
-                        maria_conn.execute(
-                            text(
-                                f"INSERT INTO {table_name} VALUES {tuple(row)}".replace(
-                                    "None,", "null,"
-                                )
-                            )
-                        )
+                for row in table_data:
+                    insert_query = f"INSERT INTO {table_name} VALUES ({', '.join([':%s' % key for key in row.keys()])})"
+                    params = {key: value if value is not None else 'NULL' for key, value in row.items()}
+                    maria_conn.execute(text(insert_query), params)
 
             maria_conn.execute(text("SET FOREIGN_KEY_CHECKS=1"))
 


### PR DESCRIPTION
Switch to using params in execute so data does not have to be formatted/sanitized before inserting