### PR TITLE
v3.0.1

### DIFF
--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -19,7 +19,7 @@ def add_platforms(request: Request) -> MessageResponse:
         MessageResponse: Standard message response
     """
 
-    pass
+    return {"msg": "Enpoint not available yet"}
 
 
 @protected_route(router.get, "/platforms", ["platforms.read"])
@@ -63,7 +63,7 @@ async def update_platform(request: Request) -> MessageResponse:
         MessageResponse: Standard message response
     """
 
-    pass
+    return {"msg": "Enpoint not available yet"}
 
 
 @protected_route(router.delete, "/platforms/{id}", ["platforms.write"])

--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -3,6 +3,7 @@ version: "3"
 volumes:
   mysql_data:
   romm_resources:
+  romm_redis_data:
 
 services:
   romm:

--- a/unraid_template/romm.xml
+++ b/unraid_template/romm.xml
@@ -20,7 +20,6 @@
    <PostArgs/>
    <CPUset/>
    <Requires>
-   Redis
    MariaDB
    </Requires>
    <Screenshot>https://raw.githubusercontent.com/zurdi15/romm/master/.github/resources/screenshots/home.png</Screenshot>


### PR DESCRIPTION
⚠️ This hotfix requires a few changes:

* A new volume has to be bound to `/redis-data`, check the [docker-compose.example.yml file](https://github.com/zurdi15/romm/blob/3.0.1/examples/docker-compose.example.yml)
* If you're seeing "Decompress Game Core" when trying to run games in EmulatorJS, you'll need to clear storage in your browser to clear IndexedDB

## Fixed

- Fix for integrated redis data persist. Check the [docker-compose.example.yml](https://github.com/zurdi15/romm/blob/3.0.1/examples/docker-compose.example.yml)
- Fixed emulatorjs integration. Fixes #695
- Fixed 404 for assets endpoint
- Fixed sqlite to mariadb migration
- Fixed async tasks not running and throwing errors
- Fixed sqlite to mariadb migration. Fixes #697 and #688
- Fixed multipart game selector when change between games