### PR TITLE
Update index.ts to include fds mapping

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -261,6 +261,7 @@ export const platformSlugEJSCoreMap = {
   "neo-geo-pocket-color": "mednafen_ngp",
   nes: "fceumm",
   famicom: "fceumm",
+  fds: "fceumm",
   "game-televisison": "fceumm",
   "new-style-nes": "fceumm",
   // n64: "mupen64plus_next", Disabled until emujs 4.0.12 is released


### PR DESCRIPTION
This should help Romm to recognise famicom disk system libraries as emulatable with emujs.